### PR TITLE
fix(file-validation): eliminar cache in-memory cross-instance

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -8,6 +8,10 @@
   - `tests/e2e/layout-consistency.spec.ts`
   - `tests/e2e/ux-mejoras.spec.ts`
 
+- **15:32** `4b6ff74` — fix(file-validation): eliminar cache in-memory cross-instance
+  - `src/app/api/admin/configuracion-upload/[id]/route.ts`
+  - `src/compartido/lib/file-validation.ts`
+
 
 ## 2026-05-13
 

--- a/src/app/api/admin/configuracion-upload/[id]/route.ts
+++ b/src/app/api/admin/configuracion-upload/[id]/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/compartido/lib/auth'
 import { prisma } from '@/compartido/lib/prisma'
-import { invalidarCacheConfigs } from '@/compartido/lib/file-validation'
 import { logAccionAdmin } from '@/compartido/lib/log'
 
 const TIPOS_VALIDOS = ['pdf', 'jpeg', 'png', 'webp', 'xlsx', 'docx', 'mp4', 'mov']
@@ -50,8 +49,6 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
         actualizadoPor: session.user.id,
       },
     })
-
-    invalidarCacheConfigs()
 
     logAccionAdmin('CONFIGURACION_UPLOAD_ACTUALIZADA', session.user.id!, {
       entidad: 'configuracion',

--- a/src/compartido/lib/file-validation.ts
+++ b/src/compartido/lib/file-validation.ts
@@ -44,27 +44,10 @@ export function detectarTipoArchivo(
   return null
 }
 
-// Cache de configuraciones en memoria (1 minuto)
-const cacheConfigs = new Map<string, { data: ConfiguracionUpload; expira: number }>()
-const CACHE_TTL_MS = 60 * 1000
-
 async function obtenerConfig(contexto: string): Promise<ConfiguracionUpload | null> {
-  const ahora = Date.now()
-  const cached = cacheConfigs.get(contexto)
-
-  if (cached && cached.expira > ahora) {
-    return cached.data
-  }
-
-  const config = await prisma.configuracionUpload.findUnique({
+  return prisma.configuracionUpload.findUnique({
     where: { contexto },
   })
-
-  if (config) {
-    cacheConfigs.set(contexto, { data: config, expira: ahora + CACHE_TTL_MS })
-  }
-
-  return config
 }
 
 export interface FileValidationResult {
@@ -145,10 +128,3 @@ export function esNombreSeguro(nombre: string): boolean {
   return true
 }
 
-/**
- * Invalida el cache de configuraciones.
- * Llamar desde el endpoint PUT despues de actualizar una config.
- */
-export function invalidarCacheConfigs() {
-  cacheConfigs.clear()
-}


### PR DESCRIPTION
## Summary
- Elimina cache Map in-memory con TTL 60s en `file-validation.ts`
- Elimina llamada a `invalidarCacheConfigs()` en endpoint admin PUT

## Causa raíz
Cache in-memory se invalidaba solo en la instancia serverless que recibía el request de admin. Otras instancias seguían con cache stale, causando que validaciones pasaran con configs viejos → 502 en Supabase Storage.

## Trade-off
Cada validación de upload hace 1 query extra a DB (<50ms). Aceptable porque file-validation no es hot path y elimina toda categoría de bugs cross-instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)