### PR TITLE
fix(tests): CI verde - smoke + 3 tests intermitentes

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,12 @@
 # Daily Log
 
+## 2026-05-18
+
+### Gerardo Breard
+- **13:35** `caf3b6d` — fix(tests): eliminar waitUntil 'load' en smoke admin/logs
+  - `tests/e2e/smoke.spec.ts`
+
+
 ## 2026-05-17
 
 ### Gerardo Breard

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-18
 
 ### Gerardo Breard
+- **13:35** `8a1759f` — fix(tests): beforeAll para restaurar config imagenes-portfolio
+  - `tests/e2e/file-validation.spec.ts`
+
 - **13:35** `caf3b6d` — fix(tests): eliminar waitUntil 'load' en smoke admin/logs
   - `tests/e2e/smoke.spec.ts`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-18
 
 ### Gerardo Breard
+- **13:43** `f7cbcaf` — fix(tests): usar getByRole heading en exportes-estado
+  - `tests/e2e/exportes-estado.spec.ts`
+
 - **13:43** `574a35b` — fix(tests): scope selector a 'header nav' en demanda-insatisfecha
   - `tests/e2e/demanda-insatisfecha.spec.ts`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-18
 
 ### Gerardo Breard
+- **13:43** `574a35b` — fix(tests): scope selector a 'header nav' en demanda-insatisfecha
+  - `tests/e2e/demanda-insatisfecha.spec.ts`
+
 - **13:35** `8a1759f` — fix(tests): beforeAll para restaurar config imagenes-portfolio
   - `tests/e2e/file-validation.spec.ts`
 

--- a/tests/e2e/demanda-insatisfecha.spec.ts
+++ b/tests/e2e/demanda-insatisfecha.spec.ts
@@ -44,7 +44,7 @@ test.describe('F-05 Dashboard de demanda insatisfecha', () => {
     await loginEstado(page)
 
     await page.goto('/estado')
-    await expect(page.locator('header').getByText('Demanda insatisfecha')).toBeVisible({ timeout: 30000 })
+    await expect(page.locator('header nav').getByText('Demanda insatisfecha')).toBeVisible({ timeout: 30000 })
   })
 
   test('Boton Exportar CSV esta visible', async ({ page }) => {

--- a/tests/e2e/exportes-estado.spec.ts
+++ b/tests/e2e/exportes-estado.spec.ts
@@ -21,7 +21,7 @@ test.describe('F-04 Exportes del Estado', () => {
     // Verificar que hay tarjetas de reportes
     await expect(page.getByRole('heading', { name: 'Talleres', exact: true })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Marcas', exact: true })).toBeVisible()
-    await expect(page.getByText('Informe mensual completo')).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Informe mensual completo' })).toBeVisible()
   })
 
   test('Botones CSV y Excel visibles en cada tarjeta', async ({ page }) => {

--- a/tests/e2e/file-validation.spec.ts
+++ b/tests/e2e/file-validation.spec.ts
@@ -18,6 +18,23 @@ function exeBuffer(): Buffer {
 test.describe.configure({ mode: 'serial' })
 
 test.describe('File validation — S-03', () => {
+  // Restaurar config imagenes-portfolio al inicio del run.
+  // Si un run anterior fallo/timeout antes de que afterEach completara,
+  // la config puede quedar desactivada en la DB compartida.
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage()
+    await loginAs(page, 'admin')
+    const res = await page.request.get('/api/admin/configuracion-upload')
+    if (res.ok()) {
+      const configs = await res.json()
+      const pc = configs.find((c: { contexto: string }) => c.contexto === 'imagenes-portfolio')
+      if (pc && !pc.activo) {
+        await page.request.put(`/api/admin/configuracion-upload/${pc.id}`, { data: { activo: true } })
+      }
+    }
+    await page.close()
+  })
+
   // Garantizar que la config imagenes-portfolio quede activa despues de
   // cada test, incluso si el test aborta por timeout. Esto previene que
   // el test :159 (que desactiva la config) deje la DB en estado sucio.

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -12,7 +12,7 @@ test.describe('Smoke test — setup basico funciona', () => {
     await page.waitForLoadState('load')
 
     // Navegar a /admin/logs (implementado en S-04)
-    await page.goto('/admin/logs', { waitUntil: 'load' })
+    await page.goto('/admin/logs')
 
     // Verificar que la pagina de logs carga con la UI mejorada de S-04
     await expect(page.getByRole('heading', { name: 'Logs de Actividad' })).toBeVisible()


### PR DESCRIPTION
## Summary

Investigacion del 18-mayo-2026: CI develop tenia 55% tasa de falla (11/20 ultimos runs).
Todas las fallas eran tests fragiles, no regresiones reales.

4 fixes aplicados:

1. **smoke admin/logs** (11/11 fallos): eliminar `waitUntil: 'load'` que causa `ERR_ABORTED` por doble navegacion
2. **file-validation JPEG** (6/11 fallos): `beforeAll` restaura config `imagenes-portfolio` al inicio de cada run (state leak cross-run)
3. **demanda-insatisfecha tab** (4/11 fallos): locator `header nav` en vez de `header` (strict mode violation por 2 elements)
4. **exportes-estado informe** (2/11 fallos): `getByRole('heading')` en vez de `getByText` (substring matching ambiguo)

Esperado tras estos fixes: <5% tasa de falla.

## Test plan

- [ ] CI E2E pasa verde en este PR
- [ ] Merge a develop y CI verde en develop
- [ ] Verificar que los 4 tests especificos pasan (smoke, file-validation, demanda-insatisfecha, exportes-estado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)