### PR TITLE
feat: X-04b CMS Novedades (CRUD simple)

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-17
 
 ### Gerardo Breard
+- **20:27** `cca786b` — feat(x-04b): add slugify utility for novedades
+  - `src/compartido/lib/slugify.ts`
+
 - **18:48** `ccfb7f0` — fix(x-06): corregir valor de enum EstadoPedido
   - `src/app/page.tsx`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,11 @@
 ## 2026-05-17
 
 ### Gerardo Breard
+- **20:29** `81a92fe` — feat(x-04b): add CRUD + upload endpoints for novedades
+  - `src/app/api/contenido/novedades/[id]/route.ts`
+  - `src/app/api/contenido/novedades/route.ts`
+  - `src/app/api/contenido/novedades/upload/route.ts`
+
 - **20:27** `cca786b` — feat(x-04b): add slugify utility for novedades
   - `src/compartido/lib/slugify.ts`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,14 @@
 ## 2026-05-17
 
 ### Gerardo Breard
+- **20:36** `bcd5fbe` — feat(x-04b): add CMS novedades pages + sidebar entry
+  - `src/app/(contenido)/contenido-sidebar.tsx`
+  - `src/app/(contenido)/contenido/novedades/[id]/editar/page.tsx`
+  - `src/app/(contenido)/contenido/novedades/formulario-novedad.tsx`
+  - `src/app/(contenido)/contenido/novedades/loading.tsx`
+  - `src/app/(contenido)/contenido/novedades/nueva/page.tsx`
+  - `src/app/(contenido)/contenido/novedades/page.tsx`
+
 - **20:29** `81a92fe` — feat(x-04b): add CRUD + upload endpoints for novedades
   - `src/app/api/contenido/novedades/[id]/route.ts`
   - `src/app/api/contenido/novedades/route.ts`

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-17
 
 ### Gerardo Breard
+- **20:51** `680b4bd` — fix: add Supabase Storage to next/image remotePatterns
+  - `next.config.ts`
+
 - **20:36** `bcd5fbe` — feat(x-04b): add CMS novedades pages + sidebar entry
   - `src/app/(contenido)/contenido-sidebar.tsx`
   - `src/app/(contenido)/contenido/novedades/[id]/editar/page.tsx`

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,16 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
   reactCompiler: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '*.supabase.co',
+        pathname: '/storage/v1/object/public/**',
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/(contenido)/contenido-sidebar.tsx
+++ b/src/app/(contenido)/contenido-sidebar.tsx
@@ -2,9 +2,10 @@
 
 import { usePathname } from 'next/navigation'
 import Link from 'next/link'
-import { BookOpen, ClipboardList, Bell } from 'lucide-react'
+import { BookOpen, ClipboardList, Bell, Newspaper } from 'lucide-react'
 
 const sidebarItems = [
+  { label: 'Novedades', href: '/contenido/novedades', icon: Newspaper },
   { label: 'Colecciones', href: '/contenido/colecciones', icon: BookOpen },
   { label: 'Evaluaciones', href: '/contenido/evaluaciones', icon: ClipboardList },
   { label: 'Notificaciones', href: '/contenido/notificaciones', icon: Bell },

--- a/src/app/(contenido)/contenido/novedades/[id]/editar/page.tsx
+++ b/src/app/(contenido)/contenido/novedades/[id]/editar/page.tsx
@@ -1,0 +1,22 @@
+import { notFound } from 'next/navigation'
+import { prisma } from '@/compartido/lib/prisma'
+import { Breadcrumbs } from '@/compartido/componentes/ui/breadcrumbs'
+import { FormularioNovedad } from '../../formulario-novedad'
+
+export default async function EditarNovedadPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const novedad = await prisma.novedad.findUnique({ where: { id } })
+
+  if (!novedad) notFound()
+
+  return (
+    <div className="space-y-6">
+      <Breadcrumbs items={[
+        { label: 'Novedades', href: '/contenido/novedades' },
+        { label: 'Editar novedad' },
+      ]} />
+      <h1 className="font-overpass font-bold text-2xl text-brand-blue">Editar novedad</h1>
+      <FormularioNovedad novedad={novedad} />
+    </div>
+  )
+}

