### PR TITLE
feat: X-06b mejoras copy y estructura landing (alineacion master V4)

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,12 @@
 ## 2026-05-17
 
 ### Gerardo Breard
+- **22:46** `8c19d3a` — feat(x-06b): HeaderPublic con pill ambiente piloto + nav reducido
+  - `src/app/(public)/layout.tsx`
+  - `src/app/page.tsx`
+  - `src/compartido/componentes/layout/header-public.tsx`
+  - `src/compartido/lib/content/institutional.ts`
+
 - **22:44** `f8a1300` — refactor(x-06b): centralizar logica showPilotPill en util
   - `src/app/(public)/layout.tsx`
   - `src/compartido/lib/env.ts`

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-17
 
 ### Gerardo Breard
+- **23:09** `e57309d` — feat(x-06b): disclaimer piloto antes del footer + limpiar carrusel
+  - `src/app/page.tsx`
+
 - **23:08** `16d2b49` — refactor(x-06b): eliminar secciones obsoletas (Para Talleres + Banner Sumate)
   - `src/app/page.tsx`
   - `src/compartido/lib/content/institutional.ts`

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-17
 
 ### Gerardo Breard
+- **22:55** `7e6492a` — feat(x-06b): nueva seccion 'Asi funciona' narrativa
+  - `src/app/page.tsx`
+
 - **22:47** `98bb682` — feat(x-06b): hero rediseñado con copy alineado a master V4
   - `src/app/page.tsx`
   - `src/compartido/lib/content/institutional.ts`

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,10 @@
 ## 2026-05-17
 
 ### Gerardo Breard
+- **23:08** `16d2b49` — refactor(x-06b): eliminar secciones obsoletas (Para Talleres + Banner Sumate)
+  - `src/app/page.tsx`
+  - `src/compartido/lib/content/institutional.ts`
+
 - **23:00** `2491b17` — feat(x-06b): impacto con stats reformuladas (metricas V4)
   - `src/app/page.tsx`
   - `src/compartido/lib/content/institutional.ts`

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-17
 
 ### Gerardo Breard
+- **23:10** `9964df2` — feat(x-06b): footer con links limpios (sin destinos 404)
+  - `src/compartido/lib/content/institutional.ts`
+
 - **23:09** `e57309d` — feat(x-06b): disclaimer piloto antes del footer + limpiar carrusel
   - `src/app/page.tsx`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,10 @@
 ## 2026-05-17
 
 ### Gerardo Breard
+- **23:00** `2491b17` — feat(x-06b): impacto con stats reformuladas (metricas V4)
+  - `src/app/page.tsx`
+  - `src/compartido/lib/content/institutional.ts`
+
 - **22:55** `7e6492a` — feat(x-06b): nueva seccion 'Asi funciona' narrativa
   - `src/app/page.tsx`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,10 @@
 ## 2026-05-17
 
 ### Gerardo Breard
+- **22:44** `f8a1300` — refactor(x-06b): centralizar logica showPilotPill en util
+  - `src/app/(public)/layout.tsx`
+  - `src/compartido/lib/env.ts`
+
 - **21:48** `cf0a354` — docs: oficializar TEMPLATE_SPEC_V4 con pre-flight y selectores criticos
   - `"docs/Dise\303\261o/TEMPLATE_SPEC_V4.md"`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,10 @@
 ## 2026-05-17
 
 ### Gerardo Breard
+- **22:47** `98bb682` — feat(x-06b): hero rediseñado con copy alineado a master V4
+  - `src/app/page.tsx`
+  - `src/compartido/lib/content/institutional.ts`
+
 - **22:46** `8c19d3a` — feat(x-06b): HeaderPublic con pill ambiente piloto + nav reducido
   - `src/app/(public)/layout.tsx`
   - `src/app/page.tsx`

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -2,14 +2,13 @@ import { auth } from '@/compartido/lib/auth'
 import { Header } from '@/compartido/componentes/layout'
 import { HeaderPublic } from '@/compartido/componentes/layout/header-public'
 import { Footer } from '@/compartido/componentes/layout/footer'
