### PR TITLE
fix(e2e): race condition en file-validation con serial mode

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-15
 
 ### Gerardo Breard
+- **15:59** `f91ea1c` — fix(e2e): resolver race condition en file-validation con serial mode
+  - `tests/e2e/file-validation.spec.ts`
+
 - **15:25** `f680b3f` — fix(e2e): strict mode y navigation race en demanda-insatisfecha y smoke
   - `tests/e2e/demanda-insatisfecha.spec.ts`
   - `tests/e2e/smoke.spec.ts`

--- a/tests/e2e/file-validation.spec.ts
+++ b/tests/e2e/file-validation.spec.ts
@@ -15,6 +15,8 @@ function exeBuffer(): Buffer {
   return Buffer.from([0x4d, 0x5a, 0x90, 0x00, 0x03, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0xff, 0xff, 0x00, 0x00])
 }
 
+test.describe.configure({ mode: 'serial' })
+
 test.describe('File validation — S-03', () => {
   test('upload JPEG valido a imagenes (portfolio) retorna URL', async ({ page }) => {
     test.setTimeout(30000)


### PR DESCRIPTION
## Summary

- Resuelve flaky de `file-validation.spec.ts` causado por test "contexto deshabilitado" que modifica DB compartida mientras otros tests corren en paralelo
- Fix: `test.describe.configure({ mode: 'serial' })` fuerza ejecucion secuencial

## Causa raiz

El test `:157` desactiva `imagenes-portfolio` en la DB y lo reactiva en `finally`. Con 2 workers, los tests `:19`, `:58`, `:124` corrian concurrentemente y golpeaban el contexto temporalmente deshabilitado.

Evidencia: `updatedAt` de `imagenes-portfolio` mostro modificacion a las 18:33:14 durante el run E2E, coincidiendo con los fallos.

## Test plan

- [x] TypeScript compila sin errores
- [ ] CI verde con 0 failed y 0 flakies en file-validation
- [ ] Duracion total similar (~3min)

Detalles tecnicos en commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)