--- a/src/app/(contenido)/contenido/novedades/formulario-novedad.tsx
+++ b/src/app/(contenido)/contenido/novedades/formulario-novedad.tsx
@@ -1,0 +1,291 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Modal } from '@/compartido/componentes/ui/modal'
+
+interface NovedadData {
+  id: string
+  tipo: 'NOTICIA' | 'CASO' | 'INDICADOR'
+  titulo: string
+  descripcion: string
+  imagenUrl: string | null
+  fecha: Date | string
+}
+
+interface Props {
+  novedad?: NovedadData
+}
+
+const TIPO_OPTIONS = [
+  { value: 'NOTICIA', label: 'Noticia' },
+  { value: 'CASO', label: 'Caso de éxito' },
+  { value: 'INDICADOR', label: 'Indicador' },
+] as const
+
+export function FormularioNovedad({ novedad }: Props) {
+  const router = useRouter()
+  const isEdit = !!novedad
+
+  const [tipo, setTipo] = useState(novedad?.tipo ?? 'NOTICIA')
+  const [titulo, setTitulo] = useState(novedad?.titulo ?? '')
+  const [descripcion, setDescripcion] = useState(novedad?.descripcion ?? '')
+  const [imagenUrl, setImagenUrl] = useState<string | null>(novedad?.imagenUrl ?? null)
+  const [fecha, setFecha] = useState(() => {
+    if (novedad?.fecha) {
+      const d = new Date(novedad.fecha)
+      return d.toISOString().split('T')[0]
+    }
+    return new Date().toISOString().split('T')[0]
+  })
+  const [loading, setLoading] = useState(false)
+  const [uploading, setUploading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [showDeleteModal, setShowDeleteModal] = useState(false)
+
+  const handleUpload = async (file: File) => {
+    setUploading(true)
+    setError(null)
+    try {
+      const formData = new FormData()
+      formData.append('file', file)
+
+      const res = await fetch('/api/contenido/novedades/upload', {
+        method: 'POST',
+        body: formData,
+      })
+
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Error subiendo imagen')
+      }
+
+      const { url } = await res.json()
+      setImagenUrl(url)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error subiendo imagen')
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setError(null)
+
+    try {
+      const url = isEdit
+        ? `/api/contenido/novedades/${novedad.id}`
+        : '/api/contenido/novedades'
+
+      const method = isEdit ? 'PATCH' : 'POST'
+
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tipo, titulo, descripcion, imagenUrl, fecha }),
+      })
+
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Error guardando')
+      }
+
+      router.push('/contenido/novedades')
+      router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error guardando')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!isEdit) return
+    setLoading(true)
+
+    try {
+      const res = await fetch(`/api/contenido/novedades/${novedad.id}`, {
+        method: 'DELETE',
+      })
+
+      if (!res.ok) throw new Error('Error eliminando')
+
+      router.push('/contenido/novedades')
+      router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error eliminando')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6 max-w-2xl">
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+          {error}
+        </div>
+      )}
+
+      {/* Tipo */}
+      <div>
+        <label className="block text-sm font-overpass font-semibold text-gray-700 mb-1">
+          Tipo <span className="text-red-500">*</span>
+        </label>
+        <select
+          value={tipo}
+          onChange={e => setTipo(e.target.value as typeof tipo)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-blue focus:border-brand-blue"
+          required
+        >
+          {TIPO_OPTIONS.map(opt => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Título */}
+      <div>
+        <label className="block text-sm font-overpass font-semibold text-gray-700 mb-1">
+          Título <span className="text-red-500">*</span>
+        </label>
+        <input
+          type="text"
+          value={titulo}
+          onChange={e => setTitulo(e.target.value)}
+          maxLength={200}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-blue focus:border-brand-blue"
+          placeholder="Ej: Convenio firmado con OIT para piloto sectorial"
+          required
+        />
+        <p className="text-xs text-gray-400 mt-1">{titulo.length}/200 caracteres</p>
+      </div>
+
+      {/* Descripción */}
+      <div>
+        <label className="block text-sm font-overpass font-semibold text-gray-700 mb-1">
+          Descripción <span className="text-red-500">*</span>
+        </label>
+        <textarea
+          value={descripcion}
+          onChange={e => setDescripcion(e.target.value)}
+          maxLength={2000}
+          rows={6}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-blue focus:border-brand-blue resize-y"
+          placeholder="Descripción de la novedad..."
+          required
+        />
+        <p className="text-xs text-gray-400 mt-1">{descripcion.length}/2000 caracteres</p>
+      </div>
+
+      {/* Imagen */}
+      <div>
+        <label className="block text-sm font-overpass font-semibold text-gray-700 mb-1">
+          Imagen
+        </label>
+        {imagenUrl ? (
+          <div className="space-y-2">
+            <img src={imagenUrl} alt="" className="max-w-xs h-40 object-cover rounded-lg border border-gray-200" />
+            <button
+              type="button"
+              onClick={() => setImagenUrl(null)}
+              className="text-sm text-red-600 hover:text-red-800 font-overpass font-medium"
+            >
+              Quitar imagen
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <input
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              disabled={uploading}
+              onChange={async (e) => {
+                const file = e.target.files?.[0]
+                if (file) await handleUpload(file)
+              }}
+              className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-overpass file:font-semibold file:bg-blue-50 file:text-brand-blue hover:file:bg-blue-100"
+            />
+            {uploading && (
+              <p className="text-sm text-brand-blue animate-pulse">Subiendo imagen...</p>
+            )}
+            <p className="text-xs text-gray-400">JPEG, PNG o WebP. Máximo 5MB.</p>
+          </div>
+        )}
+      </div>
+
+      {/* Fecha */}
+      <div>
+        <label className="block text-sm font-overpass font-semibold text-gray-700 mb-1">
+          Fecha de publicación
+        </label>
+        <input
+          type="date"
+          value={fecha}
+          onChange={e => setFecha(e.target.value)}
+          className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-blue focus:border-brand-blue"
+        />
+      </div>
+
+      {/* Acciones */}
+      <div className="flex items-center justify-between pt-4 border-t border-gray-200">
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={loading || uploading}
+            className="px-5 py-2.5 bg-brand-blue text-white rounded-lg font-overpass font-semibold text-sm hover:bg-blue-800 disabled:opacity-50 transition-colors"
+          >
+            {loading ? 'Guardando...' : isEdit ? 'Guardar cambios' : 'Crear novedad'}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push('/contenido/novedades')}
+            className="px-5 py-2.5 border border-gray-300 text-gray-700 rounded-lg font-overpass font-medium text-sm hover:bg-gray-50 transition-colors"
+          >
+            Cancelar
+          </button>
+        </div>
+
+        {isEdit && (
+          <button
+            type="button"
+            onClick={() => setShowDeleteModal(true)}
+            className="text-sm text-red-600 hover:text-red-800 font-overpass font-medium"
+          >
+            Eliminar novedad
+          </button>
+        )}
+      </div>
+
+      {/* Modal de confirmación de eliminación */}
+      <Modal
+        open={showDeleteModal}
+        onClose={() => setShowDeleteModal(false)}
+        title="Eliminar novedad"
+        size="sm"
+      >
+        <p className="text-sm text-gray-600 mb-4">
+          ¿Estás seguro de que querés eliminar esta novedad? Esta acción no se puede deshacer.
+        </p>
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={loading}
+            className="px-4 py-2 bg-red-600 text-white rounded-lg font-overpass font-semibold text-sm hover:bg-red-700 disabled:opacity-50"
+          >
+            {loading ? 'Eliminando...' : 'Sí, eliminar'}
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowDeleteModal(false)}
+            className="px-4 py-2 border border-gray-300 rounded-lg font-overpass font-medium text-sm hover:bg-gray-50"
+          >
+            Cancelar
+          </button>
+        </div>
+      </Modal>
+    </form>
+  )
+}

