### PR TITLE
fix: tab 'Todas' por default en /cuenta/notificaciones (cierra #320)

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-16
 
 ### Gerardo Breard
+- **20:30** `7d65e27` — fix(notificaciones): tab 'Todas' por default en pagina cuenta
+  - `src/app/(public)/cuenta/notificaciones/page.tsx`
+
 - **19:28** `f6c6950` — fix(api): include solo con relaciones en /api/talleres
   - `src/app/api/talleres/route.ts`
 

--- a/src/app/(public)/cuenta/notificaciones/page.tsx
+++ b/src/app/(public)/cuenta/notificaciones/page.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link'
 import { NotificacionesLista } from './notificaciones-lista'
 import { Breadcrumbs } from '@/compartido/componentes/ui/breadcrumbs'
 
-type Tab = 'comunicaciones' | 'historial'
+type Tab = 'todas' | 'comunicaciones' | 'sistema'
 
 export default async function NotificacionesPage({
   searchParams,
@@ -18,12 +18,17 @@ export default async function NotificacionesPage({
   if (!session?.user?.id) redirect('/login?callbackUrl=%2Fcuenta%2Fnotificaciones')
 
   const params = await Promise.resolve(searchParams ?? {})
-  const tab: Tab = params.tab === 'historial' ? 'historial' : 'comunicaciones'
+  const rawTab = params.tab
+  const tab: Tab = rawTab === 'historial' || rawTab === 'sistema'
+    ? 'sistema'
+    : rawTab === 'comunicaciones'
+    ? 'comunicaciones'
+    : 'todas'
 
   const where: Record<string, unknown> = { userId: session.user.id }
   if (tab === 'comunicaciones') {
     where.createdById = { not: null }
-  } else {
+  } else if (tab === 'sistema') {
     where.createdById = null
   }
 
@@ -44,6 +49,14 @@ export default async function NotificacionesPage({
       ]} />
       <div className="flex gap-2">
         <Link
+          href="/cuenta/notificaciones"
+          className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+            tab === 'todas' ? 'bg-brand-blue text-white' : 'border border-gray-300 text-gray-600 hover:bg-gray-50'
+          }`}
+        >
+          Todas
+        </Link>
+        <Link
           href="?tab=comunicaciones"
           className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
             tab === 'comunicaciones' ? 'bg-brand-blue text-white' : 'border border-gray-300 text-gray-600 hover:bg-gray-50'
@@ -52,21 +65,23 @@ export default async function NotificacionesPage({
           Comunicaciones
         </Link>
         <Link
-          href="?tab=historial"
+          href="?tab=sistema"
           className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-            tab === 'historial' ? 'bg-brand-blue text-white' : 'border border-gray-300 text-gray-600 hover:bg-gray-50'
+            tab === 'sistema' ? 'bg-brand-blue text-white' : 'border border-gray-300 text-gray-600 hover:bg-gray-50'
           }`}
         >
-          Historial del sistema
+          Sistema
         </Link>
       </div>
 
       <NotificacionesLista
         notificaciones={notificaciones}
         emptyMessage={
-          tab === 'comunicaciones'
+          tab === 'todas'
+            ? 'Estas al dia. No tenes notificaciones.'
+            : tab === 'comunicaciones'
             ? 'No recibiste comunicaciones todavia.'
-            : 'El sistema no genero notificaciones para vos todavia.'
+            : 'Sin alertas del sistema.'
         }
       />
     </div>


### PR DESCRIPTION
## Summary

- Bug #320: badge de notificaciones desincronizado con pagina
- Causa: la pagina por default mostraba solo 'comunicaciones' (createdById != null), filtrando notificaciones de sistema. El bell del header las mostraba todas, generando discrepancia visual
- Fix: 3 tabs (Todas / Comunicaciones / Sistema) con 'Todas' por default
- Mantiene `?tab=historial` como alias de `?tab=sistema` para backwards compat

## Test plan

- [ ] Abrir /cuenta/notificaciones — debe mostrar tab "Todas" activo con todas las notificaciones (comunicaciones + sistema)
- [ ] Verificar que la notificacion de "Validaciones pendientes" aparece en "Todas" y en "Sistema" pero NO en "Comunicaciones"
- [ ] Verificar que el count "Total: X | Sin leer: Y" coincide con lo que muestra la campanita del header
- [ ] Click en tab "Comunicaciones" → solo muestra notificaciones enviadas por otro usuario
- [ ] Click en tab "Sistema" → solo muestra notificaciones automaticas del sistema
- [ ] Verificar backwards compat: `/cuenta/notificaciones?tab=historial` abre el tab "Sistema"

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)