### PR TITLE
fix: restaurar usuario CONTENIDO en /acceso-rapido (cierra #321)

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-16
 
 ### Gerardo Breard
+- **21:09** `6fb4683` — fix(acceso-rapido): restaurar usuario CONTENIDO
+  - `src/app/(auth)/acceso-rapido/page.tsx`
+
 - **20:30** `7d65e27` — fix(notificaciones): tab 'Todas' por default en pagina cuenta
   - `src/app/(public)/cuenta/notificaciones/page.tsx`
 

--- a/src/app/(auth)/acceso-rapido/page.tsx
+++ b/src/app/(auth)/acceso-rapido/page.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { signIn } from 'next-auth/react'
 import { Card } from '@/compartido/componentes/ui/card'
-import { Factory, ShoppingBag, BarChart3, Shield } from 'lucide-react'
+import { Factory, ShoppingBag, BarChart3, Shield, FileText } from 'lucide-react'
 
 const usuarios = [
   {
@@ -66,6 +66,16 @@ const usuarios = [
     redirect: '/estado',
     icon: BarChart3,
     color: 'bg-green-600',
+  },
+  {
+    email: 'sofia.martinez@pdt.org.ar',
+    password: 'pdt2026',
+    nombre: 'Sofía Martínez',
+    rol: 'CONTENIDO',
+    descripcion: 'Gestión de contenido público',
+    redirect: '/contenido',
+    icon: FileText,
+    color: 'bg-purple-500',
   },
 ]
 


### PR DESCRIPTION
El usuario Sofia Martinez (CONTENIDO) se elimino del array de acceso-rapido en algun momento sin documentar. Decision: restaurarlo para facilitar testing local.

- Icono: `FileText` (representa gestion de contenido/documentos)
- Color: `bg-purple-500` (unico, no colisiona con los otros 6 usuarios)
- Redirect: `/contenido` (confirmado en middleware linea 131-132)

Closes #321