--- a/src/app/(contenido)/contenido/novedades/loading.tsx
+++ b/src/app/(contenido)/contenido/novedades/loading.tsx
@@ -1,0 +1,24 @@
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <div className="h-6 w-48 bg-gray-200 rounded animate-pulse" />
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <div className="h-8 w-40 bg-gray-200 rounded animate-pulse" />
+          <div className="h-4 w-64 bg-gray-200 rounded animate-pulse" />
+        </div>
+        <div className="h-10 w-36 bg-gray-200 rounded animate-pulse" />
+      </div>
+      <div className="bg-white rounded-xl border border-gray-200 p-4 space-y-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4">
+            <div className="w-16 h-12 bg-gray-200 rounded animate-pulse" />
+            <div className="h-4 w-20 bg-gray-200 rounded animate-pulse" />
+            <div className="h-4 w-48 bg-gray-200 rounded animate-pulse" />
+            <div className="h-4 w-24 bg-gray-200 rounded animate-pulse" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(contenido)/contenido/novedades/nueva/page.tsx
+++ b/src/app/(contenido)/contenido/novedades/nueva/page.tsx
@@ -1,0 +1,18 @@
+import { Breadcrumbs } from '@/compartido/componentes/ui/breadcrumbs'
+import { FormularioNovedad } from '../formulario-novedad'
+
+export default function NuevaNovedadPage() {
+  return (
+    <div className="space-y-6">
+      <Breadcrumbs items={[
+        { label: 'Novedades', href: '/contenido/novedades' },
+        { label: 'Nueva novedad' },
+      ]} />
+      <h1 className="font-overpass font-bold text-2xl text-brand-blue">Nueva novedad</h1>
+      <p className="text-sm text-gray-500">
+        La novedad se publicará inmediatamente en el landing.
+      </p>
+      <FormularioNovedad />
+    </div>
+  )
+}

