### PR TITLE
fix(ci): consolidación de fixes E2E (workflow + unauthorized + warmup)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -116,7 +116,7 @@ jobs:
             local LOGIN_RESULT=$(curl -s -o /dev/null -w "%{http_code} %{time_total}" \
               -c "$COOKIE_JAR" -b "$COOKIE_JAR" -L --max-redirs 5 --max-time 30 \
               -H "x-ci-bypass: $CI_BYPASS_TOKEN" \
-              -X POST "$BASE_URL/api/auth/callback/credentials" \
+              "$BASE_URL/api/auth/callback/credentials" \
               -d "email=${EMAIL}&password=${PASSWORD}&csrfToken=${CSRF_TOKEN}")
             local LOGIN_CODE=$(echo "$LOGIN_RESULT" | cut -d' ' -f1)
             local LOGIN_TIME=$(echo "$LOGIN_RESULT" | cut -d' ' -f2)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,6 @@ jobs:
     timeout-minutes: 30
 
     env:
-      TEST_BASE_URL: ${{ secrets.TEST_BASE_URL }}
       TEST_TALLER_EMAIL: ${{ secrets.TEST_TALLER_EMAIL }}
       TEST_TALLER_PASSWORD: ${{ secrets.TEST_TALLER_PASSWORD }}
       TEST_MARCA_EMAIL: ${{ secrets.TEST_MARCA_EMAIL }}
@@ -35,28 +34,62 @@ jobs:
       - run: npm ci
 
       - name: Wait for Vercel deployment
+        id: wait-deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          EXPECTED_SHA="${{ github.sha }}"
-          echo "Waiting for deploy with SHA: $EXPECTED_SHA"
-          for i in {1..60}; do
-            ACTUAL_SHA=$(curl -s "${{ secrets.TEST_BASE_URL }}/api/health/version" 2>/dev/null | jq -r '.sha // empty' || echo "")
-            if [ "$ACTUAL_SHA" = "$EXPECTED_SHA" ]; then
-              echo "Deploy ready (attempt $i)"
-              exit 0
-            fi
-            echo "Attempt $i/60: not ready (got: ${ACTUAL_SHA:0:12}, want: ${EXPECTED_SHA:0:12})"
-            sleep 10
-          done
-          echo "::error::Deploy not ready after 10 min — aborting. This is an infra issue (Vercel deploy queue), not a code problem."
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # Push to develop: use fixed TEST_BASE_URL, poll until SHA matches
+            EXPECTED_SHA="${{ github.sha }}"
+            BASE_URL="${{ secrets.TEST_BASE_URL }}"
+            echo "Waiting for deploy at $BASE_URL with SHA: ${EXPECTED_SHA:0:12}"
+            for i in {1..60}; do
+              ACTUAL_SHA=$(curl -s "$BASE_URL/api/health/version" 2>/dev/null | jq -r '.sha // empty' || echo "")
+              if [ "$ACTUAL_SHA" = "$EXPECTED_SHA" ]; then
+                echo "Deploy ready (attempt $i)"
+                echo "deploy_url=$BASE_URL" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              echo "Attempt $i/60: not ready (got: ${ACTUAL_SHA:0:12}, want: ${EXPECTED_SHA:0:12})"
+              sleep 10
+            done
+          else
+            # PR: find Vercel preview URL via GitHub Deployments API
+            EXPECTED_SHA="${{ github.event.pull_request.head.sha }}"
+            REPO="${{ github.repository }}"
+            echo "Waiting for Vercel preview for PR head SHA: ${EXPECTED_SHA:0:12}"
+            for i in {1..60}; do
+              DEPLOY_ID=$(curl -s -H "Authorization: token $GH_TOKEN" \
+                "https://api.github.com/repos/$REPO/deployments?sha=$EXPECTED_SHA&per_page=5" \
+                | jq -r '[.[] | select(.environment != "Production")][0].id // empty')
+              if [ -n "$DEPLOY_ID" ] && [ "$DEPLOY_ID" != "null" ]; then
+                TARGET_URL=$(curl -s -H "Authorization: token $GH_TOKEN" \
+                  "https://api.github.com/repos/$REPO/deployments/$DEPLOY_ID/statuses" \
+                  | jq -r '[.[] | select(.state == "success")][0].environment_url // empty')
+                if [ -n "$TARGET_URL" ] && [ "$TARGET_URL" != "null" ]; then
+                  ACTUAL_SHA=$(curl -s "$TARGET_URL/api/health/version" 2>/dev/null | jq -r '.sha // empty' || echo "")
+                  if [ "$ACTUAL_SHA" = "$EXPECTED_SHA" ]; then
+                    echo "Preview ready at $TARGET_URL (attempt $i)"
+                    echo "deploy_url=$TARGET_URL" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+                fi
+              fi
+              echo "Attempt $i/60: waiting for Vercel preview deploy..."
+              sleep 10
+            done
+          fi
+          echo "::error::Deploy not ready after 10 min — aborting."
           exit 1
 
       - name: Warm up preview functions
         run: |
