### PR TITLE
fix(e2e): scopear selector de Breadcrumb a <main>

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,14 @@
 # Daily Log
 
+## 2026-05-14
+
+### Gerardo Breard
+- **15:17** `0585e7b` — fix(e2e): scopear selector de Breadcrumb a <main>
+  - `tests/e2e/exportes-estado.spec.ts`
+  - `tests/e2e/layout-consistency.spec.ts`
+  - `tests/e2e/ux-mejoras.spec.ts`
+
+
 ## 2026-05-13
 
 ### Gerardo Breard

--- a/tests/e2e/exportes-estado.spec.ts
+++ b/tests/e2e/exportes-estado.spec.ts
@@ -96,7 +96,7 @@ test.describe('F-04 Exportes del Estado', () => {
     await page.goto('/estado/exportar')
     await page.waitForLoadState('domcontentloaded')
 
-    const breadcrumb = page.locator('nav[aria-label="Breadcrumb"]')
+    const breadcrumb = page.locator('main nav[aria-label="Breadcrumb"]')
     await expect(breadcrumb).toBeVisible({ timeout: 30000 })
   })
 })

--- a/tests/e2e/layout-consistency.spec.ts
+++ b/tests/e2e/layout-consistency.spec.ts
@@ -68,7 +68,7 @@ test.describe('Layout consistency — cada rol tiene header y sidebar correctos'
       // Header global — NO el header minimo
       await expect(page.locator('button[aria-label*="Notificaciones"]').first()).toBeVisible()
       // Breadcrumbs
-      await expect(page.locator('nav[aria-label="Breadcrumb"]')).toBeVisible()
+      await expect(page.locator('main nav[aria-label="Breadcrumb"]')).toBeVisible()
     } catch {
       test.skip()
     }
@@ -82,7 +82,7 @@ test.describe('Layout consistency — cada rol tiene header y sidebar correctos'
       // Header global
       await expect(page.locator('button[aria-label*="Notificaciones"]').first()).toBeVisible()
       // Breadcrumbs
-      await expect(page.locator('nav[aria-label="Breadcrumb"]')).toBeVisible()
+      await expect(page.locator('main nav[aria-label="Breadcrumb"]')).toBeVisible()
     } catch {
       test.skip()
     }

--- a/tests/e2e/ux-mejoras.spec.ts
+++ b/tests/e2e/ux-mejoras.spec.ts
@@ -42,7 +42,7 @@ test.describe('UX Mejoras', () => {
     expect(body).not.toContain('Application error')
 
     // Verificar que la pagina tiene breadcrumbs (nav con aria-label)
-    const breadcrumb = page.locator('nav[aria-label="Breadcrumb"]')
+    const breadcrumb = page.locator('main nav[aria-label="Breadcrumb"]')
     await expect(breadcrumb).toBeVisible({ timeout: 30000 })
   })
 


### PR DESCRIPTION
## Summary
- Scopea selector `nav[aria-label="Breadcrumb"]` → `main nav[aria-label="Breadcrumb"]` en 3 archivos de tests E2E

## Causa raíz
Durante hidratación de React 19 streaming SSR, coexisten brevemente 2 `<nav aria-label="Breadcrumb">` (uno visible en `<main>`, otro hidden en `<div id="S:1">`). Playwright strict mode captura ambos y falla.

## Archivos modificados
- `tests/e2e/ux-mejoras.spec.ts`
- `tests/e2e/layout-consistency.spec.ts`
- `tests/e2e/exportes-estado.spec.ts`

Sin cambios en código de aplicación. Solo tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)