--- a/src/app/(contenido)/contenido/novedades/page.tsx
+++ b/src/app/(contenido)/contenido/novedades/page.tsx
@@ -1,0 +1,115 @@
+export const dynamic = 'force-dynamic'
+
+import Link from 'next/link'
+import Image from 'next/image'
+import { prisma } from '@/compartido/lib/prisma'
+import { EmptyState } from '@/compartido/componentes/ui/empty-state'
+import { Breadcrumbs } from '@/compartido/componentes/ui/breadcrumbs'
+import { Newspaper, Plus, Edit } from 'lucide-react'
+import type { TipoNovedad } from '@prisma/client'
+
+const TIPO_LABELS: Record<TipoNovedad, string> = {
+  NOTICIA: 'Noticia',
+  CASO: 'Caso de éxito',
+  INDICADOR: 'Indicador',
+}
+
+const TIPO_COLOR: Record<TipoNovedad, string> = {
+  NOTICIA: 'bg-green-100 text-green-800',
+  CASO: 'bg-blue-100 text-brand-blue',
+  INDICADOR: 'bg-purple-100 text-purple-800',
+}
+
+export default async function NovedadesPage() {
+  const novedades = await prisma.novedad.findMany({
+    orderBy: { createdAt: 'desc' },
+  })
+
+  return (
+    <div className="space-y-6">
+      <Breadcrumbs items={[{ label: 'Novedades' }]} />
+
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-overpass font-bold text-2xl text-brand-blue">Novedades</h1>
+          <p className="text-sm text-gray-500 mt-1">Gestionar novedades del landing</p>
+        </div>
+        <Link
+          href="/contenido/novedades/nueva"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-overpass font-semibold bg-brand-blue hover:bg-blue-800 text-white transition-colors"
+        >
+          <Plus className="w-4 h-4" />
+          Nueva novedad
+        </Link>
+      </div>
+
+      {novedades.length === 0 ? (
+        <EmptyState
+          icon={<Newspaper className="w-8 h-8 text-brand-blue" />}
+          titulo="Aún no hay novedades"
+          mensaje="Creá la primera novedad para que aparezca en el landing."
+          accion={{ texto: 'Crear novedad', href: '/contenido/novedades/nueva' }}
+        />
+      ) : (
+        <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+          <table className="w-full">
+            <thead className="bg-gray-50 border-b border-gray-200">
+              <tr>
+                <th className="text-left px-4 py-3 text-xs font-overpass font-bold uppercase text-gray-600">Imagen</th>
+                <th className="text-left px-4 py-3 text-xs font-overpass font-bold uppercase text-gray-600">Tipo</th>
+                <th className="text-left px-4 py-3 text-xs font-overpass font-bold uppercase text-gray-600">Título</th>
+                <th className="text-left px-4 py-3 text-xs font-overpass font-bold uppercase text-gray-600">Fecha</th>
+                <th className="text-left px-4 py-3 text-xs font-overpass font-bold uppercase text-gray-600">Estado</th>
+                <th className="text-right px-4 py-3 text-xs font-overpass font-bold uppercase text-gray-600">Acciones</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {novedades.map(n => (
+                <tr key={n.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3">
+                    {n.imagenUrl ? (
+                      <Image
+                        src={n.imagenUrl}
+                        alt=""
+                        width={64}
+                        height={48}
+                        className="w-16 h-12 object-cover rounded"
+                      />
+                    ) : (
+                      <div className="w-16 h-12 bg-gray-100 rounded flex items-center justify-center">
+                        <Newspaper className="w-4 h-4 text-gray-400" />
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className={`inline-block px-2 py-1 rounded text-[10px] font-overpass font-bold uppercase ${TIPO_COLOR[n.tipo]}`}>
+                      {TIPO_LABELS[n.tipo]}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-900 max-w-xs truncate">{n.titulo}</td>
+                  <td className="px-4 py-3 text-sm text-gray-600">
+                    {n.fecha.toLocaleDateString('es-AR')}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className={`inline-block px-2 py-1 rounded text-[10px] font-overpass font-bold uppercase ${n.publicado ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600'}`}>
+                      {n.publicado ? 'Publicado' : 'Borrador'}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <Link
+                      href={`/contenido/novedades/${n.id}/editar`}
+                      className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-brand-blue hover:bg-blue-50 rounded transition-colors"
+                    >
+                      <Edit className="w-4 h-4" />
+                      Editar
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/api/contenido/novedades/[id]/route.ts
+++ b/src/app/api/contenido/novedades/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/compartido/lib/auth'
+import { prisma } from '@/compartido/lib/prisma'
+import { generarSlugUnico } from '@/compartido/lib/slugify'
+
+function checkAuth(session: { user?: { role?: string } } | null) {
+  if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+  const role = (session.user as { role?: string }).role
+  if (role !== 'CONTENIDO' && role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  return null
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await auth()
+  const authError = checkAuth(session)
+  if (authError) return authError
+
+  const { id } = await params
+  const body = await req.json()
+
+  const currentNovedad = await prisma.novedad.findUnique({ where: { id } })
+  if (!currentNovedad) {
+    return NextResponse.json({ error: 'Novedad no encontrada' }, { status: 404 })
+  }
+
+  const updates: Record<string, unknown> = {
+    titulo: body.titulo,
+    descripcion: body.descripcion,
+    tipo: body.tipo,
+    imagenUrl: body.imagenUrl ?? null,
+  }
+
+  if (body.titulo && currentNovedad.titulo !== body.titulo) {
+    updates.slug = await generarSlugUnico(body.titulo, id)
+  }
+
+  const novedad = await prisma.novedad.update({
+    where: { id },
+    data: updates,
+  })
+
+  return NextResponse.json({ novedad })
+}
+
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await auth()
+  const authError = checkAuth(session)
+  if (authError) return authError
+
+  const { id } = await params
+
+  const existing = await prisma.novedad.findUnique({ where: { id } })
+  if (!existing) {
+    return NextResponse.json({ error: 'Novedad no encontrada' }, { status: 404 })
+  }
+
+  await prisma.novedad.delete({ where: { id } })
+
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/contenido/novedades/route.ts
+++ b/src/app/api/contenido/novedades/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/compartido/lib/auth'
+import { prisma } from '@/compartido/lib/prisma'
+import { generarSlugUnico } from '@/compartido/lib/slugify'
+
+function checkAuth(session: { user?: { role?: string } } | null) {
+  if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+  const role = (session.user as { role?: string }).role
+  if (role !== 'CONTENIDO' && role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  return null
+}
+
+export async function GET() {
+  const session = await auth()
+  const authError = checkAuth(session)
+  if (authError) return authError
+
+  const novedades = await prisma.novedad.findMany({
+    orderBy: { createdAt: 'desc' },
+  })
+
+  return NextResponse.json({ novedades })
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth()
+  const authError = checkAuth(session)
+  if (authError) return authError
+
+  const body = await req.json()
+
+  if (!body.titulo || !body.descripcion || !body.tipo) {
+    return NextResponse.json({ error: 'Faltan campos requeridos' }, { status: 400 })
+  }
+
+  if (!['NOTICIA', 'CASO', 'INDICADOR'].includes(body.tipo)) {
+    return NextResponse.json({ error: 'Tipo inválido' }, { status: 400 })
+  }
+
+  if (body.titulo.length > 200) {
+    return NextResponse.json({ error: 'Título muy largo (máximo 200 caracteres)' }, { status: 400 })
+  }
+
+  if (body.descripcion.length > 2000) {
+    return NextResponse.json({ error: 'Descripción muy larga (máximo 2000 caracteres)' }, { status: 400 })
+  }
+
+  const slug = await generarSlugUnico(body.titulo)
+
+  const novedad = await prisma.novedad.create({
+    data: {
+      titulo: body.titulo,
+      slug,
+      descripcion: body.descripcion,
+      tipo: body.tipo,
+      imagenUrl: body.imagenUrl ?? null,
+      fecha: body.fecha ? new Date(body.fecha) : new Date(),
+      publicado: true,
+    },
+  })
+
+  return NextResponse.json({ novedad })
+}

--- a/src/app/api/contenido/novedades/upload/route.ts
+++ b/src/app/api/contenido/novedades/upload/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/compartido/lib/auth'
+import { uploadFile } from '@/compartido/lib/storage'
+
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp']
+const MAX_SIZE = 5 * 1024 * 1024 // 5MB
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+    }
+
+    const role = (session.user as { role?: string }).role
+    if (role !== 'CONTENIDO' && role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const formData = await req.formData()
+    const file = formData.get('file') as File | null
+
+    if (!file) {
+      return NextResponse.json({ error: 'No se proporcionó archivo' }, { status: 400 })
+    }
+
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      return NextResponse.json(
+        { error: 'Tipo de archivo no permitido. Use JPEG, PNG o WebP.' },
+        { status: 400 }
+      )
+    }
+
+    if (file.size > MAX_SIZE) {
+      return NextResponse.json(
+        { error: 'Archivo muy grande. Máximo 5MB.' },
+        { status: 400 }
+      )
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer())
+    const timestamp = Date.now()
+    const ext = file.name.split('.').pop() ?? 'jpg'
+    const path = `novedades/${timestamp}.${ext}`
+
+    const url = await uploadFile(buffer, path, file.type, 'imagenes')
+
+    return NextResponse.json({ url })
+  } catch (error) {
+    console.error('[contenido/novedades/upload]', error)
+    return NextResponse.json({ error: 'Error al subir la imagen' }, { status: 502 })
+  }
+}

--- a/src/compartido/lib/slugify.ts
+++ b/src/compartido/lib/slugify.ts
@@ -1,0 +1,29 @@
+import { prisma } from '@/compartido/lib/prisma'
+
+function basicSlugify(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .substring(0, 100)
+}
+
+export async function generarSlugUnico(titulo: string, excludeId?: string): Promise<string> {
+  const baseSlug = basicSlugify(titulo)
+
+  const existing = await prisma.novedad.findFirst({
+    where: {
+      slug: baseSlug,
+      ...(excludeId && { NOT: { id: excludeId } }),
+    },
+  })
+
+  if (!existing) return baseSlug
+
+  const timestamp = Date.now().toString().slice(-6)
+  return `${baseSlug}-${timestamp}`
+}


### PR DESCRIPTION
## Summary

- CRUD completo de novedades para rol CONTENIDO + ADMIN
- Upload de imágenes a Supabase Storage (bucket `imagenes`, path `novedades/`)
- Slug auto-generado desde título con detección de colisiones
- Server component para listado, client component para formulario
- Modal de confirmación para delete
- Sidebar de contenido actualizado con "Novedades" como primer item
- Configuración de next/image para dominios de Supabase Storage

## Archivos nuevos

- `src/compartido/lib/slugify.ts` — utility de generación de slugs únicos
- `src/app/api/contenido/novedades/route.ts` — GET + POST
- `src/app/api/contenido/novedades/[id]/route.ts` — PATCH + DELETE
- `src/app/api/contenido/novedades/upload/route.ts` — POST (imagen)
- `src/app/(contenido)/contenido/novedades/page.tsx` — listado
- `src/app/(contenido)/contenido/novedades/loading.tsx` — skeleton
- `src/app/(contenido)/contenido/novedades/formulario-novedad.tsx` — form compartido
- `src/app/(contenido)/contenido/novedades/nueva/page.tsx` — crear
- `src/app/(contenido)/contenido/novedades/[id]/editar/page.tsx` — editar

## Archivos modificados

- `src/app/(contenido)/contenido-sidebar.tsx` — agregar Novedades
- `next.config.ts` — agregar Supabase Storage a remotePatterns

## Test plan

- [ ] Login como Sofía (CONTENIDO) → ver `/contenido/novedades`
- [ ] Crear novedad con imagen → aparece en listado
- [ ] Novedad creada aparece en landing público (`/`)
- [ ] Editar novedad → cambios reflejados
- [ ] Eliminar con modal → desaparece
- [ ] Login como ADMIN → mismo acceso
- [ ] Login como TALLER → redirect a /unauthorized

🤖 Generated with [Claude Code](https://claude.com/claude-code)