-          echo "Warming up serverless functions (2 passes)..."
+          BASE_URL="${{ steps.wait-deploy.outputs.deploy_url }}"
+          echo "Warming up serverless functions at $BASE_URL (2 passes)..."
           for pass in 1 2; do
             echo "--- Pass $pass ---"
             for path in / /login /registro /directorio /estado /estado/talleres /estado/documentos /estado/configuracion-niveles /taller /marca/directorio /admin/talleres; do
-              code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "${{ secrets.TEST_BASE_URL }}${path}" || echo "ERR")
+              code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "${BASE_URL}${path}" || echo "ERR")
               echo "  $path → $code"
             done
           done
@@ -64,8 +97,11 @@ jobs:
 
       - run: npx playwright install --with-deps chromium
 
-      - run: npx playwright test
+      - name: Run Playwright tests
+        run: npx playwright test
         continue-on-error: false
+        env:
+          TEST_BASE_URL: ${{ steps.wait-deploy.outputs.deploy_url }}
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,15 +85,70 @@ jobs:
       - name: Warm up preview functions
         run: |
           BASE_URL="${{ steps.wait-deploy.outputs.deploy_url }}"
-          echo "Warming up serverless functions at $BASE_URL (2 passes)..."
-          for pass in 1 2; do
-            echo "--- Pass $pass ---"
-            for path in / /login /registro /directorio /estado /estado/talleres /estado/documentos /estado/configuracion-niveles /taller /marca/directorio /admin/talleres; do
-              code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "${BASE_URL}${path}" || echo "ERR")
-              echo "  $path → $code"
-            done
+          echo "=== Phase 1: Anonymous warmup (public pages) ==="
+          for path in / /login /registro /directorio; do
+            RESULT=$(curl -s -o /dev/null -w "%{http_code} %{time_total}" --max-time 30 "${BASE_URL}${path}" || echo "ERR 0")
+            CODE=$(echo "$RESULT" | cut -d' ' -f1)
+            TIME=$(echo "$RESULT" | cut -d' ' -f2)
+            echo "  $path -> $CODE (${TIME}s)"
           done