+import { getShowPilotPill } from '@/compartido/lib/env'
 
 export default async function PublicLayout({ children }: { children: React.ReactNode }) {
   const session = await auth()
   const role = (session?.user as { role?: string } | undefined)?.role || ''
 
-  const isMain = process.env.VERCEL_GIT_COMMIT_REF === 'main'
-  const isLocal = !process.env.VERCEL_ENV
-  const showPilotPill = !isMain && !isLocal
+  const showPilotPill = getShowPilotPill()
 
   // Logged in: Header global with tabs, sidebar, bell
   if (session?.user) {

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -33,7 +33,7 @@ export default async function PublicLayout({ children }: { children: React.React
   // Anonymous: HeaderPublic + Footer for marketing pages
   return (
     <div className="min-h-screen flex flex-col bg-white">
-      <HeaderPublic />
+      <HeaderPublic showPilotPill={showPilotPill} />
       <main className="flex-grow">
         {children}
       </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image'
 import { ArrowRight } from 'lucide-react'
 import { HeaderPublic } from '@/compartido/componentes/layout/header-public'
 import { Footer } from '@/compartido/componentes/layout/footer'
+import { getShowPilotPill } from '@/compartido/lib/env'
 import { CarruselNovedades, type CarruselItem } from '@/compartido/componentes/ui/carrusel-novedades'
 import { IconTaller, IconMarca, IconVerificado, IconTrazabilidad, IconSpark, IconCapacitacion, IconPedido } from '@/compartido/iconos'
 import { LANDING_COPY } from '@/compartido/lib/content/institutional'
@@ -74,7 +75,7 @@ export default async function Home() {
 
   return (
     <div className="min-h-screen flex flex-col bg-white">
-      <HeaderPublic />
+      <HeaderPublic showPilotPill={getShowPilotPill()} />
 
       {/* ═══ HERO ═══ */}
       <section className="relative bg-white overflow-hidden">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,11 +28,11 @@ export default async function Home() {
   }
 
   // Queries paralelas para stats + carrusel
-  const [talleresActivos, marcasRegistradas, cursosPublicados, pedidosEnProceso, novedades, colecciones] = await Promise.all([
+  const [vidrierasPublicadas, marcasExplorando, cursosPublicados, encuentrosGenerados, novedades, colecciones] = await Promise.all([
     prisma.taller.count({ where: { verificadoAfip: true } }),
     prisma.marca.count(),
     prisma.coleccion.count({ where: { activa: true } }),
-    prisma.pedido.count({ where: { estado: { in: ['EN_EJECUCION', 'PUBLICADO'] } } }),
+    prisma.pedido.count(),
     prisma.novedad.findMany({
       where: { publicado: true },
       orderBy: { fecha: 'desc' },
@@ -66,10 +66,6 @@ export default async function Home() {
       href: '/academia-publica',
     })),
   ]
-
-  const now = new Date()
-  const currentMonth = now.toLocaleDateString('es-AR', { month: 'long' })
-  const currentYear = now.getFullYear()
 
   const { hero, actores, impacto, carrusel, ctaBanner } = LANDING_COPY
 
@@ -232,7 +228,7 @@ export default async function Home() {
       </section>
 
       {/* ═══ IMPACTO ═══ */}
-      <section className="bg-ink-primary text-white py-24 relative overflow-hidden">
+      <section id="impacto" className="bg-ink-primary text-white py-24 relative overflow-hidden">
         <div className="absolute inset-0 pattern-weave opacity-50" />
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid lg:grid-cols-2 gap-12 items-center">
           <div>
@@ -242,21 +238,14 @@ export default async function Home() {
             <h2 className="font-serif font-bold text-4xl lg:text-5xl mb-6 leading-tight">
               {impacto.titleParts[0]} <span className="italic text-terra-300">{impacto.titleParts[1]}</span>
             </h2>
-            <p className="text-gray-300 leading-relaxed mb-6 max-w-md">{impacto.subtitle}</p>
-            <Link
-              href={impacto.cta.href}
-              className="inline-flex items-center gap-2 px-6 py-3 bg-terra-600 text-white font-overpass font-semibold rounded-lg hover:bg-terra-700 transition-colors"
-            >
-              {impacto.cta.label}
-              <ArrowRight className="w-4 h-4" />
-            </Link>
+            <p className="text-gray-300 leading-relaxed max-w-md">{impacto.subtitle}</p>
           </div>
           <div className="grid grid-cols-2 gap-px bg-white/10 rounded-2xl overflow-hidden">
             {[
-              { value: talleresActivos, label: 'Talleres activos verificados', icon: IconTaller, iconColor: 'text-pastel-blue' },
-              { value: marcasRegistradas, label: 'Marcas registradas', icon: IconMarca, iconColor: 'text-pastel-green' },
+              { value: vidrierasPublicadas, label: 'Vidrieras de talleres publicadas', icon: IconTaller, iconColor: 'text-pastel-blue' },
+              { value: marcasExplorando, label: 'Marcas explorando proveedores formales', icon: IconMarca, iconColor: 'text-pastel-green' },
               { value: cursosPublicados, label: 'Cursos publicados', icon: IconCapacitacion, iconColor: 'text-terra-300' },
-              { value: pedidosEnProceso, label: 'Pedidos en proceso', icon: IconPedido, iconColor: 'text-pastel-blue' },
+              { value: encuentrosGenerados, label: 'Encuentros generados', icon: IconPedido, iconColor: 'text-pastel-blue' },
             ].map(stat => (
               <div key={stat.label} className="bg-ink-primary p-8">
                 <stat.icon className={`w-6 h-6 ${stat.iconColor} mb-4`} />
@@ -267,7 +256,7 @@ export default async function Home() {
                   {stat.label}
                 </p>
                 <p className="text-[10px] text-gray-500 mt-1">
-                  Datos a {currentMonth} {currentYear}
+                  Datos a mayo 2026
                 </p>
               </div>
             ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import { HeaderPublic } from '@/compartido/componentes/layout/header-public'
 import { Footer } from '@/compartido/componentes/layout/footer'
 import { getShowPilotPill } from '@/compartido/lib/env'
 import { CarruselNovedades, type CarruselItem } from '@/compartido/componentes/ui/carrusel-novedades'
-import { IconTaller, IconMarca, IconVerificado, IconTrazabilidad, IconSpark, IconCapacitacion, IconPedido } from '@/compartido/iconos'
+import { IconTaller, IconMarca, IconVerificado, IconTrazabilidad, IconCapacitacion, IconPedido } from '@/compartido/iconos'
 import { LANDING_COPY } from '@/compartido/lib/content/institutional'
 
 export const dynamic = 'force-dynamic'
@@ -85,16 +85,10 @@ export default async function Home() {
 
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20 lg:py-28 grid lg:grid-cols-12 gap-10 items-center">
           <div className="lg:col-span-7">
-            <div className="inline-flex items-center gap-2 px-3 py-1.5 bg-terra-50 border border-terra-300/50 rounded-full mb-6">
-              <IconSpark className="w-3.5 h-3.5 text-terra-600" />
-              <span className="text-xs font-overpass font-bold uppercase tracking-widest text-terra-700">
-                {hero.badge}
-              </span>
-            </div>
             <h1 className="font-serif font-extrabold text-5xl lg:text-7xl text-ink-primary leading-[1.05] tracking-tight">
-              <span className="text-brand-blue">{hero.titleParts[0]}</span>
-              <br />
-              {hero.titleParts[1]} <span className="italic font-medium text-ink-secondary">{hero.titleParts[2]}</span>
+              {hero.titleParts[0]}<br />
+              {hero.titleParts[1]}<br />
+              <span className="italic font-medium text-ink-secondary">{hero.titleParts[2]}</span>
             </h1>
             <p className="text-ink-secondary text-lg mt-6 leading-relaxed max-w-xl">
               {hero.subtitle}
@@ -141,14 +135,6 @@ export default async function Home() {
               <p className="text-xs text-ink-secondary leading-snug">{hero.cardTrazabilidad.subtitle}</p>
             </div>
 
-            {/* Card flotante: stat */}
-            <div className="absolute -right-4 bottom-12 bg-white rounded-2xl shadow-card-hover p-4 max-w-[200px] border border-gray-100 hidden md:block">
-              <p className="font-serif font-bold text-3xl text-brand-blue leading-none">{talleresActivos}+</p>
-              <p className="text-xs text-ink-secondary mt-1 leading-snug">{hero.cardStat.label}</p>
-              <div className="h-1 w-full bg-gray-100 rounded-full mt-2 overflow-hidden">
-                <div className="h-full bg-terra-600 rounded-full" style={{ width: '33%' }} />
-              </div>
-            </div>
           </div>
         </div>
       </section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import { HeaderPublic } from '@/compartido/componentes/layout/header-public'
 import { Footer } from '@/compartido/componentes/layout/footer'
 import { getShowPilotPill } from '@/compartido/lib/env'
 import { CarruselNovedades, type CarruselItem } from '@/compartido/componentes/ui/carrusel-novedades'
-import { IconTaller, IconMarca, IconVerificado, IconTrazabilidad, IconCapacitacion, IconPedido } from '@/compartido/iconos'
+import { IconTaller, IconMarca, IconTrazabilidad, IconCapacitacion, IconPedido } from '@/compartido/iconos'
 import { LANDING_COPY } from '@/compartido/lib/content/institutional'
 
 export const dynamic = 'force-dynamic'
@@ -67,7 +67,7 @@ export default async function Home() {
     })),
   ]
 
-  const { hero, actores, impacto, carrusel, ctaBanner } = LANDING_COPY
+  const { hero, impacto, carrusel } = LANDING_COPY
 
   return (
     <div className="min-h-screen flex flex-col bg-white">
@@ -162,71 +162,6 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* ═══ PARA CADA ACTOR ═══ */}
-      <section className="bg-gray-50 py-24 relative">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-14">
-            <p className="text-xs uppercase tracking-widest font-overpass font-bold text-terra-600 mb-2">
-              {actores.eyebrow}
-            </p>
-            <h2 className="font-serif font-bold text-4xl lg:text-5xl text-ink-primary">
-              {actores.title}
-            </h2>
-            <p className="text-ink-secondary mt-3 max-w-2xl mx-auto">{actores.subtitle}</p>
-          </div>
-          <div className="grid md:grid-cols-2 gap-6 max-w-5xl mx-auto">
-            {/* Talleres */}
-            <div className="bg-white rounded-card shadow-card border border-gray-100 card-lift hover:shadow-card-hover overflow-hidden">
-              <div className="h-2 bg-brand-blue" />
-              <div className="p-8">
-                <div className="w-14 h-14 rounded-2xl bg-pastel-blue flex items-center justify-center mb-5">
-                  <IconTaller className="w-7 h-7 text-brand-blue" />
-                </div>
-                <h3 className="font-serif font-bold text-2xl mb-4">{actores.talleres.title}</h3>
-                <ul className="space-y-2.5 text-ink-secondary mb-6 text-sm">
-                  {actores.talleres.bullets.map(b => (
-                    <li key={b} className="flex items-start gap-2">
-                      <IconVerificado className="w-4 h-4 text-brand-blue flex-shrink-0 mt-0.5" />
-                      {b}
-                    </li>
-                  ))}
-                </ul>
-                <Link
-                  href={actores.talleres.cta.href}
-                  className="inline-flex items-center gap-1 text-brand-blue font-overpass font-semibold text-sm hover:gap-2 transition-all"
-                >
-                  {actores.talleres.cta.label} <ArrowRight className="w-4 h-4" />
-                </Link>
-              </div>
-            </div>
-            {/* Marcas */}
-            <div className="bg-white rounded-card shadow-card border border-gray-100 card-lift hover:shadow-card-hover overflow-hidden">
-              <div className="h-2 bg-green-700" />
-              <div className="p-8">
-                <div className="w-14 h-14 rounded-2xl bg-pastel-green flex items-center justify-center mb-5">
-                  <IconMarca className="w-7 h-7 text-green-700" />
-                </div>
-                <h3 className="font-serif font-bold text-2xl mb-4">{actores.marcas.title}</h3>
-                <ul className="space-y-2.5 text-ink-secondary mb-6 text-sm">
-                  {actores.marcas.bullets.map(b => (
-                    <li key={b} className="flex items-start gap-2">
-                      <IconVerificado className="w-4 h-4 text-green-700 flex-shrink-0 mt-0.5" />
-                      {b}
-                    </li>
-                  ))}
-                </ul>
-                <Link
-                  href={actores.marcas.cta.href}
-                  className="inline-flex items-center gap-1 text-green-700 font-overpass font-semibold text-sm hover:gap-2 transition-all"
-                >
-                  {actores.marcas.cta.label} <ArrowRight className="w-4 h-4" />
-                </Link>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
       {/* ═══ IMPACTO ═══ */}
       <section id="impacto" className="bg-ink-primary text-white py-24 relative overflow-hidden">
         <div className="absolute inset-0 pattern-weave opacity-50" />
@@ -291,36 +226,6 @@ export default async function Home() {
               className="inline-flex items-center gap-2 text-brand-blue font-overpass font-semibold hover:underline"
             >
               {carrusel.verTodas.label} <ArrowRight className="w-4 h-4" />
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      {/* ═══ BANNER CTA ═══ */}
-      <section className="bg-brand-blue relative overflow-hidden">
-        <div className="absolute inset-0 pattern-weave opacity-30" />
-        <div className="absolute -bottom-20 -right-20 w-72 h-72 rounded-full bg-terra-600 opacity-20" />
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 grid md:grid-cols-2 gap-6 items-center">
-          <div>
-            <h2 className="font-serif font-bold text-3xl lg:text-4xl text-white leading-tight">
-              {ctaBanner.titleParts[0]} <span className="italic text-terra-300">{ctaBanner.titleParts[1]}</span>
-            </h2>
-            <p className="text-blue-100 mt-3">{ctaBanner.subtitle}</p>
-          </div>
-          <div className="flex flex-wrap gap-3 md:justify-end">
-            <Link
-              href={ctaBanner.ctaTaller.href}
-              className="inline-flex items-center gap-2 px-6 py-3 bg-white text-brand-blue font-overpass font-semibold rounded-lg hover:bg-pastel-blue transition-colors"
-            >
-              <IconTaller className="w-4 h-4" />
-              {ctaBanner.ctaTaller.label}
-            </Link>
-            <Link
-              href={ctaBanner.ctaMarca.href}
-              className="inline-flex items-center gap-2 px-6 py-3 border border-white/40 text-white font-overpass font-semibold rounded-lg hover:bg-white/10 transition-colors"
-            >
-              <IconMarca className="w-4 h-4" />
-              {ctaBanner.ctaMarca.label}
             </Link>
           </div>
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -139,6 +139,33 @@ export default async function Home() {
         </div>
       </section>
 
+      {/* ═══ ASI FUNCIONA ═══ */}
+      <section id="como-funciona" className="bg-white py-24">
+        <div className="max-w-4xl mx-auto px-6 lg:px-8">
+          <div className="text-center mb-12">
+            <p className="text-xs uppercase tracking-widest font-overpass font-bold text-terra-600 mb-2">
+              Asi funciona
+            </p>
+            <h2 className="font-serif font-bold text-4xl lg:text-5xl text-ink-primary mb-4">
+              Acompañamos al sector textil en cada paso del recorrido.
+            </h2>
+          </div>
+          <div className="space-y-6 text-lg text-ink-secondary leading-relaxed">
+            <p>
+              Un taller textil se suma. Aprende con cursos gratuitos, arma su perfil
+              y muestra lo que sabe hacer.
+            </p>
+            <p>
+              Una marca de indumentaria lo descubre en el directorio. Conoce sus
+              capacidades, su trayectoria y su recorrido.
+            </p>
+            <p>
+              Se contactan directo y empiezan a trabajar juntos.
+            </p>
+          </div>
+        </div>
+      </section>
+
       {/* ═══ PARA CADA ACTOR ═══ */}
       <section className="bg-gray-50 py-24 relative">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -220,14 +220,18 @@ export default async function Home() {
             <p className="text-center text-ink-secondary py-8">Próximamente</p>
           )}
 
-          <div className="text-center mt-10">
-            <Link
-              href={carrusel.verTodas.href}
-              className="inline-flex items-center gap-2 text-brand-blue font-overpass font-semibold hover:underline"
-            >
-              {carrusel.verTodas.label} <ArrowRight className="w-4 h-4" />
-            </Link>
-          </div>
+        </div>
+      </section>
+
+      {/* ═══ DISCLAIMER PILOTO ═══ */}
+      <section className="bg-pastel-yellow border-t border-yellow-200/50 py-4">
+        <div className="max-w-4xl mx-auto px-6 lg:px-8 text-center">
+          <p className="text-xs text-ink-secondary">
+            <span className="font-overpass font-bold">Programa piloto en curso.</span>{' '}
+            Plataforma Digital Textil es una iniciativa de OIT Argentina y UNTREF
+            en fase de piloto, Conurbano Sur, mayo 2026. Los datos y funcionalidades
+            pueden evolucionar durante esta etapa.
+          </p>
         </div>
       </section>
 

--- a/src/compartido/componentes/layout/header-public.tsx
+++ b/src/compartido/componentes/layout/header-public.tsx
@@ -6,23 +6,35 @@ import {
   HEADER_PUBLIC_CTAS,
 } from '@/compartido/lib/content/institutional'
 
-export function HeaderPublic() {
+interface HeaderPublicProps {
+  showPilotPill?: boolean
+}
+
+export function HeaderPublic({ showPilotPill = false }: HeaderPublicProps) {
   return (
     <header className="sticky top-0 z-40 bg-white/95 backdrop-blur border-b border-gray-100">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
-          {/* Izquierda: logo + nombre */}
-          <Link href="/" className="flex items-center gap-3">
-            <LogoPDT variant="icon" size="md" />
-            <div className="flex flex-col leading-tight">
-              <span className="font-serif font-bold text-base text-ink-primary">
-                {INSTITUTIONAL.brandName}
+          {/* Izquierda: logo + nombre + pill condicional */}
+          <div className="flex items-center gap-3">
+            <Link href="/" className="flex items-center gap-3">
+              <LogoPDT variant="icon" size="md" />
+              <div className="flex flex-col leading-tight">
+                <span className="font-serif font-bold text-base text-ink-primary">
+                  {INSTITUTIONAL.brandName}
+                </span>
+                <span className="font-overpass font-bold text-[10px] text-terra-600 uppercase tracking-wider">
+                  {INSTITUTIONAL.brandSubtitle}
+                </span>
+              </div>
+            </Link>
+
+            {showPilotPill && (
+              <span className="hidden md:inline-flex items-center px-2 py-1 rounded-full bg-pastel-yellow text-yellow-900 text-[10px] font-overpass font-bold uppercase tracking-wider">
+                Ambiente piloto
               </span>
-              <span className="font-overpass font-bold text-[10px] text-terra-600 uppercase tracking-wider">
-                {INSTITUTIONAL.brandSubtitle}
-              </span>
-            </div>
-          </Link>
+            )}
+          </div>
 
           {/* Centro: nav (hidden en mobile) */}
           <nav className="hidden lg:flex items-center gap-6">

--- a/src/compartido/lib/content/institutional.ts
+++ b/src/compartido/lib/content/institutional.ts
@@ -63,31 +63,6 @@ export const LANDING_COPY = {
       subtitle: 'OIT y UNTREF respaldan tu recorrido.',
     },
   },
-  actores: {
-    eyebrow: 'DOS CAMINOS · UN ECOSISTEMA',
-    title: 'Para talleres y marcas del sector textil',
-    subtitle: 'El acceso institucional para organismos del Estado se gestiona por convenio con OIT y UNTREF.',
-    talleres: {
-      title: 'Talleres',
-      bullets: [
-        'Conseguí clientes formales',
-        'Accedé a certificación',
-        'Digitalizá tu producción',
-        'Capacitate y crecé de nivel',
-      ],
-      cta: { label: 'Quiero formalizarme', href: '/registro?rol=TALLER' },
-    },
-    marcas: {
-      title: 'Marcas',
-      bullets: [
-        'Encontrá proveedores verificados',
-        'Reducí riesgos legales',
-        'Trazabilidad completa',
-        'Cumplí con estándares ESG',
-      ],
-      cta: { label: 'Buscar proveedores', href: '/registro?rol=MARCA' },
-    },
-  },
   impacto: {
     eyebrow: 'NUESTRO IMPACTO',
     titleParts: ['Impulsamos un sector más', 'justo y transparente'],
@@ -96,14 +71,7 @@ export const LANDING_COPY = {
   carrusel: {
     eyebrow: 'ACADEMIA · SECTOR',
     title: 'Novedades y capacitaciones',
-    subtitle: 'Lo último de la academia y del sector textil argentino',
-    verTodas: { label: 'Ver todas las novedades y cursos', href: '/novedades' },
-  },
-  ctaBanner: {
-    titleParts: ['Sumate a la transformación del', 'sector textil'],
-    subtitle: 'Empezá hoy. Es gratis.',
-    ctaTaller: { label: 'Soy taller', href: '/registro?rol=TALLER' },
-    ctaMarca: { label: 'Soy marca', href: '/registro?rol=MARCA' },
+    subtitle: 'Lo ultimo de la academia y del sector textil argentino',
   },
 } as const
 

--- a/src/compartido/lib/content/institutional.ts
+++ b/src/compartido/lib/content/institutional.ts
@@ -53,18 +53,14 @@ export const TABS_BY_ROLE = {
 
 export const LANDING_COPY = {
   hero: {
-    badge: 'INICIATIVA DE OIT Y UNTREF',
-    titleParts: ['Formalizá,', 'conectá y trazá', 'la producción textil'],
-    subtitle: 'Construimos una industria textil transparente, confiable y sin trabajo informal. Para talleres, marcas y organismos del Estado.',
+    titleParts: ['Hacé crecer tu taller.', 'Conectá tu marca.', 'Empezá desde donde estés.'],
+    subtitle: 'Plataforma pública de OIT y UNTREF que acompaña a talleres y marcas del sector textil argentino. Capacitaciones gratuitas, perfil profesional y conexión directa entre quienes producen y quienes buscan.',
     ctaTaller: { label: 'Soy taller', href: '/registro?rol=TALLER' },
     ctaMarca: { label: 'Soy marca', href: '/registro?rol=MARCA' },
     imageAlt: 'Trabajadores en taller textil con máquinas de coser',
     cardTrazabilidad: {
-      title: 'Trazabilidad completa',
-      subtitle: 'Cada etapa del proceso registrada y verificable.',
-    },
-    cardStat: {
-      label: 'Talleres verificados en el piloto',
+      title: 'Acompañamiento institucional',
+      subtitle: 'OIT y UNTREF respaldan tu recorrido.',
     },
   },
   actores: {

--- a/src/compartido/lib/content/institutional.ts
+++ b/src/compartido/lib/content/institutional.ts
@@ -10,20 +10,15 @@ export const INSTITUTIONAL = {
 export const FOOTER_LINKS = {
   plataforma: [
     { label: '\u00bfC\u00f3mo funciona?', href: '/#como-funciona' },
-    { label: 'Para taller', href: '/taller-info' },
-    { label: 'Para marcas', href: '/marca-info' },
-    { label: 'Impacto', href: '/impacto' },
+    { label: 'Impacto', href: '/#impacto' },
   ],
   recursos: [
     { label: 'Centro de ayuda', href: '/ayuda' },
-    { label: 'Academia', href: '/academia-publica' },
-    { label: 'Novedades', href: '/novedades' },
-    { label: 'Contacto', href: '/contacto' },
+    { label: 'Contacto', href: 'mailto:soporte@plataformatextil.ar' },
   ],
   legal: [
     { label: 'T\u00e9rminos y condiciones', href: '/terminos' },
     { label: 'Pol\u00edtica de privacidad', href: '/privacidad' },
-    { label: 'Accesibilidad', href: '/accesibilidad' },
   ],
 } as const
 

--- a/src/compartido/lib/content/institutional.ts
+++ b/src/compartido/lib/content/institutional.ts
@@ -92,7 +92,6 @@ export const LANDING_COPY = {
     eyebrow: 'NUESTRO IMPACTO',
     titleParts: ['Impulsamos un sector más', 'justo y transparente'],
     subtitle: 'Trabajamos para reducir la informalidad, mejorar las condiciones laborales y generar oportunidades de desarrollo en talleres y marcas argentinas.',
-    cta: { label: 'Conocé nuestro impacto', href: '/impacto' },
   },
   carrusel: {
     eyebrow: 'ACADEMIA · SECTOR',

--- a/src/compartido/lib/content/institutional.ts
+++ b/src/compartido/lib/content/institutional.ts
@@ -113,11 +113,8 @@ export const LANDING_COPY = {
 } as const
 
 export const HEADER_PUBLIC_NAV = [
-  { label: '¿Cómo funciona?', href: '/taller-info' },
-  { label: 'Para taller', href: '/taller-info' },
-  { label: 'Para marcas', href: '/marca-info' },
-  { label: 'Impacto', href: '/impacto' },
-  { label: 'Recursos', href: '/recursos' },
+  { label: '¿Cómo funciona?', href: '#como-funciona' },
+  { label: 'Impacto', href: '#impacto' },
 ] as const
 
 export const HEADER_PUBLIC_CTAS = {

--- a/src/compartido/lib/env.ts
+++ b/src/compartido/lib/env.ts
@@ -1,0 +1,11 @@
+/**
+ * Devuelve true si debe mostrarse la pill "Ambiente piloto".
+ * - false en produccion (main)
+ * - false en local (sin VERCEL_ENV)
+ * - true en preview/dev (otros branches)
+ */
+export function getShowPilotPill(): boolean {
+  const isMain = process.env.VERCEL_GIT_COMMIT_REF === 'main'
+  const isLocal = !process.env.VERCEL_ENV
+  return !isMain && !isLocal
+}


### PR DESCRIPTION
## Summary

Implementa X-06b consolidado: mejoras de copy y estructura del landing publico, alineando con decisiones del master V4.

- Hero rediseñado: H1 institucional, eliminada pill badge y card flotante "10+ verificados"
- Nueva seccion "Asi funciona" narrativa (3 parrafos)
- 4 stats reformuladas: Vidrieras, Marcas explorando, Cursos, Encuentros generados
- Eliminadas secciones obsoletas: "Para Talleres/Marcas" y Banner "Sumate"
- Disclaimer "Programa piloto en curso" antes del footer
- HeaderPublic con pill "Ambiente piloto" condicional (dev/preview)
- Nav reducido a 2 anchors internos (#como-funciona, #impacto)
- Footer limpio sin links a destinos 404
- showPilotPill centralizado en `src/compartido/lib/env.ts`

## Origen

- Spec G-XX preparado por Sergio (alineacion con master V4)
- 3 decisiones de Gerardo sobre conflictos
- 5 decisiones post-pre-flight (D1-D5)

## Pre-flight results

- 0 tests E2E afectados
- Schema validado (no existe ContactoMarcaTaller → fallback a Pedido)
- HeaderPublic refactorizado para aceptar showPilotPill
- 0 conflictos de anchors

## Test plan

- [ ] Landing sin login: verificar 7 secciones en orden correcto
- [ ] Pill "Ambiente piloto" visible en preview, NO en produccion
- [ ] Click "#como-funciona" scrollea a seccion correcta
- [ ] Click "#impacto" scrollea a seccion correcta
- [ ] NO existe seccion "Para Talleres / Para Marcas"
- [ ] NO existe banner "Sumate a la transformacion"
- [ ] Disclaimer piloto visible antes del footer
- [ ] Footer: solo links funcionales (ayuda, terminos, privacidad, mailto)
- [ ] Stats muestran datos reales de la DB
- [ ] CI verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)