-          echo "Warm-up complete"
+
+          echo ""
+          echo "=== Phase 2: Authenticated warmup (role pages) ==="
+
+          warmup_role() {
+            local ROLE="$1" EMAIL="$2" PASSWORD="$3"
+            shift 3
+            local PAGES=("$@")
+            local COOKIE_JAR=$(mktemp)
+
+            # 1. Get CSRF token
+            local CSRF_JSON=$(curl -s -c "$COOKIE_JAR" --max-time 15 "$BASE_URL/api/auth/csrf")
+            local CSRF_TOKEN=$(echo "$CSRF_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin).get('csrfToken',''))" 2>/dev/null)
+
+            if [ -z "$CSRF_TOKEN" ]; then
+              echo "  [$ROLE] CSRF failed -- skipping"
+              rm -f "$COOKIE_JAR"
+              return 1
+            fi
+
+            # 2. Login (follow redirects to capture session cookie)
+            local LOGIN_RESULT=$(curl -s -o /dev/null -w "%{http_code} %{time_total}" \
+              -c "$COOKIE_JAR" -b "$COOKIE_JAR" -L --max-redirs 5 --max-time 30 \
+              -H "x-ci-bypass: $CI_BYPASS_TOKEN" \
+              -X POST "$BASE_URL/api/auth/callback/credentials" \
+              -d "email=${EMAIL}&password=${PASSWORD}&csrfToken=${CSRF_TOKEN}")
+            local LOGIN_CODE=$(echo "$LOGIN_RESULT" | cut -d' ' -f1)
+            local LOGIN_TIME=$(echo "$LOGIN_RESULT" | cut -d' ' -f2)
+            echo "  [$ROLE] login -> $LOGIN_CODE (${LOGIN_TIME}s)"
+
+            # 3. Visit role pages with session cookie
+            for PAGE in "${PAGES[@]}"; do
+              local RESULT=$(curl -s -o /dev/null -w "%{http_code} %{time_total}" \
+                -b "$COOKIE_JAR" -L --max-time 30 \
+                "$BASE_URL$PAGE")
+              local CODE=$(echo "$RESULT" | cut -d' ' -f1)
+              local TIME=$(echo "$RESULT" | cut -d' ' -f2)
+              echo "  [$ROLE] $PAGE -> $CODE (${TIME}s)"
+            done
+
+            rm -f "$COOKIE_JAR"
+          }
+
+          warmup_role "TALLER" "$TEST_TALLER_EMAIL" "$TEST_TALLER_PASSWORD" \
+            /taller /taller/pedidos
+
+          warmup_role "MARCA" "$TEST_MARCA_EMAIL" "$TEST_MARCA_PASSWORD" \
+            /marca /marca/directorio
+
+          warmup_role "ESTADO" "$TEST_ESTADO_EMAIL" "$TEST_ESTADO_PASSWORD" \
+            /estado /estado/talleres /estado/documentos /estado/configuracion-niveles
+
+          warmup_role "ADMIN" "$TEST_ADMIN_EMAIL" "$TEST_ADMIN_PASSWORD" \
+            /admin /admin/talleres
+
+          echo ""
+          echo "=== Warmup complete ==="
 
       - run: npx playwright install --with-deps chromium
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-13
 
 ### Gerardo Breard
+- **13:20** `6bbe557` — fix(ci): E2E workflow soporta preview deploys de PRs
+  - `.github/workflows/e2e.yml`
+
 - **11:58** `7d5c473` — chore: trigger redeploy con variables de entorno corregidas
 
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-13
 
 ### Gerardo Breard
+- **16:07** `4836ead` — fix(middleware): /unauthorized debe ser pública
+  - `src/middleware.ts`
+
 - **13:20** `6bbe557` — fix(ci): E2E workflow soporta preview deploys de PRs
   - `.github/workflows/e2e.yml`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-13
 
 ### Gerardo Breard
+- **16:37** `44b65c9` — feat(ci): warmup programático con login real por rol
+  - `.github/workflows/e2e.yml`
+
 - **16:07** `4836ead` — fix(middleware): /unauthorized debe ser pública
   - `src/middleware.ts`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,10 @@
 ## 2026-05-13
 
 ### Gerardo Breard
+- **17:16** `cb66a4b` — fix(ci+auth): consolidar fixes E2E preview deploys
+  - `.github/workflows/e2e.yml`
+  - `src/compartido/lib/email.ts`
+
 - **16:37** `44b65c9` — feat(ci): warmup programático con login real por rol
   - `.github/workflows/e2e.yml`
 

--- a/src/compartido/lib/email.ts
+++ b/src/compartido/lib/email.ts
@@ -1,5 +1,8 @@
 import { Resend } from 'resend'
 
+const appBaseUrl = process.env.NEXTAUTH_URL
+  ?? (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '')
+
 interface EmailOptions {
   to: string
   subject: string
@@ -83,7 +86,7 @@ export function buildComunicacionAdminEmail(data: {
   mensaje: string
   nombreUsuario: string
 }): { subject: string; html: string } {
-  const dashUrl = process.env.NEXTAUTH_URL ?? ''
+  const dashUrl = appBaseUrl
   return {
     subject: data.titulo,
     html: emailWrapper(`
@@ -96,7 +99,7 @@ export function buildComunicacionAdminEmail(data: {
 
 export function buildBienvenidaEmail(data: { nombre: string; role: 'TALLER' | 'MARCA' }): { subject: string; html: string } {
   const esTaller = data.role === 'TALLER'
-  const dashUrl = `${process.env.NEXTAUTH_URL ?? ''}/${esTaller ? 'taller' : 'marca/directorio'}`
+  const dashUrl = `${appBaseUrl}/${esTaller ? 'taller' : 'marca/directorio'}`
   return {
     subject: 'Bienvenido/a a la Plataforma Digital Textil',
     html: emailWrapper(`
@@ -118,7 +121,7 @@ export function buildDocAprobadoEmail(data: { nombreTaller: string; tipoDoc: str
       <h2 style="margin: 0 0 12px; color: #16a34a;">Documento aprobado</h2>
       <p>Hola <strong>${data.nombreTaller}</strong>, tu documento <strong>${data.tipoDoc}</strong> fue revisado y aprobado por el equipo de PDT.</p>
       <p>Tu nivel de formalización fue actualizado. Seguí cargando documentos para avanzar hacia el nivel Oro.</p>
-      ${btnPrimario(`${process.env.NEXTAUTH_URL ?? ''}/taller/formalizacion`, 'Ver mi formalización')}
+      ${btnPrimario(`${appBaseUrl}/taller/formalizacion`, 'Ver mi formalización')}
     `),
   }
 }
@@ -131,13 +134,13 @@ export function buildDocRechazadoEmail(data: { nombreTaller: string; tipoDoc: st
       <p>Hola <strong>${data.nombreTaller}</strong>, tu documento <strong>${data.tipoDoc}</strong> fue revisado y necesita correcciones.</p>
       <p style="background: #fef2f2; border-left: 4px solid #dc2626; padding: 12px 16px; border-radius: 4px;"><strong>Motivo:</strong> ${data.motivo}</p>
       <p>Podés volver a subir el documento corregido desde tu panel de formalización.</p>
-      ${btnPrimario(`${process.env.NEXTAUTH_URL ?? ''}/taller/formalizacion`, 'Volver a cargar el documento')}
+      ${btnPrimario(`${appBaseUrl}/taller/formalizacion`, 'Volver a cargar el documento')}
     `),
   }
 }
 
 export function buildCertificadoEmail(data: { nombreTaller: string; tituloColeccion: string; codigo: string; calificacion: number }): { subject: string; html: string } {
-  const verificarUrl = `${process.env.NEXTAUTH_URL ?? ''}/verificar?code=${data.codigo}`
+  const verificarUrl = `${appBaseUrl}/verificar?code=${data.codigo}`
   return {
     subject: `Certificado obtenido: ${data.tituloColeccion} - PDT`,
     html: emailWrapper(`
@@ -198,7 +201,7 @@ export function buildCotizacionRecibidaEmail(data: {
         <p style="margin: 4px 0;"><strong>Precio:</strong> $${data.precio.toLocaleString('es-AR')}</p>
         <p style="margin: 4px 0;"><strong>Plazo:</strong> ${data.plazoDias} dias</p>
       </div>
-      ${btnPrimario(`${process.env.NEXTAUTH_URL ?? ''}/marca/pedidos`, 'Ver cotizaciones')}
+      ${btnPrimario(`${appBaseUrl}/marca/pedidos`, 'Ver cotizaciones')}
     `),
   }
 }
@@ -221,7 +224,7 @@ export function buildCotizacionAceptadaEmail(data: {
         <p style="margin: 4px 0;"><strong>Plazo:</strong> ${data.plazoDias} dias</p>
       </div>
       <p>Ya se creo la orden de manufactura. Revisa los detalles en tu panel.</p>
-      ${btnPrimario(`${process.env.NEXTAUTH_URL ?? ''}/taller/pedidos`, 'Ver mis pedidos')}
+      ${btnPrimario(`${appBaseUrl}/taller/pedidos`, 'Ver mis pedidos')}
     `),
   }
 }
@@ -237,7 +240,7 @@ export function buildCotizacionRechazadaEmail(data: {
       <h2 style="margin: 0 0 12px;">Cotizacion no seleccionada</h2>
       <p>Hola <strong>${data.nombreTaller}</strong>, la marca <strong>${data.nombreMarca}</strong> selecciono otra cotizacion para el proceso <strong>${data.proceso}</strong>.</p>
       <p>Segui cotizando otros pedidos disponibles en la plataforma.</p>
-      ${btnPrimario(`${process.env.NEXTAUTH_URL ?? ''}/taller/pedidos`, 'Ver pedidos disponibles')}
+      ${btnPrimario(`${appBaseUrl}/taller/pedidos`, 'Ver pedidos disponibles')}
     `),
   }
 }
@@ -265,8 +268,8 @@ export function buildInvitacionRegistroEmail(data: {
   nombreReferente: string
   cargoReferente: string
 }): { subject: string; html: string } {
-  const registroUrl = `${process.env.NEXTAUTH_URL ?? ''}/registro`
-  const guiaUrl = `${process.env.NEXTAUTH_URL ?? ''}/ayuda/onboarding-taller`
+  const registroUrl = `${appBaseUrl}/registro`
+  const guiaUrl = `${appBaseUrl}/ayuda/onboarding-taller`
   return {
     subject: 'Te invitamos a la Plataforma Digital Textil — UNTREF/OIT',
     html: emailWrapper(`

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,6 +24,7 @@ export default auth((req) => {
     '/denunciar',
     '/consultar-denuncia',
     '/directorio',
+    '/unauthorized',
     '/perfil/',        // Perfil público taller /perfil/[id]
     '/perfil-marca/',  // Perfil público marca /perfil-marca/[id]
     '/n/',             // Magic links WhatsApp (F-02)


### PR DESCRIPTION
## Summary

Consolida 3 fixes que son interdependientes:

1. **Fix de detección de preview URL para PRs** — El workflow ahora usa la GitHub Deployments API para encontrar la preview URL de Vercel en PRs, en vez de usar la URL fija de develop
2. **Fix de /unauthorized como ruta pública** — Agrega `/unauthorized` a `publicRoutes` en el middleware para evitar redirect chains a `/login`
3. **Warmup programático con login real** — Reemplaza el warmup anónimo (curl sin sesión) por login programático con cada rol, calentando las funciones autenticadas (auth + Prisma + DB)

Sin los 3 juntos, los E2E de PRs no pueden pasar. Reemplaza al PR #313 que fue cerrado por dependencia circular.

## Criterio de éxito

- Vercel deploy verde
- E2E Tests verde con 0 o ≤2 flakies en primer intento
- El test 'TALLER no puede acceder a /estado/talleres' pasa

## Test plan

- [ ] YAML válido (verificado localmente)
- [ ] Warmup log muestra Phase 1 + Phase 2 con login exitoso para 4 roles
- [ ] Test `roles-estado.spec.ts:79` (unauthorized) pasa
- [ ] Tests ESTADO pasan en primer intento (sin timeout por cold start)

🤖 Generated with [Claude Code](https://claude.com/claude-code)