### PR TITLE
feat: X-07a paleta V4 a dashboards (critico)

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,29 @@
 ## 2026-05-18
 
 ### Gerardo Breard
+- **16:22** `60192c1` — feat(x-07a): paleta V4 en 21 paginas con clases blue inline
+  - `src/app/(admin)/admin/auditorias/page.tsx`
+  - `src/app/(admin)/admin/notificaciones/page.tsx`
+  - `src/app/(admin)/admin/observaciones/page.tsx`
+  - `src/app/(admin)/admin/onboarding/page.tsx`
+  - `src/app/(admin)/admin/talleres/[id]/page.tsx`
+  - `src/app/(admin)/layout.tsx`
+  - `src/app/(contenido)/contenido/notificaciones/page.tsx`
+  - `src/app/(contenido)/contenido/novedades/formulario-novedad.tsx`
+  - `src/app/(contenido)/contenido/novedades/page.tsx`
+  - `src/app/(contenido)/layout.tsx`
+  - `src/app/(estado)/estado/exportar/page.tsx`
+  - `src/app/(estado)/estado/page.tsx`
+  - `src/app/(estado)/estado/talleres/[id]/page.tsx`
+  - `src/app/(marca)/marca/directorio/[id]/page.tsx`
+  - `src/app/(marca)/marca/page.tsx`
+  - `src/app/(marca)/marca/pedidos/[id]/page.tsx`
+  - `src/app/(taller)/taller/page.tsx`
+  - `src/app/(taller)/taller/pedidos/[id]/page.tsx`
+  - `src/app/(taller)/taller/pedidos/page.tsx`
+  - `src/app/(taller)/taller/perfil/completar/page.tsx`
+  - `src/app/(taller)/taller/perfil/page.tsx`
+
 - **16:14** `7d58d2b` — feat(x-07a): paleta V4 en componentes layout y secundarios
   - `src/compartido/componentes/activity-timeline.tsx`
   - `src/compartido/componentes/badge-arca.tsx`

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,16 @@
 ## 2026-05-18
 
 ### Gerardo Breard
+- **16:14** `7d58d2b` — feat(x-07a): paleta V4 en componentes layout y secundarios
+  - `src/compartido/componentes/activity-timeline.tsx`
+  - `src/compartido/componentes/badge-arca.tsx`
+  - `src/compartido/componentes/error-page.tsx`
+  - `src/compartido/componentes/feedback-widget.tsx`
+  - `src/compartido/componentes/layout/notificaciones-bell.tsx`
+  - `src/compartido/componentes/layout/user-sidebar.tsx`
+  - `src/compartido/componentes/ui/progress-ring.tsx`
+  - `src/compartido/componentes/ui/section-error.tsx`
+
 - **15:58** `8cccda2` — feat(x-07a): paleta V4 en componentes UI base — toast.tsx
   - `src/compartido/componentes/ui/toast.tsx`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,12 @@
 # Daily Log
 
+## 2026-05-19
+
+### Gerardo Breard
+- **11:24** `364640e` — fix(x-07a): refactor /taller dashboard a V4 (paridad con /marca)
+  - `src/app/(taller)/taller/page.tsx`
+
+
 ## 2026-05-18
 
 ### Gerardo Breard

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-18
 
 ### Gerardo Breard
+- **15:58** `8cccda2` — feat(x-07a): paleta V4 en componentes UI base — toast.tsx
+  - `src/compartido/componentes/ui/toast.tsx`
+
 - **14:34** `971e673` — docs: lecciones de investigacion CI flaky (18-mayo-2026)
   - `KNOWN_ISSUES.md`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,71 @@
 ## 2026-05-18
 
 ### Gerardo Breard
+- **16:34** `8dcf0b0` — feat(x-07a): font-serif en titulares H1/H2 de dashboards
+  - `src/app/(admin)/admin/auditorias/[id]/informe-client.tsx`
+  - `src/app/(admin)/admin/auditorias/[id]/page.tsx`
+  - `src/app/(admin)/admin/auditorias/page.tsx`
+  - `src/app/(admin)/admin/certificados/page.tsx`
+  - `src/app/(admin)/admin/colecciones/[id]/page.tsx`
+  - `src/app/(admin)/admin/colecciones/[id]/videos/page.tsx`
+  - `src/app/(admin)/admin/colecciones/nueva/page.tsx`
+  - `src/app/(admin)/admin/colecciones/page.tsx`
+  - `src/app/(admin)/admin/configuracion/archivos/page.tsx`
+  - `src/app/(admin)/admin/configuracion/page.tsx`
+  - `src/app/(admin)/admin/dashboard/page.tsx`
+  - `src/app/(admin)/admin/evaluaciones/page.tsx`
+  - `src/app/(admin)/admin/feedback/page.tsx`
+  - `src/app/(admin)/admin/integraciones/email/page.tsx`
+  - `src/app/(admin)/admin/integraciones/llm/page.tsx`
+  - `src/app/(admin)/admin/integraciones/page.tsx`
+  - `src/app/(admin)/admin/logs/page.tsx`
+  - `src/app/(admin)/admin/marcas/[id]/page.tsx`
+  - `src/app/(admin)/admin/marcas/page.tsx`
+  - `src/app/(admin)/admin/notificaciones/page.tsx`
+  - `src/app/(admin)/admin/observaciones/[id]/editar/page.tsx`
+  - `src/app/(admin)/admin/observaciones/nueva/page.tsx`
+  - `src/app/(admin)/admin/observaciones/page.tsx`
+  - `src/app/(admin)/admin/onboarding/page.tsx`
+  - `src/app/(admin)/admin/pedidos/page.tsx`
+  - `src/app/(admin)/admin/procesos/page.tsx`
+  - `src/app/(admin)/admin/reportes/page.tsx`
+  - `src/app/(admin)/admin/talleres/[id]/page.tsx`
+  - `src/app/(admin)/admin/talleres/page.tsx`
+  - `src/app/(admin)/admin/usuarios/page.tsx`
+  - `src/app/(contenido)/contenido/colecciones/page.tsx`
+  - `src/app/(contenido)/contenido/evaluaciones/page.tsx`
+  - `src/app/(contenido)/contenido/notificaciones/page.tsx`
+  - `src/app/(contenido)/contenido/novedades/[id]/editar/page.tsx`
+  - `src/app/(contenido)/contenido/novedades/nueva/page.tsx`
+  - `src/app/(contenido)/contenido/novedades/page.tsx`
+  - `src/app/(estado)/estado/auditorias/page.tsx`
+  - `src/app/(estado)/estado/configuracion-niveles/page.tsx`
+  - `src/app/(estado)/estado/demanda-insatisfecha/page.tsx`
+  - `src/app/(estado)/estado/documentos/page.tsx`
+  - `src/app/(estado)/estado/exportar/page.tsx`
+  - `src/app/(estado)/estado/page.tsx`
+  - `src/app/(estado)/estado/sector/page.tsx`
+  - `src/app/(estado)/estado/talleres/[id]/page.tsx`
+  - `src/app/(estado)/estado/talleres/page.tsx`
+  - `src/app/(marca)/marca/directorio/[id]/page.tsx`
+  - `src/app/(marca)/marca/directorio/page.tsx`
+  - `src/app/(marca)/marca/page.tsx`
+  - `src/app/(marca)/marca/pedidos/[id]/page.tsx`
+  - `src/app/(marca)/marca/pedidos/nuevo/nuevo-pedido-form.tsx`
+  - `src/app/(marca)/marca/pedidos/page.tsx`
+  - `src/app/(marca)/marca/perfil/page.tsx`
+  - `src/app/(taller)/taller/aprender/[id]/page.tsx`
+  - `src/app/(taller)/taller/aprender/page.tsx`
+  - `src/app/(taller)/taller/formalizacion/page.tsx`
+  - `src/app/(taller)/taller/page.tsx`
+  - `src/app/(taller)/taller/pedidos/[id]/page.tsx`
+  - `src/app/(taller)/taller/pedidos/disponibles/[id]/page.tsx`
+  - `src/app/(taller)/taller/pedidos/disponibles/page.tsx`
+  - `src/app/(taller)/taller/pedidos/page.tsx`
+  - `src/app/(taller)/taller/perfil/completar/page.tsx`
+  - `src/app/(taller)/taller/perfil/editar/editar-form.tsx`
+  - `src/app/(taller)/taller/perfil/page.tsx`
+
 - **16:22** `60192c1` — feat(x-07a): paleta V4 en 21 paginas con clases blue inline
   - `src/app/(admin)/admin/auditorias/page.tsx`
   - `src/app/(admin)/admin/notificaciones/page.tsx`

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-19
 
 ### Gerardo Breard
+- **16:10** `21d454c` — Merge remote-tracking branch 'origin/develop' into feature/v4-x-07a-paleta-dashboards-critico
+
+
 - **11:32** `f05047c` — fix(x-07a): consistencia H1 ink-primary + H2 font-serif
   - `src/app/(admin)/admin/auditorias/[id]/page.tsx`
   - `src/app/(admin)/admin/auditorias/page.tsx`

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,79 @@
 ## 2026-05-19
 
 ### Gerardo Breard
+- **11:32** `f05047c` — fix(x-07a): consistencia H1 ink-primary + H2 font-serif
+  - `src/app/(admin)/admin/auditorias/[id]/page.tsx`
+  - `src/app/(admin)/admin/auditorias/page.tsx`
+  - `src/app/(admin)/admin/certificados/page.tsx`
+  - `src/app/(admin)/admin/colecciones/[id]/page.tsx`
+  - `src/app/(admin)/admin/colecciones/[id]/videos/page.tsx`
+  - `src/app/(admin)/admin/colecciones/nueva/page.tsx`
+  - `src/app/(admin)/admin/colecciones/page.tsx`
+  - `src/app/(admin)/admin/configuracion/archivos/page.tsx`
+  - `src/app/(admin)/admin/configuracion/page.tsx`
+  - `src/app/(admin)/admin/dashboard/page.tsx`
+  - `src/app/(admin)/admin/evaluaciones/page.tsx`
+  - `src/app/(admin)/admin/feedback/page.tsx`
+  - `src/app/(admin)/admin/integraciones/email/page.tsx`
+  - `src/app/(admin)/admin/integraciones/llm/page.tsx`
+  - `src/app/(admin)/admin/integraciones/page.tsx`
+  - `src/app/(admin)/admin/logs/page.tsx`
+  - `src/app/(admin)/admin/marcas/[id]/page.tsx`
+  - `src/app/(admin)/admin/marcas/page.tsx`
+  - `src/app/(admin)/admin/notificaciones/page.tsx`
+  - `src/app/(admin)/admin/observaciones/[id]/editar/page.tsx`
+  - `src/app/(admin)/admin/observaciones/nueva/page.tsx`
+  - `src/app/(admin)/admin/observaciones/page.tsx`
+  - `src/app/(admin)/admin/onboarding/page.tsx`
+  - `src/app/(admin)/admin/pedidos/page.tsx`
+  - `src/app/(admin)/admin/procesos/page.tsx`
+  - `src/app/(admin)/admin/reportes/page.tsx`
+  - `src/app/(admin)/admin/talleres/[id]/page.tsx`
+  - `src/app/(admin)/admin/talleres/page.tsx`
+  - `src/app/(admin)/admin/usuarios/page.tsx`
+  - `src/app/(auth)/acceso-rapido/page.tsx`
+  - `src/app/(auth)/layout.tsx`
+  - `src/app/(auth)/login/page.tsx`
+  - `src/app/(auth)/mi-cuenta/page.tsx`
+  - `src/app/(auth)/olvide-contrasena/page.tsx`
+  - `src/app/(auth)/registro/completar/page.tsx`
+  - `src/app/(auth)/registro/page.tsx`
+  - `src/app/(auth)/restablecer/[token]/page.tsx`
+  - `src/app/(contenido)/contenido/colecciones/page.tsx`
+  - `src/app/(contenido)/contenido/evaluaciones/page.tsx`
+  - `src/app/(contenido)/contenido/notificaciones/page.tsx`
+  - `src/app/(contenido)/contenido/novedades/[id]/editar/page.tsx`
+  - `src/app/(contenido)/contenido/novedades/nueva/page.tsx`
+  - `src/app/(contenido)/contenido/novedades/page.tsx`
+  - `src/app/(estado)/estado/auditorias/page.tsx`
+  - `src/app/(estado)/estado/configuracion-niveles/page.tsx`
+  - `src/app/(estado)/estado/demanda-insatisfecha/page.tsx`
+  - `src/app/(estado)/estado/documentos/page.tsx`
+  - `src/app/(estado)/estado/exportar/page.tsx`
+  - `src/app/(estado)/estado/page.tsx`
+  - `src/app/(estado)/estado/sector/page.tsx`
+  - `src/app/(estado)/estado/talleres/[id]/page.tsx`
+  - `src/app/(estado)/estado/talleres/page.tsx`
+  - `src/app/(marca)/marca/directorio/[id]/page.tsx`
+  - `src/app/(marca)/marca/directorio/page.tsx`
+  - `src/app/(marca)/marca/page.tsx`
+  - `src/app/(marca)/marca/pedidos/[id]/page.tsx`
+  - `src/app/(marca)/marca/pedidos/nuevo/nuevo-pedido-form.tsx`
+  - `src/app/(marca)/marca/pedidos/page.tsx`
+  - `src/app/(marca)/marca/perfil/page.tsx`
+  - `src/app/(taller)/taller/aprender/[id]/page.tsx`
+  - `src/app/(taller)/taller/aprender/page.tsx`
+  - `src/app/(taller)/taller/formalizacion/page.tsx`
+  - `src/app/(taller)/taller/page.tsx`
+  - `src/app/(taller)/taller/pedidos/[id]/page.tsx`
+  - `src/app/(taller)/taller/pedidos/disponibles/[id]/page.tsx`
+  - `src/app/(taller)/taller/pedidos/disponibles/page.tsx`
+  - `src/app/(taller)/taller/pedidos/page.tsx`
+  - `src/app/(taller)/taller/perfil/completar/page.tsx`
+  - `src/app/(taller)/taller/perfil/editar/editar-form.tsx`
+  - `src/app/(taller)/taller/perfil/page.tsx`
+  - `src/app/unauthorized/page.tsx`
+
 - **11:24** `364640e` — fix(x-07a): refactor /taller dashboard a V4 (paridad con /marca)
   - `src/app/(taller)/taller/page.tsx`
 

--- a/src/app/(admin)/admin/auditorias/[id]/informe-client.tsx
+++ b/src/app/(admin)/admin/auditorias/[id]/informe-client.tsx
@@ -132,7 +132,7 @@ export function AuditoriaInformeClient({
 
   return (
     <div className="bg-white rounded-xl border border-gray-100 p-6 space-y-4">
-      <h2 className="font-overpass font-bold text-gray-800">Informe de auditoria</h2>
+      <h2 className="font-serif font-bold text-gray-800">Informe de auditoria</h2>
 
       <div>
         <label className="text-sm font-medium text-gray-700">Estado</label>

--- a/src/app/(admin)/admin/auditorias/[id]/page.tsx
+++ b/src/app/(admin)/admin/auditorias/[id]/page.tsx
@@ -34,7 +34,7 @@ export default async function AuditoriaDetallePage({
       ]} />
 
       <div>
-        <h1 className="text-3xl font-bold font-overpass text-brand-blue">
+        <h1 className="text-3xl font-bold font-serif text-brand-blue">
           Auditoria — {auditoria.taller.nombre}
         </h1>
         <p className="text-gray-500 mt-1">
@@ -45,7 +45,7 @@ export default async function AuditoriaDetallePage({
       </div>
 
       <div className="bg-white rounded-xl border border-gray-100 p-6">
-        <h2 className="font-overpass font-bold text-gray-800 mb-3">Taller auditado</h2>
+        <h2 className="font-serif font-bold text-gray-800 mb-3">Taller auditado</h2>
         <div className="grid grid-cols-2 gap-3 text-sm">
           <div><span className="text-gray-500">Nombre:</span> <span className="font-medium">{auditoria.taller.nombre}</span></div>
           <div><span className="text-gray-500">CUIT:</span> <span className="font-medium">{auditoria.taller.cuit}</span></div>

--- a/src/app/(admin)/admin/auditorias/[id]/page.tsx
+++ b/src/app/(admin)/admin/auditorias/[id]/page.tsx
@@ -34,7 +34,7 @@ export default async function AuditoriaDetallePage({
       ]} />
 
       <div>
-        <h1 className="text-3xl font-bold font-serif text-brand-blue">
+        <h1 className="text-3xl font-bold font-serif text-ink-primary">
           Auditoria — {auditoria.taller.nombre}
         </h1>
         <p className="text-gray-500 mt-1">

--- a/src/app/(admin)/admin/auditorias/page.tsx
+++ b/src/app/(admin)/admin/auditorias/page.tsx
@@ -18,7 +18,7 @@ const tipoLabels: Record<string, string> = {
 }
 
 const estadoConfig: Record<string, { label: string; bg: string; text: string }> = {
-  PROGRAMADA: { label: 'Programada', bg: 'bg-blue-100', text: 'text-blue-700' },
+  PROGRAMADA: { label: 'Programada', bg: 'bg-pastel-blue', text: 'text-brand-blue-dark' },
   EN_CURSO: { label: 'En curso', bg: 'bg-yellow-100', text: 'text-yellow-700' },
   COMPLETADA: { label: 'Completada', bg: 'bg-green-100', text: 'text-green-700' },
   CANCELADA: { label: 'Cancelada', bg: 'bg-gray-100', text: 'text-gray-500' },
@@ -69,7 +69,7 @@ async function AuditoriasContent() {
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
         <div className="bg-white rounded-xl shadow-sm p-5 border border-gray-100">
           <div className="flex items-center gap-3">
-            <Calendar className="w-5 h-5 text-blue-600" />
+            <Calendar className="w-5 h-5 text-brand-blue" />
             <div>
               <p className="text-2xl font-bold text-gray-800">{programadas}</p>
               <p className="text-xs text-gray-500">Programadas</p>
@@ -153,7 +153,7 @@ async function AuditoriasContent() {
                   </div>
                   <Link
                     href={`/admin/auditorias/${a.id}`}
-                    className="text-xs font-semibold text-brand-blue bg-blue-50 px-3 py-1.5 rounded-lg hover:bg-blue-100 transition-colors"
+                    className="text-xs font-semibold text-brand-blue bg-pastel-blue px-3 py-1.5 rounded-lg hover:bg-pastel-blue transition-colors"
                   >
                     Cargar informe
                   </Link>

--- a/src/app/(admin)/admin/auditorias/page.tsx
+++ b/src/app/(admin)/admin/auditorias/page.tsx
@@ -59,7 +59,7 @@ async function AuditoriasContent() {
     <div className="max-w-4xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Auditorias</h1>
+          <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Auditorias</h1>
           <p className="text-gray-500 text-sm">Programacion y seguimiento de auditorias presenciales</p>
         </div>
         <AuditoriasClient talleres={talleres} />
@@ -97,7 +97,7 @@ async function AuditoriasContent() {
       </div>
 
       {/* Proximas auditorias */}
-      <h2 className="font-overpass font-bold text-lg text-brand-blue mb-3">Proximas Auditorias</h2>
+      <h2 className="font-serif font-bold text-lg text-brand-blue mb-3">Proximas Auditorias</h2>
       {proximas.length === 0 ? (
         <div className="mb-6">
           <EmptyState
@@ -135,7 +135,7 @@ async function AuditoriasContent() {
       {/* Pendientes de informe */}
       {pendientesInforme.length > 0 && (
         <>
-          <h2 className="font-overpass font-bold text-lg text-brand-blue mb-3">Pendientes de Informe</h2>
+          <h2 className="font-serif font-bold text-lg text-brand-blue mb-3">Pendientes de Informe</h2>
           <div className="space-y-3 mb-6">
             {pendientesInforme.map(a => (
               <div key={a.id} className="bg-white rounded-xl shadow-sm p-4 border border-gray-100 border-l-4 border-l-yellow-400">
@@ -167,7 +167,7 @@ async function AuditoriasContent() {
       {/* Historial */}
       {historial.length > 0 && (
         <>
-          <h2 className="font-overpass font-bold text-lg text-brand-blue mb-3">Historial</h2>
+          <h2 className="font-serif font-bold text-lg text-brand-blue mb-3">Historial</h2>
           <div className="bg-white rounded-xl shadow-sm border border-gray-100 divide-y divide-gray-100">
             {historial.map(a => (
               <div key={a.id} className="px-5 py-3 flex items-center justify-between">

--- a/src/app/(admin)/admin/auditorias/page.tsx
+++ b/src/app/(admin)/admin/auditorias/page.tsx
@@ -59,7 +59,7 @@ async function AuditoriasContent() {
     <div className="max-w-4xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Auditorias</h1>
+          <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Auditorias</h1>
           <p className="text-gray-500 text-sm">Programacion y seguimiento de auditorias presenciales</p>
         </div>
         <AuditoriasClient talleres={talleres} />

--- a/src/app/(admin)/admin/certificados/page.tsx
+++ b/src/app/(admin)/admin/certificados/page.tsx
@@ -85,7 +85,7 @@ export default function AdminCertificadosPage() {
 
   return (
     <div className="max-w-5xl mx-auto py-6 px-4">
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Certificados Emitidos</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Certificados Emitidos</h1>
       <p className="text-gray-500 text-sm mb-6">Control de certificados de la plataforma</p>
 
       <div className="grid grid-cols-2 gap-4 mb-6">

--- a/src/app/(admin)/admin/certificados/page.tsx
+++ b/src/app/(admin)/admin/certificados/page.tsx
@@ -85,7 +85,7 @@ export default function AdminCertificadosPage() {
 
   return (
     <div className="max-w-5xl mx-auto py-6 px-4">
-      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Certificados Emitidos</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Certificados Emitidos</h1>
       <p className="text-gray-500 text-sm mb-6">Control de certificados de la plataforma</p>
 
       <div className="grid grid-cols-2 gap-4 mb-6">

--- a/src/app/(admin)/admin/colecciones/[id]/page.tsx
+++ b/src/app/(admin)/admin/colecciones/[id]/page.tsx
@@ -115,7 +115,7 @@ export default function AdminEditarColeccionPage() {
       ]} />
 
       <div className="flex items-center justify-between mb-6 mt-4">
-        <h1 className="font-serif font-bold text-2xl text-brand-blue">Editar Colección</h1>
+        <h1 className="font-serif font-bold text-2xl text-ink-primary">Editar Colección</h1>
         <Badge variant={activa ? 'success' : 'default'}>{activa ? 'Publicada' : 'Borrador'}</Badge>
       </div>
 

--- a/src/app/(admin)/admin/colecciones/[id]/page.tsx
+++ b/src/app/(admin)/admin/colecciones/[id]/page.tsx
@@ -115,7 +115,7 @@ export default function AdminEditarColeccionPage() {
       ]} />
 
       <div className="flex items-center justify-between mb-6 mt-4">
-        <h1 className="font-overpass font-bold text-2xl text-brand-blue">Editar Colección</h1>
+        <h1 className="font-serif font-bold text-2xl text-brand-blue">Editar Colección</h1>
         <Badge variant={activa ? 'success' : 'default'}>{activa ? 'Publicada' : 'Borrador'}</Badge>
       </div>
 
@@ -127,7 +127,7 @@ export default function AdminEditarColeccionPage() {
       )}
 
       <Card className="mb-6">
-        <h2 className="font-overpass font-bold text-brand-blue mb-4">Información Básica</h2>
+        <h2 className="font-serif font-bold text-brand-blue mb-4">Información Básica</h2>
         <div className="space-y-4">
           <Input label="Título de la colección *" value={titulo} onChange={e => setTitulo(e.target.value)} />
           <div>
@@ -160,7 +160,7 @@ export default function AdminEditarColeccionPage() {
       {/* Videos */}
       <Card className="mb-6">
         <div className="flex items-center justify-between mb-3">
-          <h2 className="font-overpass font-bold text-brand-blue">Videos ({videos.length})</h2>
+          <h2 className="font-serif font-bold text-brand-blue">Videos ({videos.length})</h2>
           <Link href={`/admin/colecciones/${coleccionId}/videos`}>
             <Button size="sm" variant="secondary" icon={<Plus className="w-3.5 h-3.5" />}>Agregar video</Button>
           </Link>
@@ -192,7 +192,7 @@ export default function AdminEditarColeccionPage() {
 
       {/* Estado */}
       <Card className="mb-6">
-        <h2 className="font-overpass font-bold text-brand-blue mb-3">Estado de publicación</h2>
+        <h2 className="font-serif font-bold text-brand-blue mb-3">Estado de publicación</h2>
         <div className="flex gap-4">
           <label className="flex items-center gap-2 cursor-pointer">
             <input type="radio" checked={!activa} onChange={() => setActiva(false)} className="accent-[var(--color-brand-blue)]" />

--- a/src/app/(admin)/admin/colecciones/[id]/videos/page.tsx
+++ b/src/app/(admin)/admin/colecciones/[id]/videos/page.tsx
@@ -60,7 +60,7 @@ export default function AdminAgregarVideoPage() {
         { label: 'Videos' },
       ]} />
 
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-6 mt-4">Agregar Video</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-6 mt-4">Agregar Video</h1>
 
       {error && (
         <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600 flex items-center gap-2">
@@ -70,7 +70,7 @@ export default function AdminAgregarVideoPage() {
       )}
 
       <Card className="mb-6">
-        <h2 className="font-overpass font-bold text-brand-blue mb-3">Paso 1: URL de YouTube</h2>
+        <h2 className="font-serif font-bold text-brand-blue mb-3">Paso 1: URL de YouTube</h2>
         <Input
           placeholder="https://www.youtube.com/watch?v=..."
           value={url}
@@ -88,7 +88,7 @@ export default function AdminAgregarVideoPage() {
 
       {urlValida && videoId && (
         <Card className="mb-6">
-          <h2 className="font-overpass font-bold text-brand-blue mb-3">Vista previa</h2>
+          <h2 className="font-serif font-bold text-brand-blue mb-3">Vista previa</h2>
           <div className="aspect-video w-full rounded-lg overflow-hidden bg-black">
             <iframe
               src={`https://www.youtube.com/embed/${videoId}`}
@@ -102,7 +102,7 @@ export default function AdminAgregarVideoPage() {
       )}
 
       <Card className="mb-6">
-        <h2 className="font-overpass font-bold text-brand-blue mb-3">Paso 2: Información del video</h2>
+        <h2 className="font-serif font-bold text-brand-blue mb-3">Paso 2: Información del video</h2>
         <div className="space-y-4">
           <Input
             label="Título en la plataforma *"
@@ -119,7 +119,7 @@ export default function AdminAgregarVideoPage() {
       </Card>
 
       <Card className="mb-6">
-        <h2 className="font-overpass font-bold text-brand-blue mb-3">Verificación de contenido</h2>
+        <h2 className="font-serif font-bold text-brand-blue mb-3">Verificación de contenido</h2>
         <div className="space-y-2">
           {[
             { key: 'preciso' as const, label: 'Verifiqué que el contenido es preciso y actualizado' },

--- a/src/app/(admin)/admin/colecciones/[id]/videos/page.tsx
+++ b/src/app/(admin)/admin/colecciones/[id]/videos/page.tsx
@@ -60,7 +60,7 @@ export default function AdminAgregarVideoPage() {
         { label: 'Videos' },
       ]} />
 
-      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-6 mt-4">Agregar Video</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-6 mt-4">Agregar Video</h1>
 
       {error && (
         <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600 flex items-center gap-2">

--- a/src/app/(admin)/admin/colecciones/nueva/page.tsx
+++ b/src/app/(admin)/admin/colecciones/nueva/page.tsx
@@ -47,7 +47,7 @@ export default function NuevaColeccionPage() {
         { label: 'Nueva' },
       ]} />
 
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1 mt-4">Nueva Colección</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1 mt-4">Nueva Colección</h1>
       <p className="text-gray-500 text-sm mb-6">Creá una nueva colección de videos de capacitación</p>
 
       <form onSubmit={handleSubmit}>

--- a/src/app/(admin)/admin/colecciones/nueva/page.tsx
+++ b/src/app/(admin)/admin/colecciones/nueva/page.tsx
@@ -47,7 +47,7 @@ export default function NuevaColeccionPage() {
         { label: 'Nueva' },
       ]} />
 
-      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1 mt-4">Nueva Colección</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1 mt-4">Nueva Colección</h1>
       <p className="text-gray-500 text-sm mb-6">Creá una nueva colección de videos de capacitación</p>
 
       <form onSubmit={handleSubmit}>

--- a/src/app/(admin)/admin/colecciones/page.tsx
+++ b/src/app/(admin)/admin/colecciones/page.tsx
@@ -33,7 +33,7 @@ export default function AdminColeccionesPage() {
     <div className="max-w-4xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Colecciones de Cursos</h1>
+          <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Colecciones de Cursos</h1>
           <p className="text-gray-500 text-sm">Gestioná las colecciones de videos curados</p>
         </div>
         <Link href="/admin/colecciones/nueva">
@@ -52,7 +52,7 @@ export default function AdminColeccionesPage() {
           <Card key={col.id}>
             <div className="flex items-start justify-between">
               <div>
-                <h2 className="font-overpass font-bold text-brand-blue">{col.titulo}</h2>
+                <h2 className="font-serif font-bold text-brand-blue">{col.titulo}</h2>
                 <p className="text-sm text-gray-500 mt-1">{col.institucion} | {col._count.videos} videos</p>
                 <div className="mt-2">
                   <Badge variant={col.activa ? 'success' : 'warning'}>

--- a/src/app/(admin)/admin/colecciones/page.tsx
+++ b/src/app/(admin)/admin/colecciones/page.tsx
@@ -33,7 +33,7 @@ export default function AdminColeccionesPage() {
     <div className="max-w-4xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Colecciones de Cursos</h1>
+          <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Colecciones de Cursos</h1>
           <p className="text-gray-500 text-sm">Gestioná las colecciones de videos curados</p>
         </div>
         <Link href="/admin/colecciones/nueva">

--- a/src/app/(admin)/admin/configuracion/archivos/page.tsx
+++ b/src/app/(admin)/admin/configuracion/archivos/page.tsx
@@ -93,7 +93,7 @@ export default function AdminConfiguracionArchivosPage() {
       <div className="flex items-center gap-3 mb-1">
         <a href="/admin/configuracion" className="text-brand-blue hover:underline text-sm">&larr; Configuracion</a>
       </div>
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Configuracion de Archivos</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Configuracion de Archivos</h1>
       <p className="text-gray-500 text-sm mb-6">Define que tipos de archivo y tamano maximo se aceptan en cada contexto de la plataforma</p>
 
       {loading && (

--- a/src/app/(admin)/admin/configuracion/archivos/page.tsx
+++ b/src/app/(admin)/admin/configuracion/archivos/page.tsx
@@ -93,7 +93,7 @@ export default function AdminConfiguracionArchivosPage() {
       <div className="flex items-center gap-3 mb-1">
         <a href="/admin/configuracion" className="text-brand-blue hover:underline text-sm">&larr; Configuracion</a>
       </div>
-      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Configuracion de Archivos</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Configuracion de Archivos</h1>
       <p className="text-gray-500 text-sm mb-6">Define que tipos de archivo y tamano maximo se aceptan en cada contexto de la plataforma</p>
 
       {loading && (

--- a/src/app/(admin)/admin/configuracion/page.tsx
+++ b/src/app/(admin)/admin/configuracion/page.tsx
@@ -118,7 +118,7 @@ export default function AdminConfiguracionPage() {
 
   return (
     <div className="max-w-3xl mx-auto py-6 px-4">
-      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Configuración General</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Configuración General</h1>
       <p className="text-gray-500 text-sm mb-6">Parámetros del sistema</p>
 
       {loading && (

--- a/src/app/(admin)/admin/configuracion/page.tsx
+++ b/src/app/(admin)/admin/configuracion/page.tsx
@@ -118,7 +118,7 @@ export default function AdminConfiguracionPage() {
 
   return (
     <div className="max-w-3xl mx-auto py-6 px-4">
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Configuración General</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Configuración General</h1>
       <p className="text-gray-500 text-sm mb-6">Parámetros del sistema</p>
 
       {loading && (
@@ -147,7 +147,7 @@ export default function AdminConfiguracionPage() {
       {tab === 'general' && (
         <>
           <Card className="mb-6">
-            <h2 className="font-overpass font-bold text-brand-blue mb-4">Información de la Plataforma</h2>
+            <h2 className="font-serif font-bold text-brand-blue mb-4">Información de la Plataforma</h2>
             <div className="space-y-4">
               <Input label="Nombre de la plataforma" value={nombrePlataforma} onChange={e => setNombrePlataforma(e.target.value)} />
               <Input label="Email de soporte" value={emailSoporte} onChange={e => setEmailSoporte(e.target.value)} />
@@ -156,7 +156,7 @@ export default function AdminConfiguracionPage() {
           </Card>
 
           <Card className="mb-6">
-            <h2 className="font-overpass font-bold text-brand-blue mb-4">Registro de Usuarios</h2>
+            <h2 className="font-serif font-bold text-brand-blue mb-4">Registro de Usuarios</h2>
             <div className="space-y-3">
               <label className="flex items-center gap-2 cursor-pointer">
                 <input type="checkbox" checked={permitirTalleres} onChange={e => setPermitirTalleres(e.target.checked)} className="rounded" />
@@ -174,7 +174,7 @@ export default function AdminConfiguracionPage() {
           </Card>
 
           <Card className="mb-6">
-            <h2 className="font-overpass font-bold text-brand-blue mb-4">Certificados</h2>
+            <h2 className="font-serif font-bold text-brand-blue mb-4">Certificados</h2>
             <div className="space-y-4">
               <Input label="Prefijo de código de certificado" value={prefijoCertificado} onChange={e => setPrefijoCertificado(e.target.value)} />
               <Input label="Institución que firma certificados" value={institucionFirma} onChange={e => setInstitucionFirma(e.target.value)} />
@@ -185,14 +185,14 @@ export default function AdminConfiguracionPage() {
 
       {tab === 'emails' && (
         <Card className="mb-6">
-          <h2 className="font-overpass font-bold text-brand-blue mb-4">Configuración de Email</h2>
+          <h2 className="font-serif font-bold text-brand-blue mb-4">Configuración de Email</h2>
           <p className="text-sm text-gray-500">Configurá los proveedores de email en <a href="/admin/integraciones/email" className="text-brand-blue hover:underline">Integraciones - Email</a></p>
         </Card>
       )}
 
       {tab === 'integraciones' && (
         <Card className="mb-6">
-          <h2 className="font-overpass font-bold text-brand-blue mb-4">Integraciones</h2>
+          <h2 className="font-serif font-bold text-brand-blue mb-4">Integraciones</h2>
           <p className="text-sm text-gray-500">Configurá las integraciones externas en <a href="/admin/integraciones" className="text-brand-blue hover:underline">Integraciones</a></p>
         </Card>
       )}
@@ -200,7 +200,7 @@ export default function AdminConfiguracionPage() {
       {tab === 'features' && (
         <>
           <Card className="mb-6">
-            <h2 className="font-overpass font-bold text-brand-blue mb-4">Escenario 1 — Formalizacion</h2>
+            <h2 className="font-serif font-bold text-brand-blue mb-4">Escenario 1 — Formalizacion</h2>
             <div className="space-y-3">
               {Object.entries(flagsE1).map(([clave, activo]) => (
                 <label key={clave} className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0">
@@ -220,7 +220,7 @@ export default function AdminConfiguracionPage() {
           </Card>
 
           <Card className="mb-6">
-            <h2 className="font-overpass font-bold text-brand-blue mb-4">Escenario 2 — Marketplace</h2>
+            <h2 className="font-serif font-bold text-brand-blue mb-4">Escenario 2 — Marketplace</h2>
             <div className="space-y-3">
               {Object.entries(flagsE2).map(([clave, activo]) => (
                 <label key={clave} className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0">

--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -52,7 +52,7 @@ export default function AdminDashboardPage() {
 
   return (
     <div className="max-w-6xl mx-auto py-6 px-4">
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Panel de Administración</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Panel de Administración</h1>
       <p className="text-gray-500 text-sm mb-6">Gestión completa de la plataforma</p>
 
       {loading && (
@@ -105,7 +105,7 @@ export default function AdminDashboardPage() {
         </Card>
       </div>
 
-      <h2 className="font-overpass font-bold text-lg text-brand-blue mb-3">Menú Completo</h2>
+      <h2 className="font-serif font-bold text-lg text-brand-blue mb-3">Menú Completo</h2>
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
         {menuItems.map(item => (
           <Link key={item.href} href={item.href}>

--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -52,7 +52,7 @@ export default function AdminDashboardPage() {
 
   return (
     <div className="max-w-6xl mx-auto py-6 px-4">
-      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Panel de Administración</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Panel de Administración</h1>
       <p className="text-gray-500 text-sm mb-6">Gestión completa de la plataforma</p>
 
       {loading && (

--- a/src/app/(admin)/admin/evaluaciones/page.tsx
+++ b/src/app/(admin)/admin/evaluaciones/page.tsx
@@ -127,7 +127,7 @@ export default function AdminEvaluacionesPage() {
   return (
     <div className="max-w-4xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-1">
-        <h1 className="font-serif font-bold text-2xl text-brand-blue">Evaluaciones</h1>
+        <h1 className="font-serif font-bold text-2xl text-ink-primary">Evaluaciones</h1>
         {tieneEval && <Badge variant="success">Evaluación activa</Badge>}
         {coleccionId && !tieneEval && !loading && <Badge variant="default">Sin evaluación</Badge>}
       </div>

--- a/src/app/(admin)/admin/evaluaciones/page.tsx
+++ b/src/app/(admin)/admin/evaluaciones/page.tsx
@@ -127,7 +127,7 @@ export default function AdminEvaluacionesPage() {
   return (
     <div className="max-w-4xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-1">
-        <h1 className="font-overpass font-bold text-2xl text-brand-blue">Evaluaciones</h1>
+        <h1 className="font-serif font-bold text-2xl text-brand-blue">Evaluaciones</h1>
         {tieneEval && <Badge variant="success">Evaluación activa</Badge>}
         {coleccionId && !tieneEval && !loading && <Badge variant="default">Sin evaluación</Badge>}
       </div>
@@ -151,7 +151,7 @@ export default function AdminEvaluacionesPage() {
       {!loading && coleccionId && (
         <>
           <Card className="mb-6">
-            <h2 className="font-overpass font-bold text-brand-blue mb-3">Configuración</h2>
+            <h2 className="font-serif font-bold text-brand-blue mb-3">Configuración</h2>
             <Input
               label="Puntaje mínimo para aprobar (%)"
               type="number"
@@ -162,7 +162,7 @@ export default function AdminEvaluacionesPage() {
           </Card>
 
           <div className="flex items-center justify-between mb-3">
-            <h2 className="font-overpass font-bold text-lg text-brand-blue">
+            <h2 className="font-serif font-bold text-lg text-brand-blue">
               Preguntas ({preguntas.length})
             </h2>
             <Button size="sm" icon={<Plus className="w-4 h-4" />} onClick={abrirNueva}>

--- a/src/app/(admin)/admin/feedback/page.tsx
+++ b/src/app/(admin)/admin/feedback/page.tsx
@@ -30,7 +30,7 @@ export default async function AdminFeedbackPage() {
       <div className="flex items-center gap-3 mb-6">
         <MessageSquare className="w-6 h-6 text-brand-blue" />
         <div>
-          <h1 className="font-serif font-bold text-2xl text-brand-blue">Feedback del piloto</h1>
+          <h1 className="font-serif font-bold text-2xl text-ink-primary">Feedback del piloto</h1>
           <p className="text-gray-500 text-sm">Ultimos 50 feedbacks de los usuarios</p>
         </div>
       </div>

--- a/src/app/(admin)/admin/feedback/page.tsx
+++ b/src/app/(admin)/admin/feedback/page.tsx
@@ -30,7 +30,7 @@ export default async function AdminFeedbackPage() {
       <div className="flex items-center gap-3 mb-6">
         <MessageSquare className="w-6 h-6 text-brand-blue" />
         <div>
-          <h1 className="font-overpass font-bold text-2xl text-brand-blue">Feedback del piloto</h1>
+          <h1 className="font-serif font-bold text-2xl text-brand-blue">Feedback del piloto</h1>
           <p className="text-gray-500 text-sm">Ultimos 50 feedbacks de los usuarios</p>
         </div>
       </div>

--- a/src/app/(admin)/admin/integraciones/email/page.tsx
+++ b/src/app/(admin)/admin/integraciones/email/page.tsx
@@ -15,7 +15,7 @@ export default function AdminIntegracionEmailPage() {
         { label: 'Email' },
       ]} />
 
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1 mt-4">Configuracion SendGrid</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1 mt-4">Configuracion SendGrid</h1>
       <p className="text-gray-500 text-sm mb-6">Envio de emails transaccionales y masivos</p>
 
       <div className="mb-6 p-4 bg-amber-50 border border-amber-200 rounded-xl flex items-center gap-3">
@@ -29,7 +29,7 @@ export default function AdminIntegracionEmailPage() {
       </div>
 
       <Card className="mb-6 opacity-50">
-        <h2 className="font-overpass font-bold text-brand-blue mb-4">API de SendGrid</h2>
+        <h2 className="font-serif font-bold text-brand-blue mb-4">API de SendGrid</h2>
         <div className="space-y-4">
           <Input label="API Key" type="password" value="............" disabled onChange={() => {}} />
           <Input label="Email remitente" value="noreply@plataformatextil.ar" disabled onChange={() => {}} />
@@ -38,7 +38,7 @@ export default function AdminIntegracionEmailPage() {
       </Card>
 
       <Card className="mb-6 opacity-50">
-        <h2 className="font-overpass font-bold text-brand-blue mb-4">Emails Habilitados</h2>
+        <h2 className="font-serif font-bold text-brand-blue mb-4">Emails Habilitados</h2>
         <div className="space-y-2">
           {['Bienvenida al registrarse', 'Verificacion de email', 'Recuperar contrasena', 'Certificado emitido', 'Recordatorio de documentos por vencer'].map(label => (
             <label key={label} className="flex items-center gap-2">
@@ -50,7 +50,7 @@ export default function AdminIntegracionEmailPage() {
       </Card>
 
       <Card className="mb-6">
-        <h2 className="font-overpass font-bold text-brand-blue mb-3">Estado</h2>
+        <h2 className="font-serif font-bold text-brand-blue mb-3">Estado</h2>
         <div className="flex items-center gap-2">
           <Badge variant="success">Activo</Badge>
           <span className="text-sm text-gray-500">Configurado via variables de entorno</span>

--- a/src/app/(admin)/admin/integraciones/email/page.tsx
+++ b/src/app/(admin)/admin/integraciones/email/page.tsx
@@ -15,7 +15,7 @@ export default function AdminIntegracionEmailPage() {
         { label: 'Email' },
       ]} />
 
-      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1 mt-4">Configuracion SendGrid</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1 mt-4">Configuracion SendGrid</h1>
       <p className="text-gray-500 text-sm mb-6">Envio de emails transaccionales y masivos</p>
 
       <div className="mb-6 p-4 bg-amber-50 border border-amber-200 rounded-xl flex items-center gap-3">

--- a/src/app/(admin)/admin/integraciones/llm/page.tsx
+++ b/src/app/(admin)/admin/integraciones/llm/page.tsx
@@ -113,11 +113,11 @@ export default function AdminIntegracionLlmPage() {
         { label: 'LLM' },
       ]} />
 
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1 mt-4">Configuracion LLM</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1 mt-4">Configuracion LLM</h1>
       <p className="text-gray-500 text-sm mb-6">Asistente virtual con IA para talleres</p>
 
       <Card className="mb-6">
-        <h2 className="font-overpass font-bold text-brand-blue mb-4">Proveedor</h2>
+        <h2 className="font-serif font-bold text-brand-blue mb-4">Proveedor</h2>
         <div className="space-y-4">
           <Select label="Proveedor de IA" value={provider} onChange={e => setProvider(e.target.value)}
             options={[{ value: 'anthropic', label: 'Anthropic' }, { value: 'openai', label: 'OpenAI' }]} />
@@ -135,7 +135,7 @@ export default function AdminIntegracionLlmPage() {
       </Card>
 
       <Card className="mb-6">
-        <h2 className="font-overpass font-bold text-brand-blue mb-4">System Prompt</h2>
+        <h2 className="font-serif font-bold text-brand-blue mb-4">System Prompt</h2>
         <textarea value={systemPrompt} onChange={e => setSystemPrompt(e.target.value)} rows={5}
           className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue focus:border-transparent" />
       </Card>
@@ -146,7 +146,7 @@ export default function AdminIntegracionLlmPage() {
 
       {/* Documentos del corpus */}
       <Card>
-        <h2 className="font-overpass font-bold text-brand-blue mb-4">Documentos del corpus ({documentos.length})</h2>
+        <h2 className="font-serif font-bold text-brand-blue mb-4">Documentos del corpus ({documentos.length})</h2>
 
         {/* Agregar documento */}
         <div className="space-y-3 mb-4 pb-4 border-b border-gray-100">

--- a/src/app/(admin)/admin/integraciones/llm/page.tsx
+++ b/src/app/(admin)/admin/integraciones/llm/page.tsx
@@ -113,7 +113,7 @@ export default function AdminIntegracionLlmPage() {
         { label: 'LLM' },
       ]} />
 
-      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1 mt-4">Configuracion LLM</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1 mt-4">Configuracion LLM</h1>
       <p className="text-gray-500 text-sm mb-6">Asistente virtual con IA para talleres</p>
 
       <Card className="mb-6">

--- a/src/app/(admin)/admin/integraciones/page.tsx
+++ b/src/app/(admin)/admin/integraciones/page.tsx
@@ -43,7 +43,7 @@ const integraciones = [
 export default function AdminIntegracionesPage() {
   return (
     <div className="max-w-4xl mx-auto py-6 px-4">
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Integraciones API</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Integraciones API</h1>
       <p className="text-gray-500 text-sm mb-6">Configuración de servicios externos</p>
 
       <div className="space-y-3">
@@ -55,7 +55,7 @@ export default function AdminIntegracionesPage() {
                   <int.icon className="w-6 h-6 text-brand-blue" />
                 </div>
                 <div className="flex-1">
-                  <h2 className="font-overpass font-bold text-brand-blue">{int.nombre}</h2>
+                  <h2 className="font-serif font-bold text-brand-blue">{int.nombre}</h2>
                   <p className="text-sm text-gray-500">{int.descripcion}</p>
                 </div>
                 {int.proximamente ? (

--- a/src/app/(admin)/admin/integraciones/page.tsx
+++ b/src/app/(admin)/admin/integraciones/page.tsx
@@ -43,7 +43,7 @@ const integraciones = [
 export default function AdminIntegracionesPage() {
   return (
     <div className="max-w-4xl mx-auto py-6 px-4">
-      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Integraciones API</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Integraciones API</h1>
       <p className="text-gray-500 text-sm mb-6">Configuración de servicios externos</p>
 
       <div className="space-y-3">

--- a/src/app/(admin)/admin/logs/page.tsx
+++ b/src/app/(admin)/admin/logs/page.tsx
@@ -139,7 +139,7 @@ export default function AdminLogsPage() {
   return (
     <div className="max-w-6xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-1">
-        <h1 className="font-overpass font-bold text-2xl text-brand-blue">Logs de Actividad</h1>
+        <h1 className="font-serif font-bold text-2xl text-brand-blue">Logs de Actividad</h1>
         <Button size="sm" variant="secondary" onClick={exportCsv}>
           <Download className="w-4 h-4 mr-1" /> Exportar CSV
         </Button>

--- a/src/app/(admin)/admin/logs/page.tsx
+++ b/src/app/(admin)/admin/logs/page.tsx
@@ -139,7 +139,7 @@ export default function AdminLogsPage() {
   return (
     <div className="max-w-6xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-1">
-        <h1 className="font-serif font-bold text-2xl text-brand-blue">Logs de Actividad</h1>
+        <h1 className="font-serif font-bold text-2xl text-ink-primary">Logs de Actividad</h1>
         <Button size="sm" variant="secondary" onClick={exportCsv}>
           <Download className="w-4 h-4 mr-1" /> Exportar CSV
         </Button>

--- a/src/app/(admin)/admin/marcas/[id]/page.tsx
+++ b/src/app/(admin)/admin/marcas/[id]/page.tsx
@@ -108,7 +108,7 @@ export default async function AdminDetalleMarcaPage({ params }: {
             {marca.nombre.charAt(0)}
           </div>
           <div className="flex-1">
-            <h1 className="font-serif font-bold text-xl text-brand-blue">{marca.nombre}</h1>
+            <h1 className="font-serif font-bold text-xl text-ink-primary">{marca.nombre}</h1>
             <p className="text-sm text-gray-500">CUIT: {marca.cuit}</p>
             <div className="flex flex-wrap gap-3 mt-2 text-sm text-gray-500">
               {marca.ubicacion && (

--- a/src/app/(admin)/admin/marcas/[id]/page.tsx
+++ b/src/app/(admin)/admin/marcas/[id]/page.tsx
@@ -108,7 +108,7 @@ export default async function AdminDetalleMarcaPage({ params }: {
             {marca.nombre.charAt(0)}
           </div>
           <div className="flex-1">
-            <h1 className="font-overpass font-bold text-xl text-brand-blue">{marca.nombre}</h1>
+            <h1 className="font-serif font-bold text-xl text-brand-blue">{marca.nombre}</h1>
             <p className="text-sm text-gray-500">CUIT: {marca.cuit}</p>
             <div className="flex flex-wrap gap-3 mt-2 text-sm text-gray-500">
               {marca.ubicacion && (
@@ -226,7 +226,7 @@ export default async function AdminDetalleMarcaPage({ params }: {
 
       {/* Pedidos */}
       <Card className="mb-6">
-        <h2 className="font-overpass font-bold text-brand-blue mb-3">Pedidos</h2>
+        <h2 className="font-serif font-bold text-brand-blue mb-3">Pedidos</h2>
         {marca.pedidos.length === 0 ? (
           <p className="text-sm text-gray-500">Sin pedidos registrados.</p>
         ) : (
@@ -265,7 +265,7 @@ export default async function AdminDetalleMarcaPage({ params }: {
 
       {/* Actividad (logs) */}
       <Card className="mb-6">
-        <h2 className="font-overpass font-bold text-brand-blue mb-3">Actividad Reciente</h2>
+        <h2 className="font-serif font-bold text-brand-blue mb-3">Actividad Reciente</h2>
         {logs.length === 0 ? (
           <p className="text-sm text-gray-500">Sin actividad registrada.</p>
         ) : (
@@ -286,7 +286,7 @@ export default async function AdminDetalleMarcaPage({ params }: {
 
       {/* Notas */}
       <Card>
-        <h2 className="font-overpass font-bold text-brand-blue mb-3">Notas Internas</h2>
+        <h2 className="font-serif font-bold text-brand-blue mb-3">Notas Internas</h2>
         <form action={guardarNota} className="flex gap-2 mb-4">
           <input
             type="text"

--- a/src/app/(admin)/admin/marcas/page.tsx
+++ b/src/app/(admin)/admin/marcas/page.tsx
@@ -56,7 +56,7 @@ export default function AdminMarcasPage() {
 
   return (
     <div className="max-w-5xl mx-auto py-6 px-4">
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Gestión de Marcas</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Gestión de Marcas</h1>
       <p className="text-gray-500 text-sm mb-6">Todas las marcas/empresas registradas</p>
 
       <div className="grid grid-cols-2 gap-4 mb-6">

--- a/src/app/(admin)/admin/marcas/page.tsx
+++ b/src/app/(admin)/admin/marcas/page.tsx
@@ -56,7 +56,7 @@ export default function AdminMarcasPage() {
 
   return (
     <div className="max-w-5xl mx-auto py-6 px-4">
-      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Gestión de Marcas</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Gestión de Marcas</h1>
       <p className="text-gray-500 text-sm mb-6">Todas las marcas/empresas registradas</p>
 
       <div className="grid grid-cols-2 gap-4 mb-6">

--- a/src/app/(admin)/admin/notificaciones/page.tsx
+++ b/src/app/(admin)/admin/notificaciones/page.tsx
@@ -47,7 +47,7 @@ export default async function AdminNotificacionesPage({
     <div className="max-w-4xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Comunicaciones</h1>
+          <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Comunicaciones</h1>
           <p className="text-gray-500 text-sm">Envio de comunicaciones a usuarios</p>
         </div>
         <NotificacionesClient />

--- a/src/app/(admin)/admin/notificaciones/page.tsx
+++ b/src/app/(admin)/admin/notificaciones/page.tsx
@@ -57,7 +57,7 @@ export default async function AdminNotificacionesPage({
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
         <div className="bg-white rounded-xl shadow-sm p-5 border border-gray-100">
           <div className="flex items-center gap-3">
-            <Send className="w-5 h-5 text-blue-600" />
+            <Send className="w-5 h-5 text-brand-blue" />
             <div>
               <p className="text-2xl font-bold text-gray-800">{total}</p>
               <p className="text-xs text-gray-500">Total enviadas</p>

--- a/src/app/(admin)/admin/notificaciones/page.tsx
+++ b/src/app/(admin)/admin/notificaciones/page.tsx
@@ -47,7 +47,7 @@ export default async function AdminNotificacionesPage({
     <div className="max-w-4xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Comunicaciones</h1>
+          <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Comunicaciones</h1>
           <p className="text-gray-500 text-sm">Envio de comunicaciones a usuarios</p>
         </div>
         <NotificacionesClient />

--- a/src/app/(admin)/admin/observaciones/[id]/editar/page.tsx
+++ b/src/app/(admin)/admin/observaciones/[id]/editar/page.tsx
@@ -36,7 +36,7 @@ export default async function EditarObservacionPage({
         { label: 'Editar observacion' },
       ]} />
       <div className="flex items-center justify-between">
-        <h1 className="font-serif font-bold text-2xl text-brand-blue">Editar observacion</h1>
+        <h1 className="font-serif font-bold text-2xl text-ink-primary">Editar observacion</h1>
         {canEdit && <EliminarObservacion observacionId={id} />}
       </div>
       {canEdit ? (

--- a/src/app/(admin)/admin/observaciones/[id]/editar/page.tsx
+++ b/src/app/(admin)/admin/observaciones/[id]/editar/page.tsx
@@ -36,7 +36,7 @@ export default async function EditarObservacionPage({
         { label: 'Editar observacion' },
       ]} />
       <div className="flex items-center justify-between">
-        <h1 className="font-overpass font-bold text-2xl text-brand-blue">Editar observacion</h1>
+        <h1 className="font-serif font-bold text-2xl text-brand-blue">Editar observacion</h1>
         {canEdit && <EliminarObservacion observacionId={id} />}
       </div>
       {canEdit ? (

--- a/src/app/(admin)/admin/observaciones/nueva/page.tsx
+++ b/src/app/(admin)/admin/observaciones/nueva/page.tsx
@@ -10,7 +10,7 @@ export default function NuevaObservacionPage() {
         { label: 'Observaciones', href: '/admin/observaciones' },
         { label: 'Nueva observacion' },
       ]} />
-      <h1 className="font-serif font-bold text-2xl text-brand-blue">Nueva observacion</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary">Nueva observacion</h1>
       <p className="text-sm text-gray-500">
         Esta info se usa para el reporte a OIT. No incluyas datos sensibles que no quieras compartir.
       </p>

--- a/src/app/(admin)/admin/observaciones/nueva/page.tsx
+++ b/src/app/(admin)/admin/observaciones/nueva/page.tsx
@@ -10,7 +10,7 @@ export default function NuevaObservacionPage() {
         { label: 'Observaciones', href: '/admin/observaciones' },
         { label: 'Nueva observacion' },
       ]} />
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue">Nueva observacion</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue">Nueva observacion</h1>
       <p className="text-sm text-gray-500">
         Esta info se usa para el reporte a OIT. No incluyas datos sensibles que no quieras compartir.
       </p>

--- a/src/app/(admin)/admin/observaciones/page.tsx
+++ b/src/app/(admin)/admin/observaciones/page.tsx
@@ -99,7 +99,7 @@ export default async function ObservacionesPage({
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="font-serif font-bold text-2xl text-brand-blue">Observaciones de campo</h1>
+          <h1 className="font-serif font-bold text-2xl text-ink-primary">Observaciones de campo</h1>
           <p className="text-sm text-gray-500 mt-1">Registro cualitativo del piloto para el reporte a OIT</p>
         </div>
         <div className="flex gap-2">

--- a/src/app/(admin)/admin/observaciones/page.tsx
+++ b/src/app/(admin)/admin/observaciones/page.tsx
@@ -112,7 +112,7 @@ export default async function ObservacionesPage({
           </Link>
           <Link
             href="/admin/observaciones/nueva"
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-overpass font-semibold bg-brand-blue hover:bg-blue-800 text-white transition-colors"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-overpass font-semibold bg-brand-blue hover:bg-brand-blue-dark text-white transition-colors"
           >
             <Plus className="w-4 h-4" />
             Nueva observacion
@@ -171,7 +171,7 @@ export default async function ObservacionesPage({
           </div>
         </div>
         <div className="mt-3 flex justify-end">
-          <button type="submit" className="px-4 py-2 rounded-lg text-sm font-overpass font-semibold bg-brand-blue text-white hover:bg-blue-800 transition-colors">
+          <button type="submit" className="px-4 py-2 rounded-lg text-sm font-overpass font-semibold bg-brand-blue text-white hover:bg-brand-blue-dark transition-colors">
             Filtrar
           </button>
         </div>

--- a/src/app/(admin)/admin/observaciones/page.tsx
+++ b/src/app/(admin)/admin/observaciones/page.tsx
@@ -99,7 +99,7 @@ export default async function ObservacionesPage({
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="font-overpass font-bold text-2xl text-brand-blue">Observaciones de campo</h1>
+          <h1 className="font-serif font-bold text-2xl text-brand-blue">Observaciones de campo</h1>
           <p className="text-sm text-gray-500 mt-1">Registro cualitativo del piloto para el reporte a OIT</p>
         </div>
         <div className="flex gap-2">

--- a/src/app/(admin)/admin/onboarding/page.tsx
+++ b/src/app/(admin)/admin/onboarding/page.tsx
@@ -83,7 +83,7 @@ export default async function AdminOnboardingPage() {
         <h2 className="font-overpass font-bold text-lg text-gray-800 mb-4">Funnel de adopcion</h2>
         <div className="space-y-3">
           <FunnelBar label="Invitados" count={total} pct={100} color="bg-gray-300" />
-          <FunnelBar label="Registrados" count={total - conteos.INVITADO} pct={pctRegistrados} color="bg-blue-400" />
+          <FunnelBar label="Registrados" count={total - conteos.INVITADO} pct={pctRegistrados} color="bg-brand-blue/60" />
           <FunnelBar label="Perfil completo" count={conteos.PERFIL_COMPLETO + conteos.ACTIVO} pct={pctPerfilCompleto} color="bg-amber-400" />
           <FunnelBar label="Activos" count={conteos.ACTIVO} pct={pctActivos} color="bg-green-500" />
         </div>

--- a/src/app/(admin)/admin/onboarding/page.tsx
+++ b/src/app/(admin)/admin/onboarding/page.tsx
@@ -54,7 +54,7 @@ export default async function AdminOnboardingPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="font-overpass font-bold text-2xl text-brand-blue">Estado del onboarding</h1>
+          <h1 className="font-serif font-bold text-2xl text-brand-blue">Estado del onboarding</h1>
           <p className="text-sm text-gray-500 mt-1">Seguimiento del progreso de talleres y marcas en el piloto</p>
         </div>
       </div>
@@ -80,7 +80,7 @@ export default async function AdminOnboardingPage() {
 
       {/* Funnel */}
       <div className="bg-white rounded-xl border border-gray-200 p-6">
-        <h2 className="font-overpass font-bold text-lg text-gray-800 mb-4">Funnel de adopcion</h2>
+        <h2 className="font-serif font-bold text-lg text-gray-800 mb-4">Funnel de adopcion</h2>
         <div className="space-y-3">
           <FunnelBar label="Invitados" count={total} pct={100} color="bg-gray-300" />
           <FunnelBar label="Registrados" count={total - conteos.INVITADO} pct={pctRegistrados} color="bg-brand-blue/60" />
@@ -92,7 +92,7 @@ export default async function AdminOnboardingPage() {
       {/* Tabla de usuarios */}
       <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
         <div className="px-6 py-4 border-b border-gray-100">
-          <h2 className="font-overpass font-bold text-lg text-gray-800">Usuarios</h2>
+          <h2 className="font-serif font-bold text-lg text-gray-800">Usuarios</h2>
         </div>
         {usuariosConEtapa.length === 0 ? (
           <EmptyState

--- a/src/app/(admin)/admin/onboarding/page.tsx
+++ b/src/app/(admin)/admin/onboarding/page.tsx
@@ -54,7 +54,7 @@ export default async function AdminOnboardingPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="font-serif font-bold text-2xl text-brand-blue">Estado del onboarding</h1>
+          <h1 className="font-serif font-bold text-2xl text-ink-primary">Estado del onboarding</h1>
           <p className="text-sm text-gray-500 mt-1">Seguimiento del progreso de talleres y marcas en el piloto</p>
         </div>
       </div>

--- a/src/app/(admin)/admin/pedidos/page.tsx
+++ b/src/app/(admin)/admin/pedidos/page.tsx
@@ -67,7 +67,7 @@ export default function AdminPedidosPage() {
 
   return (
     <div className="max-w-5xl mx-auto py-6 px-4">
-      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Gestión de Pedidos</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Gestión de Pedidos</h1>
       <p className="text-gray-500 text-sm mb-6">Todos los pedidos realizados en la plataforma</p>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">

--- a/src/app/(admin)/admin/pedidos/page.tsx
+++ b/src/app/(admin)/admin/pedidos/page.tsx
@@ -67,7 +67,7 @@ export default function AdminPedidosPage() {
 
   return (
     <div className="max-w-5xl mx-auto py-6 px-4">
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Gestión de Pedidos</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Gestión de Pedidos</h1>
       <p className="text-gray-500 text-sm mb-6">Todos los pedidos realizados en la plataforma</p>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">

--- a/src/app/(admin)/admin/procesos/page.tsx
+++ b/src/app/(admin)/admin/procesos/page.tsx
@@ -99,7 +99,7 @@ export default function AdminProcesosPage() {
     <div className="max-w-4xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Procesos Productivos</h1>
+          <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Procesos Productivos</h1>
           <p className="text-gray-500 text-sm">Tags que los talleres usan para indicar sus capacidades</p>
         </div>
         <Button icon={<Plus className="w-4 h-4" />} onClick={handleNew}>Nuevo Proceso</Button>

--- a/src/app/(admin)/admin/procesos/page.tsx
+++ b/src/app/(admin)/admin/procesos/page.tsx
@@ -99,7 +99,7 @@ export default function AdminProcesosPage() {
     <div className="max-w-4xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Procesos Productivos</h1>
+          <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Procesos Productivos</h1>
           <p className="text-gray-500 text-sm">Tags que los talleres usan para indicar sus capacidades</p>
         </div>
         <Button icon={<Plus className="w-4 h-4" />} onClick={handleNew}>Nuevo Proceso</Button>

--- a/src/app/(admin)/admin/reportes/page.tsx
+++ b/src/app/(admin)/admin/reportes/page.tsx
@@ -66,10 +66,10 @@ export default async function AdminReportesPage() {
 
   return (
     <div className="max-w-4xl mx-auto py-6 px-4">
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Reportes y Estadisticas</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Reportes y Estadisticas</h1>
       <p className="text-gray-500 text-sm mb-6">Metricas de la plataforma</p>
 
-      <h2 className="font-overpass font-bold text-lg text-brand-blue mb-3">Metricas Principales</h2>
+      <h2 className="font-serif font-bold text-lg text-brand-blue mb-3">Metricas Principales</h2>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
         <StatCard value={String(totalTalleres)} label="Talleres" variant="success" />
         <StatCard value={String(totalMarcas)} label="Marcas" variant="success" />
@@ -77,7 +77,7 @@ export default async function AdminReportesPage() {
         <StatCard value={String(totalVideosVistos)} label="Videos completados" variant="muted" />
       </div>
 
-      <h2 className="font-overpass font-bold text-lg text-brand-blue mb-3">Distribucion por Nivel</h2>
+      <h2 className="font-serif font-bold text-lg text-brand-blue mb-3">Distribucion por Nivel</h2>
       <Card className="mb-6">
         {totalTalleres === 0 ? (
           <p className="text-sm text-gray-500 py-2">Sin talleres registrados.</p>
@@ -99,7 +99,7 @@ export default async function AdminReportesPage() {
         )}
       </Card>
 
-      <h2 className="font-overpass font-bold text-lg text-brand-blue mb-3">Registros por Mes</h2>
+      <h2 className="font-serif font-bold text-lg text-brand-blue mb-3">Registros por Mes</h2>
       <Card className="mb-6">
         {registros.length === 0 ? (
           <p className="text-sm text-gray-500 py-2">Sin registros en los ultimos 6 meses.</p>

--- a/src/app/(admin)/admin/reportes/page.tsx
+++ b/src/app/(admin)/admin/reportes/page.tsx
@@ -66,7 +66,7 @@ export default async function AdminReportesPage() {
 
   return (
     <div className="max-w-4xl mx-auto py-6 px-4">
-      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Reportes y Estadisticas</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Reportes y Estadisticas</h1>
       <p className="text-gray-500 text-sm mb-6">Metricas de la plataforma</p>
 
       <h2 className="font-serif font-bold text-lg text-brand-blue mb-3">Metricas Principales</h2>

--- a/src/app/(admin)/admin/talleres/[id]/page.tsx
+++ b/src/app/(admin)/admin/talleres/[id]/page.tsx
@@ -134,7 +134,7 @@ export default async function AdminDetalleTallerPage({ params, searchParams }: {
       </Card>
 
       {/* Link a vista ESTADO */}
-      <div className="mb-4 rounded-lg bg-blue-50 border border-blue-200 px-4 py-3 text-sm text-blue-700">
+      <div className="mb-4 rounded-lg bg-pastel-blue border border-brand-blue/30 px-4 py-3 text-sm text-brand-blue-dark">
         Las acciones de formalizacion (aprobar/rechazar documentos) son responsabilidad del Estado.{' '}
         <Link href={`/estado/talleres/${id}`} className="font-semibold text-brand-blue hover:underline">
           Ver vista de formalizacion

--- a/src/app/(admin)/admin/talleres/[id]/page.tsx
+++ b/src/app/(admin)/admin/talleres/[id]/page.tsx
@@ -103,7 +103,7 @@ export default async function AdminDetalleTallerPage({ params, searchParams }: {
             {taller.nombre.charAt(0)}
           </div>
           <div className="flex-1">
-            <h1 className="font-overpass font-bold text-xl text-brand-blue">{taller.nombre}</h1>
+            <h1 className="font-serif font-bold text-xl text-brand-blue">{taller.nombre}</h1>
             <p className="text-sm text-gray-500">CUIT: {taller.cuit} {taller.verificadoAfip && <span className="text-green-500">&#10003;</span>}</p>
             <div className="flex flex-wrap gap-3 mt-2 text-sm text-gray-500">
               {taller.provincia && <span className="flex items-center gap-1"><MapPin className="w-3.5 h-3.5" /> {taller.provincia}{taller.partido ? `, ${taller.partido}` : ''}</span>}
@@ -259,7 +259,7 @@ export default async function AdminDetalleTallerPage({ params, searchParams }: {
       {/* Tab: Historial */}
       {tab === 'historial' && (
         <Card>
-          <h2 className="font-overpass font-bold text-brand-blue mb-3">Historial del taller</h2>
+          <h2 className="font-serif font-bold text-brand-blue mb-3">Historial del taller</h2>
           {historialLogs.length === 0 ? (
             <p className="text-sm text-gray-500">Sin actividad registrada.</p>
           ) : (
@@ -295,7 +295,7 @@ export default async function AdminDetalleTallerPage({ params, searchParams }: {
       {/* Tab: Actividad */}
       {tab === 'actividad' && (
         <Card>
-          <h2 className="font-overpass font-bold text-brand-blue mb-3">Actividad Reciente</h2>
+          <h2 className="font-serif font-bold text-brand-blue mb-3">Actividad Reciente</h2>
           {logs.length === 0 ? (
             <p className="text-sm text-gray-500">Sin actividad registrada.</p>
           ) : (
@@ -319,7 +319,7 @@ export default async function AdminDetalleTallerPage({ params, searchParams }: {
 
       {/* Notas */}
       <Card className="mt-6">
-        <h2 className="font-overpass font-bold text-brand-blue mb-3">Notas Internas</h2>
+        <h2 className="font-serif font-bold text-brand-blue mb-3">Notas Internas</h2>
         <form action={guardarNota} className="flex gap-2 mb-4">
           <input
             type="text"

--- a/src/app/(admin)/admin/talleres/[id]/page.tsx
+++ b/src/app/(admin)/admin/talleres/[id]/page.tsx
@@ -103,7 +103,7 @@ export default async function AdminDetalleTallerPage({ params, searchParams }: {
             {taller.nombre.charAt(0)}
           </div>
           <div className="flex-1">
-            <h1 className="font-serif font-bold text-xl text-brand-blue">{taller.nombre}</h1>
+            <h1 className="font-serif font-bold text-xl text-ink-primary">{taller.nombre}</h1>
             <p className="text-sm text-gray-500">CUIT: {taller.cuit} {taller.verificadoAfip && <span className="text-green-500">&#10003;</span>}</p>
             <div className="flex flex-wrap gap-3 mt-2 text-sm text-gray-500">
               {taller.provincia && <span className="flex items-center gap-1"><MapPin className="w-3.5 h-3.5" /> {taller.provincia}{taller.partido ? `, ${taller.partido}` : ''}</span>}

--- a/src/app/(admin)/admin/talleres/page.tsx
+++ b/src/app/(admin)/admin/talleres/page.tsx
@@ -68,7 +68,7 @@ export default function AdminTalleresPage() {
 
   return (
     <div className="max-w-5xl mx-auto py-6 px-4">
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Gestión de Talleres</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Gestión de Talleres</h1>
       <p className="text-gray-500 text-sm mb-6">Todos los talleres registrados en la plataforma</p>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">

--- a/src/app/(admin)/admin/talleres/page.tsx
+++ b/src/app/(admin)/admin/talleres/page.tsx
@@ -68,7 +68,7 @@ export default function AdminTalleresPage() {
 
   return (
     <div className="max-w-5xl mx-auto py-6 px-4">
-      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Gestión de Talleres</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Gestión de Talleres</h1>
       <p className="text-gray-500 text-sm mb-6">Todos los talleres registrados en la plataforma</p>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">

--- a/src/app/(admin)/admin/usuarios/page.tsx
+++ b/src/app/(admin)/admin/usuarios/page.tsx
@@ -139,12 +139,12 @@ export default function AdminUsuariosPage() {
 
   return (
     <div className="max-w-5xl mx-auto py-6 px-4">
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Usuarios</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Usuarios</h1>
       <p className="text-gray-500 text-sm mb-6">Gestión de usuarios de la plataforma</p>
 
       {registrosIncompletos.length > 0 && (
         <Card className="mb-6 border-l-4 border-l-amber-400">
-          <h2 className="font-overpass font-bold text-brand-blue mb-3">Registros incompletos</h2>
+          <h2 className="font-serif font-bold text-brand-blue mb-3">Registros incompletos</h2>
           <p className="text-sm text-gray-500 mb-3">Usuarios que iniciaron registro con Google o magic link pero no completaron el CUIT y rol.</p>
           <div className="divide-y divide-gray-100">
             {registrosIncompletos.map((r) => (

--- a/src/app/(admin)/admin/usuarios/page.tsx
+++ b/src/app/(admin)/admin/usuarios/page.tsx
@@ -139,7 +139,7 @@ export default function AdminUsuariosPage() {
 
   return (
     <div className="max-w-5xl mx-auto py-6 px-4">
-      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Usuarios</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Usuarios</h1>
       <p className="text-gray-500 text-sm mb-6">Gestión de usuarios de la plataforma</p>
 
       {registrosIncompletos.length > 0 && (

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -52,8 +52,8 @@ export default async function AdminLayout({ children }: { children: React.ReactN
           </div>
           <div className="flex items-center gap-4">
             <NotificacionesBell />
-            <span className="text-sm text-blue-200">{session.user.name}</span>
-            <Link href="/" className="text-sm hover:text-blue-200 transition-colors">Volver al sitio</Link>
+            <span className="text-sm text-white/70">{session.user.name}</span>
+            <Link href="/" className="text-sm hover:text-white/70 transition-colors">Volver al sitio</Link>
             <LogoutButton />
           </div>
         </div>

--- a/src/app/(auth)/acceso-rapido/page.tsx
+++ b/src/app/(auth)/acceso-rapido/page.tsx
@@ -115,7 +115,7 @@ export default function AccesoRapidoPage() {
         <div className="w-16 h-16 rounded-full bg-brand-blue flex items-center justify-center mx-auto mb-4">
           <span className="font-overpass font-bold text-white text-xl">PDT</span>
         </div>
-        <h1 className="font-overpass font-bold text-2xl text-brand-blue">Acceso rapido</h1>
+        <h1 className="font-overpass font-bold text-2xl text-ink-primary">Acceso rapido</h1>
         <p className="text-gray-500 text-sm mt-1">Selecciona un usuario para ingresar al sistema</p>
       </div>
 

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -9,7 +9,7 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
             <div className="w-20 h-20 rounded-full bg-brand-blue flex items-center justify-center mx-auto mb-4">
               <span className="font-overpass font-bold text-white text-2xl">PDT</span>
             </div>
-            <h1 className="font-overpass font-bold text-2xl text-brand-blue">Plataforma Digital Textil</h1>
+            <h1 className="font-overpass font-bold text-2xl text-ink-primary">Plataforma Digital Textil</h1>
           </div>
           {children}
         </div>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -109,7 +109,7 @@ export default function LoginPage() {
 
   return (
     <Card className="p-8">
-      <h2 className="font-overpass font-bold text-xl text-brand-blue text-center mb-6">
+      <h2 className="font-serif font-bold text-xl text-brand-blue text-center mb-6">
         Iniciar sesion
       </h2>
 

--- a/src/app/(auth)/mi-cuenta/page.tsx
+++ b/src/app/(auth)/mi-cuenta/page.tsx
@@ -112,7 +112,7 @@ export default function MiCuentaPage() {
 
   return (
     <div className="max-w-2xl mx-auto py-8 px-4">
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-6">Mi Cuenta</h1>
+      <h1 className="font-overpass font-bold text-2xl text-ink-primary mb-6">Mi Cuenta</h1>
 
       <Card title="Información de la cuenta" className="mb-6">
         <div className="flex items-center gap-3 mb-3 pb-3 border-b border-gray-100">

--- a/src/app/(auth)/olvide-contrasena/page.tsx
+++ b/src/app/(auth)/olvide-contrasena/page.tsx
@@ -46,7 +46,7 @@ export default function OlvideContrasenaPage() {
         <div className="w-16 h-16 rounded-full bg-green-100 flex items-center justify-center mx-auto mb-4">
           <CheckCircle className="w-8 h-8 text-green-600" />
         </div>
-        <h2 className="font-overpass font-bold text-xl text-brand-blue mb-2">Email enviado</h2>
+        <h2 className="font-serif font-bold text-xl text-brand-blue mb-2">Email enviado</h2>
         <p className="text-sm text-gray-600 mb-6">
           Te enviamos un email con instrucciones para restablecer tu contraseña. Revisá tu bandeja de entrada.
         </p>
@@ -59,7 +59,7 @@ export default function OlvideContrasenaPage() {
 
   return (
     <Card className="p-8">
-      <h2 className="font-overpass font-bold text-xl text-brand-blue text-center mb-2">
+      <h2 className="font-serif font-bold text-xl text-brand-blue text-center mb-2">
         Recuperar contraseña
       </h2>
       <p className="text-sm text-gray-500 text-center mb-6">

--- a/src/app/(auth)/registro/completar/page.tsx
+++ b/src/app/(auth)/registro/completar/page.tsx
@@ -107,7 +107,7 @@ export default function CompletarRegistroPage() {
         </div>
       )}
 
-      <h2 className="font-overpass font-bold text-xl text-brand-blue text-center mb-2">
+      <h2 className="font-serif font-bold text-xl text-brand-blue text-center mb-2">
         Completa tu registro
       </h2>
       <p className="text-sm text-gray-500 text-center mb-6">

--- a/src/app/(auth)/registro/page.tsx
+++ b/src/app/(auth)/registro/page.tsx
@@ -88,7 +88,7 @@ function StepIndicator({ currentStep, totalSteps }: { currentStep: number; total
 function StepRole({ onSelect }: { onSelect: (role: Role) => void }) {
   return (
     <div>
-      <h2 className="font-overpass font-bold text-xl text-brand-blue text-center mb-2">
+      <h2 className="font-serif font-bold text-xl text-brand-blue text-center mb-2">
         Crear cuenta
       </h2>
       <p className="text-sm text-gray-500 text-center mb-6">
@@ -151,7 +151,7 @@ function StepPersonalInfo({
 
   return (
     <div>
-      <h2 className="font-overpass font-bold text-xl text-brand-blue text-center mb-2">
+      <h2 className="font-serif font-bold text-xl text-brand-blue text-center mb-2">
         Datos personales
       </h2>
       <p className="text-sm text-gray-500 text-center mb-6">
@@ -278,7 +278,7 @@ function StepEntidadInfo({
 
   return (
     <div>
-      <h2 className="font-overpass font-bold text-xl text-brand-blue text-center mb-2">{titulo}</h2>
+      <h2 className="font-serif font-bold text-xl text-brand-blue text-center mb-2">{titulo}</h2>
       <p className="text-sm text-gray-500 text-center mb-6">{subtitulo}</p>
 
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">

--- a/src/app/(auth)/restablecer/[token]/page.tsx
+++ b/src/app/(auth)/restablecer/[token]/page.tsx
@@ -63,7 +63,7 @@ export default function RestablecerPage() {
         <div className="w-16 h-16 rounded-full bg-green-100 flex items-center justify-center mx-auto mb-4">
           <CheckCircle className="w-8 h-8 text-green-600" />
         </div>
-        <h2 className="font-overpass font-bold text-xl text-brand-blue mb-2">Contraseña restablecida</h2>
+        <h2 className="font-serif font-bold text-xl text-brand-blue mb-2">Contraseña restablecida</h2>
         <p className="text-sm text-gray-600 mb-6">Tu contraseña fue actualizada. Redirigiendo al login...</p>
         <Link href="/login" className="text-sm font-semibold text-brand-blue hover:underline">
           Ir al login
@@ -78,7 +78,7 @@ export default function RestablecerPage() {
         <div className="w-16 h-16 rounded-full bg-red-100 flex items-center justify-center mx-auto mb-4">
           <XCircle className="w-8 h-8 text-red-600" />
         </div>
-        <h2 className="font-overpass font-bold text-xl text-red-600 mb-2">Error</h2>
+        <h2 className="font-serif font-bold text-xl text-red-600 mb-2">Error</h2>
         <p className="text-sm text-gray-600 mb-6">{errorMsg}</p>
         <Link href="/olvide-contrasena" className="text-sm font-semibold text-brand-blue hover:underline">
           Solicitar nuevo enlace
@@ -89,7 +89,7 @@ export default function RestablecerPage() {
 
   return (
     <Card className="p-8">
-      <h2 className="font-overpass font-bold text-xl text-brand-blue text-center mb-2">Nueva contraseña</h2>
+      <h2 className="font-serif font-bold text-xl text-brand-blue text-center mb-2">Nueva contraseña</h2>
       <p className="text-sm text-gray-500 text-center mb-6">Ingresá tu nueva contraseña.</p>
 
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">

--- a/src/app/(contenido)/contenido/colecciones/page.tsx
+++ b/src/app/(contenido)/contenido/colecciones/page.tsx
@@ -33,7 +33,7 @@ export default function ContenidoColeccionesPage() {
     <div className="max-w-4xl mx-auto">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Colecciones de Cursos</h1>
+          <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Colecciones de Cursos</h1>
           <p className="text-gray-500 text-sm">Gestiona las colecciones de videos curados</p>
         </div>
         <Link href="/admin/colecciones/nueva">
@@ -48,7 +48,7 @@ export default function ContenidoColeccionesPage() {
           <Card key={col.id}>
             <div className="flex items-start justify-between">
               <div>
-                <h2 className="font-overpass font-bold text-brand-blue">{col.titulo}</h2>
+                <h2 className="font-serif font-bold text-brand-blue">{col.titulo}</h2>
                 <p className="text-sm text-gray-500 mt-1">{col.institucion} | {col._count.videos} videos</p>
                 <div className="mt-2">
                   <Badge variant={col.activa ? 'success' : 'warning'}>

--- a/src/app/(contenido)/contenido/colecciones/page.tsx
+++ b/src/app/(contenido)/contenido/colecciones/page.tsx
@@ -33,7 +33,7 @@ export default function ContenidoColeccionesPage() {
     <div className="max-w-4xl mx-auto">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Colecciones de Cursos</h1>
+          <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Colecciones de Cursos</h1>
           <p className="text-gray-500 text-sm">Gestiona las colecciones de videos curados</p>
         </div>
         <Link href="/admin/colecciones/nueva">

--- a/src/app/(contenido)/contenido/evaluaciones/page.tsx
+++ b/src/app/(contenido)/contenido/evaluaciones/page.tsx
@@ -127,7 +127,7 @@ export default function AdminEvaluacionesPage() {
   return (
     <div className="max-w-4xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-1">
-        <h1 className="font-serif font-bold text-2xl text-brand-blue">Evaluaciones</h1>
+        <h1 className="font-serif font-bold text-2xl text-ink-primary">Evaluaciones</h1>
         {tieneEval && <Badge variant="success">Evaluación activa</Badge>}
         {coleccionId && !tieneEval && !loading && <Badge variant="default">Sin evaluación</Badge>}
       </div>

--- a/src/app/(contenido)/contenido/evaluaciones/page.tsx
+++ b/src/app/(contenido)/contenido/evaluaciones/page.tsx
@@ -127,7 +127,7 @@ export default function AdminEvaluacionesPage() {
   return (
     <div className="max-w-4xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-1">
-        <h1 className="font-overpass font-bold text-2xl text-brand-blue">Evaluaciones</h1>
+        <h1 className="font-serif font-bold text-2xl text-brand-blue">Evaluaciones</h1>
         {tieneEval && <Badge variant="success">Evaluación activa</Badge>}
         {coleccionId && !tieneEval && !loading && <Badge variant="default">Sin evaluación</Badge>}
       </div>
@@ -151,7 +151,7 @@ export default function AdminEvaluacionesPage() {
       {!loading && coleccionId && (
         <>
           <Card className="mb-6">
-            <h2 className="font-overpass font-bold text-brand-blue mb-3">Configuración</h2>
+            <h2 className="font-serif font-bold text-brand-blue mb-3">Configuración</h2>
             <Input
               label="Puntaje mínimo para aprobar (%)"
               type="number"
@@ -162,7 +162,7 @@ export default function AdminEvaluacionesPage() {
           </Card>
 
           <div className="flex items-center justify-between mb-3">
-            <h2 className="font-overpass font-bold text-lg text-brand-blue">
+            <h2 className="font-serif font-bold text-lg text-brand-blue">
               Preguntas ({preguntas.length})
             </h2>
             <Button size="sm" icon={<Plus className="w-4 h-4" />} onClick={abrirNueva}>

--- a/src/app/(contenido)/contenido/notificaciones/page.tsx
+++ b/src/app/(contenido)/contenido/notificaciones/page.tsx
@@ -24,7 +24,7 @@ export default async function ContenidoNotificacionesPage() {
     <div className="max-w-4xl mx-auto">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Notificaciones</h1>
+          <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Notificaciones</h1>
           <p className="text-gray-500 text-sm">Envio de comunicaciones a talleres</p>
         </div>
         <NotificacionesClient />
@@ -60,7 +60,7 @@ export default async function ContenidoNotificacionesPage() {
         </div>
       </div>
 
-      <h2 className="font-overpass font-bold text-lg text-brand-blue mb-3">Recientes</h2>
+      <h2 className="font-serif font-bold text-lg text-brand-blue mb-3">Recientes</h2>
       {notificaciones.length === 0 ? (
         <div className="bg-white rounded-xl shadow-sm p-8 border border-gray-100 text-center">
           <Mail className="w-8 h-8 text-gray-300 mx-auto mb-2" />

--- a/src/app/(contenido)/contenido/notificaciones/page.tsx
+++ b/src/app/(contenido)/contenido/notificaciones/page.tsx
@@ -33,7 +33,7 @@ export default async function ContenidoNotificacionesPage() {
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
         <div className="bg-white rounded-xl shadow-sm p-5 border border-gray-100">
           <div className="flex items-center gap-3">
-            <Send className="w-5 h-5 text-blue-600" />
+            <Send className="w-5 h-5 text-brand-blue" />
             <div>
               <p className="text-2xl font-bold text-gray-800">{total}</p>
               <p className="text-xs text-gray-500">Total enviadas</p>
@@ -73,7 +73,7 @@ export default async function ContenidoNotificacionesPage() {
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
                   <p className="font-semibold text-sm text-gray-800 truncate">{n.titulo}</p>
-                  {!n.leida && <span className="w-2 h-2 rounded-full bg-blue-500 flex-shrink-0" aria-label="Sin leer" />}
+                  {!n.leida && <span className="w-2 h-2 rounded-full bg-brand-blue flex-shrink-0" aria-label="Sin leer" />}
                 </div>
                 <p className="text-xs text-gray-500 mt-0.5 line-clamp-1">{n.mensaje}</p>
                 <p className="text-xs text-gray-400 mt-1">
@@ -81,7 +81,7 @@ export default async function ContenidoNotificacionesPage() {
                   {' | '}{n.createdAt.toLocaleDateString('es-AR', { day: '2-digit', month: '2-digit', year: '2-digit' })}
                 </p>
               </div>
-              <span className={`text-xs font-medium px-2.5 py-1 rounded-full flex-shrink-0 ${n.leida ? 'bg-gray-100 text-gray-500' : 'bg-blue-100 text-blue-700'}`}>
+              <span className={`text-xs font-medium px-2.5 py-1 rounded-full flex-shrink-0 ${n.leida ? 'bg-gray-100 text-gray-500' : 'bg-pastel-blue text-brand-blue-dark'}`}>
                 {n.leida ? 'Leida' : 'Sin leer'}
               </span>
             </div>

--- a/src/app/(contenido)/contenido/notificaciones/page.tsx
+++ b/src/app/(contenido)/contenido/notificaciones/page.tsx
@@ -24,7 +24,7 @@ export default async function ContenidoNotificacionesPage() {
     <div className="max-w-4xl mx-auto">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Notificaciones</h1>
+          <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Notificaciones</h1>
           <p className="text-gray-500 text-sm">Envio de comunicaciones a talleres</p>
         </div>
         <NotificacionesClient />

--- a/src/app/(contenido)/contenido/novedades/[id]/editar/page.tsx
+++ b/src/app/(contenido)/contenido/novedades/[id]/editar/page.tsx
@@ -15,7 +15,7 @@ export default async function EditarNovedadPage({ params }: { params: Promise<{ 
         { label: 'Novedades', href: '/contenido/novedades' },
         { label: 'Editar novedad' },
       ]} />
-      <h1 className="font-serif font-bold text-2xl text-brand-blue">Editar novedad</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary">Editar novedad</h1>
       <FormularioNovedad novedad={novedad} />
     </div>
   )

--- a/src/app/(contenido)/contenido/novedades/[id]/editar/page.tsx
+++ b/src/app/(contenido)/contenido/novedades/[id]/editar/page.tsx
@@ -15,7 +15,7 @@ export default async function EditarNovedadPage({ params }: { params: Promise<{ 
         { label: 'Novedades', href: '/contenido/novedades' },
         { label: 'Editar novedad' },
       ]} />
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue">Editar novedad</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue">Editar novedad</h1>
       <FormularioNovedad novedad={novedad} />
     </div>
   )

--- a/src/app/(contenido)/contenido/novedades/formulario-novedad.tsx
+++ b/src/app/(contenido)/contenido/novedades/formulario-novedad.tsx
@@ -205,7 +205,7 @@ export function FormularioNovedad({ novedad }: Props) {
                 const file = e.target.files?.[0]
                 if (file) await handleUpload(file)
               }}
-              className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-overpass file:font-semibold file:bg-blue-50 file:text-brand-blue hover:file:bg-blue-100"
+              className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-overpass file:font-semibold file:bg-pastel-blue file:text-brand-blue hover:file:bg-pastel-blue"
             />
             {uploading && (
               <p className="text-sm text-brand-blue animate-pulse">Subiendo imagen...</p>
@@ -234,7 +234,7 @@ export function FormularioNovedad({ novedad }: Props) {
           <button
             type="submit"
             disabled={loading || uploading}
-            className="px-5 py-2.5 bg-brand-blue text-white rounded-lg font-overpass font-semibold text-sm hover:bg-blue-800 disabled:opacity-50 transition-colors"
+            className="px-5 py-2.5 bg-brand-blue text-white rounded-lg font-overpass font-semibold text-sm hover:bg-brand-blue-dark disabled:opacity-50 transition-colors"
           >
             {loading ? 'Guardando...' : isEdit ? 'Guardar cambios' : 'Crear novedad'}
           </button>

--- a/src/app/(contenido)/contenido/novedades/nueva/page.tsx
+++ b/src/app/(contenido)/contenido/novedades/nueva/page.tsx
@@ -8,7 +8,7 @@ export default function NuevaNovedadPage() {
         { label: 'Novedades', href: '/contenido/novedades' },
         { label: 'Nueva novedad' },
       ]} />
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue">Nueva novedad</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue">Nueva novedad</h1>
       <p className="text-sm text-gray-500">
         La novedad se publicará inmediatamente en el landing.
       </p>

--- a/src/app/(contenido)/contenido/novedades/nueva/page.tsx
+++ b/src/app/(contenido)/contenido/novedades/nueva/page.tsx
@@ -8,7 +8,7 @@ export default function NuevaNovedadPage() {
         { label: 'Novedades', href: '/contenido/novedades' },
         { label: 'Nueva novedad' },
       ]} />
-      <h1 className="font-serif font-bold text-2xl text-brand-blue">Nueva novedad</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary">Nueva novedad</h1>
       <p className="text-sm text-gray-500">
         La novedad se publicará inmediatamente en el landing.
       </p>

--- a/src/app/(contenido)/contenido/novedades/page.tsx
+++ b/src/app/(contenido)/contenido/novedades/page.tsx
@@ -31,7 +31,7 @@ export default async function NovedadesPage() {
 
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="font-serif font-bold text-2xl text-brand-blue">Novedades</h1>
+          <h1 className="font-serif font-bold text-2xl text-ink-primary">Novedades</h1>
           <p className="text-sm text-gray-500 mt-1">Gestionar novedades del landing</p>
         </div>
         <Link

--- a/src/app/(contenido)/contenido/novedades/page.tsx
+++ b/src/app/(contenido)/contenido/novedades/page.tsx
@@ -16,7 +16,7 @@ const TIPO_LABELS: Record<TipoNovedad, string> = {
 
 const TIPO_COLOR: Record<TipoNovedad, string> = {
   NOTICIA: 'bg-green-100 text-green-800',
-  CASO: 'bg-blue-100 text-brand-blue',
+  CASO: 'bg-pastel-blue text-brand-blue',
   INDICADOR: 'bg-purple-100 text-purple-800',
 }
 
@@ -36,7 +36,7 @@ export default async function NovedadesPage() {
         </div>
         <Link
           href="/contenido/novedades/nueva"
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-overpass font-semibold bg-brand-blue hover:bg-blue-800 text-white transition-colors"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-overpass font-semibold bg-brand-blue hover:bg-brand-blue-dark text-white transition-colors"
         >
           <Plus className="w-4 h-4" />
           Nueva novedad
@@ -98,7 +98,7 @@ export default async function NovedadesPage() {
                   <td className="px-4 py-3 text-right">
                     <Link
                       href={`/contenido/novedades/${n.id}/editar`}
-                      className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-brand-blue hover:bg-blue-50 rounded transition-colors"
+                      className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-brand-blue hover:bg-pastel-blue rounded transition-colors"
                     >
                       <Edit className="w-4 h-4" />
                       Editar

--- a/src/app/(contenido)/contenido/novedades/page.tsx
+++ b/src/app/(contenido)/contenido/novedades/page.tsx
@@ -31,7 +31,7 @@ export default async function NovedadesPage() {
 
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="font-overpass font-bold text-2xl text-brand-blue">Novedades</h1>
+          <h1 className="font-serif font-bold text-2xl text-brand-blue">Novedades</h1>
           <p className="text-sm text-gray-500 mt-1">Gestionar novedades del landing</p>
         </div>
         <Link

--- a/src/app/(contenido)/layout.tsx
+++ b/src/app/(contenido)/layout.tsx
@@ -23,7 +23,7 @@ export default async function ContenidoLayout({ children }: { children: React.Re
             <span className="font-overpass font-bold text-lg">Panel de Contenidos</span>
           </div>
           <div className="flex items-center gap-4">
-            <Link href="/" className="text-sm hover:text-blue-200 transition-colors">
+            <Link href="/" className="text-sm hover:text-white/70 transition-colors">
               Volver al sitio
             </Link>
             <LogoutButton />

--- a/src/app/(estado)/estado/auditorias/page.tsx
+++ b/src/app/(estado)/estado/auditorias/page.tsx
@@ -63,7 +63,7 @@ export default async function EstadoAuditoriasPage({
   return (
     <div className="max-w-6xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-1">
-        <h1 className="font-serif font-bold text-2xl text-brand-blue">Auditorias de Formalizacion</h1>
+        <h1 className="font-serif font-bold text-2xl text-ink-primary">Auditorias de Formalizacion</h1>
         <a href={`/api/admin/logs?${exportParams}`} target="_blank" rel="noopener noreferrer">
           <Button size="sm" variant="secondary">
             <Download className="w-4 h-4 mr-1" /> Exportar CSV

--- a/src/app/(estado)/estado/auditorias/page.tsx
+++ b/src/app/(estado)/estado/auditorias/page.tsx
@@ -63,7 +63,7 @@ export default async function EstadoAuditoriasPage({
   return (
     <div className="max-w-6xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-1">
-        <h1 className="font-overpass font-bold text-2xl text-brand-blue">Auditorias de Formalizacion</h1>
+        <h1 className="font-serif font-bold text-2xl text-brand-blue">Auditorias de Formalizacion</h1>
         <a href={`/api/admin/logs?${exportParams}`} target="_blank" rel="noopener noreferrer">
           <Button size="sm" variant="secondary">
             <Download className="w-4 h-4 mr-1" /> Exportar CSV

--- a/src/app/(estado)/estado/configuracion-niveles/page.tsx
+++ b/src/app/(estado)/estado/configuracion-niveles/page.tsx
@@ -112,7 +112,7 @@ export default function EstadoConfiguracionNivelesPage() {
 
   return (
     <div className="max-w-4xl mx-auto py-6 px-4">
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Configuracion de Niveles</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Configuracion de Niveles</h1>
       <p className="text-gray-500 text-sm mb-6">Criterios para que los talleres alcancen cada nivel — configuracion regulatoria del Estado</p>
 
       {loading ? (

--- a/src/app/(estado)/estado/configuracion-niveles/page.tsx
+++ b/src/app/(estado)/estado/configuracion-niveles/page.tsx
@@ -112,7 +112,7 @@ export default function EstadoConfiguracionNivelesPage() {
 
   return (
     <div className="max-w-4xl mx-auto py-6 px-4">
-      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Configuracion de Niveles</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Configuracion de Niveles</h1>
       <p className="text-gray-500 text-sm mb-6">Criterios para que los talleres alcancen cada nivel — configuracion regulatoria del Estado</p>
 
       {loading ? (

--- a/src/app/(estado)/estado/demanda-insatisfecha/page.tsx
+++ b/src/app/(estado)/estado/demanda-insatisfecha/page.tsx
@@ -53,7 +53,7 @@ export default async function DemandaInsatisfechaPage({ searchParams }: PageProp
             { label: 'Demanda insatisfecha', href: '/estado/demanda-insatisfecha' },
             { label: catInfo.label },
           ]} />
-          <h1 className="font-overpass font-bold text-2xl text-brand-blue mt-2">
+          <h1 className="font-serif font-bold text-2xl text-brand-blue mt-2">
             Pedidos sin matchear: {catInfo.label}
           </h1>
           <p className="text-gray-500 text-sm mt-1">
@@ -135,7 +135,7 @@ export default async function DemandaInsatisfechaPage({ searchParams }: PageProp
             { label: 'Demanda insatisfecha', href: '/estado/demanda-insatisfecha' },
             { label: 'Talleres cerca' },
           ]} />
-          <h1 className="font-overpass font-bold text-2xl text-brand-blue mt-2">
+          <h1 className="font-serif font-bold text-2xl text-brand-blue mt-2">
             Talleres cerca de poder matchear
           </h1>
           <p className="text-gray-500 text-sm mt-1">
@@ -193,7 +193,7 @@ export default async function DemandaInsatisfechaPage({ searchParams }: PageProp
     <div className="space-y-8">
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="font-overpass font-bold text-3xl text-brand-blue">
+          <h1 className="font-serif font-bold text-3xl text-brand-blue">
             Demanda insatisfecha
           </h1>
           <p className="text-gray-500 text-sm mt-1">

--- a/src/app/(estado)/estado/demanda-insatisfecha/page.tsx
+++ b/src/app/(estado)/estado/demanda-insatisfecha/page.tsx
@@ -53,7 +53,7 @@ export default async function DemandaInsatisfechaPage({ searchParams }: PageProp
             { label: 'Demanda insatisfecha', href: '/estado/demanda-insatisfecha' },
             { label: catInfo.label },
           ]} />
-          <h1 className="font-serif font-bold text-2xl text-brand-blue mt-2">
+          <h1 className="font-serif font-bold text-2xl text-ink-primary mt-2">
             Pedidos sin matchear: {catInfo.label}
           </h1>
           <p className="text-gray-500 text-sm mt-1">
@@ -135,7 +135,7 @@ export default async function DemandaInsatisfechaPage({ searchParams }: PageProp
             { label: 'Demanda insatisfecha', href: '/estado/demanda-insatisfecha' },
             { label: 'Talleres cerca' },
           ]} />
-          <h1 className="font-serif font-bold text-2xl text-brand-blue mt-2">
+          <h1 className="font-serif font-bold text-2xl text-ink-primary mt-2">
             Talleres cerca de poder matchear
           </h1>
           <p className="text-gray-500 text-sm mt-1">
@@ -193,7 +193,7 @@ export default async function DemandaInsatisfechaPage({ searchParams }: PageProp
     <div className="space-y-8">
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="font-serif font-bold text-3xl text-brand-blue">
+          <h1 className="font-serif font-bold text-3xl text-ink-primary">
             Demanda insatisfecha
           </h1>
           <p className="text-gray-500 text-sm mt-1">

--- a/src/app/(estado)/estado/documentos/page.tsx
+++ b/src/app/(estado)/estado/documentos/page.tsx
@@ -82,7 +82,7 @@ export default function EstadoDocumentosPage() {
   function renderList(title: string, items: TipoDocumento[]) {
     return (
       <div className="mb-6">
-        <h2 className="font-overpass font-bold text-brand-blue mb-2">{title}</h2>
+        <h2 className="font-serif font-bold text-brand-blue mb-2">{title}</h2>
         <Card>
           {items.length === 0 ? (
             <p className="text-sm text-gray-500 py-2">Sin documentos en esta categoria.</p>
@@ -117,7 +117,7 @@ export default function EstadoDocumentosPage() {
     <div className="max-w-4xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Tipos de Documento</h1>
+          <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Tipos de Documento</h1>
           <p className="text-gray-500 text-sm">Requisitos de formalizacion por nivel — configuracion regulatoria del Estado</p>
         </div>
         <Button icon={<Plus className="w-4 h-4" />} onClick={handleNew}>Nuevo Requisito</Button>

--- a/src/app/(estado)/estado/documentos/page.tsx
+++ b/src/app/(estado)/estado/documentos/page.tsx
@@ -117,7 +117,7 @@ export default function EstadoDocumentosPage() {
     <div className="max-w-4xl mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Tipos de Documento</h1>
+          <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Tipos de Documento</h1>
           <p className="text-gray-500 text-sm">Requisitos de formalizacion por nivel — configuracion regulatoria del Estado</p>
         </div>
         <Button icon={<Plus className="w-4 h-4" />} onClick={handleNew}>Nuevo Requisito</Button>

--- a/src/app/(estado)/estado/exportar/page.tsx
+++ b/src/app/(estado)/estado/exportar/page.tsx
@@ -140,7 +140,7 @@ export default function ExportarReportePage() {
       </div>
 
       {/* Informe mensual destacado */}
-      <Card className="border-brand-blue/30 bg-blue-50/30">
+      <Card className="border-brand-blue/30 bg-pastel-blue/30">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
             <h2 className="font-overpass font-bold text-lg text-brand-blue">Informe mensual completo</h2>

--- a/src/app/(estado)/estado/exportar/page.tsx
+++ b/src/app/(estado)/estado/exportar/page.tsx
@@ -135,7 +135,7 @@ export default function ExportarReportePage() {
           { label: 'Estado', href: '/estado' },
           { label: 'Exportar' },
         ]} />
-        <h1 className="font-overpass font-bold text-2xl text-brand-blue">Exportar Reportes</h1>
+        <h1 className="font-serif font-bold text-2xl text-brand-blue">Exportar Reportes</h1>
         <p className="text-gray-500 text-sm mt-1">Genera informes del sector en formato CSV o Excel</p>
       </div>
 
@@ -143,7 +143,7 @@ export default function ExportarReportePage() {
       <Card className="border-brand-blue/30 bg-pastel-blue/30">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
-            <h2 className="font-overpass font-bold text-lg text-brand-blue">Informe mensual completo</h2>
+            <h2 className="font-serif font-bold text-lg text-brand-blue">Informe mensual completo</h2>
             <p className="text-sm text-gray-600 mt-1">
               Plantilla Excel con todas las hojas: talleres, marcas, pedidos, validaciones, demanda insatisfecha y resumen.
               Listo para presentar a OIT.

--- a/src/app/(estado)/estado/exportar/page.tsx
+++ b/src/app/(estado)/estado/exportar/page.tsx
@@ -135,7 +135,7 @@ export default function ExportarReportePage() {
           { label: 'Estado', href: '/estado' },
           { label: 'Exportar' },
         ]} />
-        <h1 className="font-serif font-bold text-2xl text-brand-blue">Exportar Reportes</h1>
+        <h1 className="font-serif font-bold text-2xl text-ink-primary">Exportar Reportes</h1>
         <p className="text-gray-500 text-sm mt-1">Genera informes del sector en formato CSV o Excel</p>
       </div>
 

--- a/src/app/(estado)/estado/page.tsx
+++ b/src/app/(estado)/estado/page.tsx
@@ -86,13 +86,13 @@ export default async function EstadoDashboardPage() {
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="font-overpass font-bold text-3xl text-brand-blue">Dashboard del Sector</h1>
+        <h1 className="font-serif font-bold text-3xl text-brand-blue">Dashboard del Sector</h1>
         <p className="text-gray-500 text-sm mt-1">Monitoreo de la Plataforma Digital Textil</p>
       </div>
 
       {/* ── SECCION 1: Como esta el sector? ── */}
       <div>
-        <h2 className="font-overpass font-bold text-lg text-gray-700 mb-4">Como esta el sector?</h2>
+        <h2 className="font-serif font-bold text-lg text-gray-700 mb-4">Como esta el sector?</h2>
 
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
           <Card className="text-center">
@@ -148,7 +148,7 @@ export default async function EstadoDashboardPage() {
 
       {/* ── SECCION 2: Donde hay que actuar? ── */}
       <div>
-        <h2 className="font-overpass font-bold text-lg text-gray-700 mb-4">Donde hay que actuar?</h2>
+        <h2 className="font-serif font-bold text-lg text-gray-700 mb-4">Donde hay que actuar?</h2>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Card className="border-l-4 border-l-amber-400">
@@ -225,7 +225,7 @@ export default async function EstadoDashboardPage() {
 
       {/* ── SECCION 3: Que esta funcionando? ── */}
       <div>
-        <h2 className="font-overpass font-bold text-lg text-gray-700 mb-4">Que esta funcionando?</h2>
+        <h2 className="font-serif font-bold text-lg text-gray-700 mb-4">Que esta funcionando?</h2>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Card className="border-l-4 border-l-green-400">

--- a/src/app/(estado)/estado/page.tsx
+++ b/src/app/(estado)/estado/page.tsx
@@ -86,7 +86,7 @@ export default async function EstadoDashboardPage() {
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="font-serif font-bold text-3xl text-brand-blue">Dashboard del Sector</h1>
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">Dashboard del Sector</h1>
         <p className="text-gray-500 text-sm mt-1">Monitoreo de la Plataforma Digital Textil</p>
       </div>
 

--- a/src/app/(estado)/estado/page.tsx
+++ b/src/app/(estado)/estado/page.tsx
@@ -245,7 +245,7 @@ export default async function EstadoDashboardPage() {
                 <p className="text-2xl font-bold text-gray-800">{subieronNivelMes}</p>
                 <p className="text-sm text-gray-500">Subieron de nivel este mes</p>
               </div>
-              <TrendingUp className="w-8 h-8 text-blue-400" />
+              <TrendingUp className="w-8 h-8 text-brand-blue/70" />
             </div>
           </Card>
 
@@ -268,7 +268,7 @@ export default async function EstadoDashboardPage() {
             },
             NIVEL_SUBIDO: {
               texto: 'subio de nivel',
-              icono: <TrendingUp className="w-4 h-4 text-blue-500 shrink-0" />,
+              icono: <TrendingUp className="w-4 h-4 text-brand-blue shrink-0" />,
             },
             NIVEL_BAJADO: {
               texto: 'bajo de nivel',

--- a/src/app/(estado)/estado/sector/page.tsx
+++ b/src/app/(estado)/estado/sector/page.tsx
@@ -149,7 +149,7 @@ export default async function DiagnosticoSectorPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-3xl font-bold font-overpass text-brand-blue">Datos sectoriales</h1>
+        <h1 className="text-3xl font-bold font-serif text-brand-blue">Datos sectoriales</h1>
         <p className="text-gray-500 mt-1">Datos productivos agregados de los talleres registrados</p>
         <p className="text-xs text-gray-400 mt-1">
           Basado en el perfil productivo completado por cada taller.

--- a/src/app/(estado)/estado/sector/page.tsx
+++ b/src/app/(estado)/estado/sector/page.tsx
@@ -149,7 +149,7 @@ export default async function DiagnosticoSectorPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-3xl font-bold font-serif text-brand-blue">Datos sectoriales</h1>
+        <h1 className="text-3xl font-bold font-serif text-ink-primary">Datos sectoriales</h1>
         <p className="text-gray-500 mt-1">Datos productivos agregados de los talleres registrados</p>
         <p className="text-xs text-gray-400 mt-1">
           Basado en el perfil productivo completado por cada taller.

--- a/src/app/(estado)/estado/talleres/[id]/page.tsx
+++ b/src/app/(estado)/estado/talleres/[id]/page.tsx
@@ -209,7 +209,7 @@ export default async function EstadoDetalleTallerPage({ params, searchParams }: 
             {taller.nombre.charAt(0)}
           </div>
           <div className="flex-1">
-            <h1 className="font-serif font-bold text-xl text-brand-blue">{taller.nombre}</h1>
+            <h1 className="font-serif font-bold text-xl text-ink-primary">{taller.nombre}</h1>
             <div className="flex items-center gap-2 mt-0.5">
               <p className="text-sm text-gray-500">CUIT: {taller.cuit}</p>
               <BadgeArca verificado={taller.verificadoAfip} fecha={taller.verificadoAfipAt} />

--- a/src/app/(estado)/estado/talleres/[id]/page.tsx
+++ b/src/app/(estado)/estado/talleres/[id]/page.tsx
@@ -209,7 +209,7 @@ export default async function EstadoDetalleTallerPage({ params, searchParams }: 
             {taller.nombre.charAt(0)}
           </div>
           <div className="flex-1">
-            <h1 className="font-overpass font-bold text-xl text-brand-blue">{taller.nombre}</h1>
+            <h1 className="font-serif font-bold text-xl text-brand-blue">{taller.nombre}</h1>
             <div className="flex items-center gap-2 mt-0.5">
               <p className="text-sm text-gray-500">CUIT: {taller.cuit}</p>
               <BadgeArca verificado={taller.verificadoAfip} fecha={taller.verificadoAfipAt} />
@@ -250,7 +250,7 @@ export default async function EstadoDetalleTallerPage({ params, searchParams }: 
       {/* Tab: Formalizacion */}
       {tab === 'formalizacion' && (
         <Card>
-          <h2 className="font-overpass font-bold text-brand-blue mb-3">Checklist de Formalizacion</h2>
+          <h2 className="font-serif font-bold text-brand-blue mb-3">Checklist de Formalizacion</h2>
           <div className="divide-y divide-gray-100">
             {taller.validaciones.map(v => (
               <div key={v.id} className="py-3 first:pt-0 last:pb-0">
@@ -347,7 +347,7 @@ export default async function EstadoDetalleTallerPage({ params, searchParams }: 
       {/* Tab: Historial */}
       {tab === 'historial' && (
         <Card>
-          <h2 className="font-overpass font-bold text-brand-blue mb-3">Historial de decisiones</h2>
+          <h2 className="font-serif font-bold text-brand-blue mb-3">Historial de decisiones</h2>
           {historialLogs.length === 0 ? (
             <p className="text-sm text-gray-500">Sin decisiones registradas.</p>
           ) : (
@@ -389,7 +389,7 @@ export default async function EstadoDetalleTallerPage({ params, searchParams }: 
       {/* Tab: Datos del taller (solo lectura) */}
       {tab === 'datos' && (
         <Card>
-          <h2 className="font-overpass font-bold text-brand-blue mb-3">Datos del Taller</h2>
+          <h2 className="font-serif font-bold text-brand-blue mb-3">Datos del Taller</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
             <div>
               <p className="text-gray-500">Responsable</p>

--- a/src/app/(estado)/estado/talleres/[id]/page.tsx
+++ b/src/app/(estado)/estado/talleres/[id]/page.tsx
@@ -197,7 +197,7 @@ export default async function EstadoDetalleTallerPage({ params, searchParams }: 
       ]} />
 
       {soloLectura && (
-        <div className="mb-4 rounded-lg bg-blue-50 border border-blue-200 px-4 py-3 text-sm text-blue-700">
+        <div className="mb-4 rounded-lg bg-pastel-blue border border-brand-blue/30 px-4 py-3 text-sm text-brand-blue-dark">
           Modo lectura — las acciones de formalizacion son responsabilidad del Estado.
         </div>
       )}

--- a/src/app/(estado)/estado/talleres/page.tsx
+++ b/src/app/(estado)/estado/talleres/page.tsx
@@ -56,7 +56,7 @@ export default async function EstadoTalleresPage({
 
   return (
     <div className="max-w-5xl mx-auto py-6 px-4">
-      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Talleres</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Talleres</h1>
       <p className="text-gray-500 text-sm mb-6">Vista regulatoria — estado de formalización y documentación</p>
 
       <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">

--- a/src/app/(estado)/estado/talleres/page.tsx
+++ b/src/app/(estado)/estado/talleres/page.tsx
@@ -56,7 +56,7 @@ export default async function EstadoTalleresPage({
 
   return (
     <div className="max-w-5xl mx-auto py-6 px-4">
-      <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">Talleres</h1>
+      <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">Talleres</h1>
       <p className="text-gray-500 text-sm mb-6">Vista regulatoria — estado de formalización y documentación</p>
 
       <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">

--- a/src/app/(marca)/marca/directorio/[id]/page.tsx
+++ b/src/app/(marca)/marca/directorio/[id]/page.tsx
@@ -53,7 +53,7 @@ export default async function TallerPerfilMarcaPage({ params }: { params: Promis
             <span className="font-overpass font-bold text-brand-blue text-xl">{taller.nombre.charAt(0)}</span>
           </div>
           <div className="flex-1">
-            <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">{taller.nombre}</h1>
+            <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">{taller.nombre}</h1>
             {(taller.verificadoAfip || taller.validaciones.length > 0) && (
               <div className="flex flex-wrap items-center gap-2 mb-1">
                 {taller.verificadoAfip && (

--- a/src/app/(marca)/marca/directorio/[id]/page.tsx
+++ b/src/app/(marca)/marca/directorio/[id]/page.tsx
@@ -53,7 +53,7 @@ export default async function TallerPerfilMarcaPage({ params }: { params: Promis
             <span className="font-overpass font-bold text-brand-blue text-xl">{taller.nombre.charAt(0)}</span>
           </div>
           <div className="flex-1">
-            <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-1">{taller.nombre}</h1>
+            <h1 className="font-serif font-bold text-2xl text-brand-blue mb-1">{taller.nombre}</h1>
             {(taller.verificadoAfip || taller.validaciones.length > 0) && (
               <div className="flex flex-wrap items-center gap-2 mb-1">
                 {taller.verificadoAfip && (

--- a/src/app/(marca)/marca/directorio/[id]/page.tsx
+++ b/src/app/(marca)/marca/directorio/[id]/page.tsx
@@ -88,7 +88,7 @@ export default async function TallerPerfilMarcaPage({ params }: { params: Promis
         <Card className="text-center p-3"><Star className="w-5 h-5 text-yellow-500 mx-auto mb-1" /><p className="font-bold text-lg">{taller.rating.toFixed(1)}</p><p className="text-xs text-gray-500">Rating</p></Card>
         <Card className="text-center p-3"><Users className="w-5 h-5 text-brand-blue mx-auto mb-1" /><p className="font-bold text-lg">{taller.trabajadoresRegistrados}</p><p className="text-xs text-gray-500">Trabajadores</p></Card>
         <Card className="text-center p-3"><TrendingUp className="w-5 h-5 text-green-600 mx-auto mb-1" /><p className="font-bold text-lg">{taller.capacidadMensual.toLocaleString()}</p><p className="text-xs text-gray-500">Cap/mes</p></Card>
-        <Card className="text-center p-3"><Clock className="w-5 h-5 text-blue-500 mx-auto mb-1" /><p className="font-bold text-lg">{taller.ontimeRate}%</p><p className="text-xs text-gray-500">On-time</p></Card>
+        <Card className="text-center p-3"><Clock className="w-5 h-5 text-brand-blue mx-auto mb-1" /><p className="font-bold text-lg">{taller.ontimeRate}%</p><p className="text-xs text-gray-500">On-time</p></Card>
       </div>
 
       {taller.procesos.length > 0 && (

--- a/src/app/(marca)/marca/directorio/page.tsx
+++ b/src/app/(marca)/marca/directorio/page.tsx
@@ -86,7 +86,7 @@ export default async function DirectorioPage({
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="font-serif font-bold text-3xl text-brand-blue">
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">
           Explorar Proveedores
         </h1>
         <p className="text-gray-600 mt-2">

--- a/src/app/(marca)/marca/directorio/page.tsx
+++ b/src/app/(marca)/marca/directorio/page.tsx
@@ -86,7 +86,7 @@ export default async function DirectorioPage({
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="font-overpass font-bold text-3xl text-brand-blue">
+        <h1 className="font-serif font-bold text-3xl text-brand-blue">
           Explorar Proveedores
         </h1>
         <p className="text-gray-600 mt-2">

--- a/src/app/(marca)/marca/page.tsx
+++ b/src/app/(marca)/marca/page.tsx
@@ -106,8 +106,8 @@ export default async function MarcaDashboardPage() {
       </div>
 
       {cotizacionesRecibidas > 0 && (
-        <div className="p-4 bg-blue-50 border border-blue-200 rounded-xl">
-          <p className="text-sm font-medium text-blue-800">
+        <div className="p-4 bg-pastel-blue border border-brand-blue/30 rounded-xl">
+          <p className="text-sm font-medium text-brand-blue-dark">
             Tenés {cotizacionesRecibidas} cotización{cotizacionesRecibidas > 1 ? 'es' : ''} pendiente{cotizacionesRecibidas > 1 ? 's' : ''} de revisión
           </p>
           <Link href="/marca/pedidos" className="text-xs text-brand-blue font-semibold hover:underline mt-1 block">

--- a/src/app/(marca)/marca/page.tsx
+++ b/src/app/(marca)/marca/page.tsx
@@ -39,7 +39,7 @@ export default async function MarcaDashboardPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="font-serif font-bold text-3xl text-brand-blue">
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">
           Bienvenido, {marca?.nombre ?? session.user.name}
         </h1>
         <p className="text-gray-500 mt-1">Tu panel de gestión de producción</p>

--- a/src/app/(marca)/marca/page.tsx
+++ b/src/app/(marca)/marca/page.tsx
@@ -39,7 +39,7 @@ export default async function MarcaDashboardPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="font-overpass font-bold text-3xl text-brand-blue">
+        <h1 className="font-serif font-bold text-3xl text-brand-blue">
           Bienvenido, {marca?.nombre ?? session.user.name}
         </h1>
         <p className="text-gray-500 mt-1">Tu panel de gestión de producción</p>

--- a/src/app/(marca)/marca/pedidos/[id]/page.tsx
+++ b/src/app/(marca)/marca/pedidos/[id]/page.tsx
@@ -131,7 +131,7 @@ export default async function MarcaPedidoDetallePage({ params }: { params: Promi
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
         <div>
-          <h1 className="font-serif font-bold text-3xl text-brand-blue">{pedido.omId}</h1>
+          <h1 className="font-serif font-bold text-3xl text-ink-primary">{pedido.omId}</h1>
           <p className="text-gray-600 mt-1">{pedido.tipoPrenda} - {pedido.cantidad.toLocaleString()} unidades</p>
           <p className="text-sm text-gray-400 mt-1">
             Creado: {new Date(pedido.createdAt).toLocaleDateString('es-AR')}

--- a/src/app/(marca)/marca/pedidos/[id]/page.tsx
+++ b/src/app/(marca)/marca/pedidos/[id]/page.tsx
@@ -131,7 +131,7 @@ export default async function MarcaPedidoDetallePage({ params }: { params: Promi
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
         <div>
-          <h1 className="font-overpass font-bold text-3xl text-brand-blue">{pedido.omId}</h1>
+          <h1 className="font-serif font-bold text-3xl text-brand-blue">{pedido.omId}</h1>
           <p className="text-gray-600 mt-1">{pedido.tipoPrenda} - {pedido.cantidad.toLocaleString()} unidades</p>
           <p className="text-sm text-gray-400 mt-1">
             Creado: {new Date(pedido.createdAt).toLocaleDateString('es-AR')}
@@ -365,7 +365,7 @@ export default async function MarcaPedidoDetallePage({ params }: { params: Promi
       {/* Contacto talleres asignados */}
       {pedido.ordenes.length > 0 && (
         <Card>
-          <h2 className="font-overpass font-semibold text-gray-700 text-sm uppercase mb-3">
+          <h2 className="font-serif font-semibold text-gray-700 text-sm uppercase mb-3">
             Contacto talleres
           </h2>
           <div className="space-y-3">
@@ -396,7 +396,7 @@ export default async function MarcaPedidoDetallePage({ params }: { params: Promi
 
       {actividad.length > 0 && (
         <Card>
-          <h2 className="font-overpass font-bold text-brand-blue mb-3">Actividad del pedido</h2>
+          <h2 className="font-serif font-bold text-brand-blue mb-3">Actividad del pedido</h2>
           <ActivityTimeline eventos={actividad} perspective="marca" />
         </Card>
       )}

--- a/src/app/(marca)/marca/pedidos/[id]/page.tsx
+++ b/src/app/(marca)/marca/pedidos/[id]/page.tsx
@@ -205,7 +205,7 @@ export default async function MarcaPedidoDetallePage({ params }: { params: Promi
           <p className="text-xs text-gray-500">Monto total</p>
         </Card>
         <Card className="text-center p-4">
-          <Clock className="w-5 h-5 text-blue-500 mx-auto mb-1" />
+          <Clock className="w-5 h-5 text-brand-blue mx-auto mb-1" />
           <p className="font-overpass font-bold text-lg">
             {pedido.fechaObjetivo
               ? new Date(pedido.fechaObjetivo).toLocaleDateString('es-AR')

--- a/src/app/(marca)/marca/pedidos/nuevo/nuevo-pedido-form.tsx
+++ b/src/app/(marca)/marca/pedidos/nuevo/nuevo-pedido-form.tsx
@@ -73,7 +73,7 @@ export function NuevoPedidoForm({ marcaId, procesos }: Props) {
     <div className="max-w-3xl mx-auto space-y-6">
       <div className="flex items-center justify-between gap-3">
         <div>
-          <h1 className="font-overpass font-bold text-3xl text-brand-blue">Nuevo Pedido</h1>
+          <h1 className="font-serif font-bold text-3xl text-brand-blue">Nuevo Pedido</h1>
           <p className="text-gray-600 mt-2">Crea una orden para iniciar tu flujo de produccion.</p>
         </div>
         <Link

--- a/src/app/(marca)/marca/pedidos/nuevo/nuevo-pedido-form.tsx
+++ b/src/app/(marca)/marca/pedidos/nuevo/nuevo-pedido-form.tsx
@@ -73,7 +73,7 @@ export function NuevoPedidoForm({ marcaId, procesos }: Props) {
     <div className="max-w-3xl mx-auto space-y-6">
       <div className="flex items-center justify-between gap-3">
         <div>
-          <h1 className="font-serif font-bold text-3xl text-brand-blue">Nuevo Pedido</h1>
+          <h1 className="font-serif font-bold text-3xl text-ink-primary">Nuevo Pedido</h1>
           <p className="text-gray-600 mt-2">Crea una orden para iniciar tu flujo de produccion.</p>
         </div>
         <Link

--- a/src/app/(marca)/marca/pedidos/page.tsx
+++ b/src/app/(marca)/marca/pedidos/page.tsx
@@ -82,7 +82,7 @@ async function PedidosContent({ query, estado, created }: { query: string; estad
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="font-overpass font-bold text-3xl text-brand-blue">Mis Pedidos</h1>
+        <h1 className="font-serif font-bold text-3xl text-brand-blue">Mis Pedidos</h1>
         <p className="text-gray-600 mt-2">Seguimiento de pedidos de {marca.nombre}</p>
       </div>
 

--- a/src/app/(marca)/marca/pedidos/page.tsx
+++ b/src/app/(marca)/marca/pedidos/page.tsx
@@ -82,7 +82,7 @@ async function PedidosContent({ query, estado, created }: { query: string; estad
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="font-serif font-bold text-3xl text-brand-blue">Mis Pedidos</h1>
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mis Pedidos</h1>
         <p className="text-gray-600 mt-2">Seguimiento de pedidos de {marca.nombre}</p>
       </div>
 

--- a/src/app/(marca)/marca/perfil/page.tsx
+++ b/src/app/(marca)/marca/perfil/page.tsx
@@ -69,7 +69,7 @@ export default async function MarcaPerfilPage() {
   if (!marca) {
     return (
       <div className="space-y-6">
-        <h1 className="font-serif font-bold text-3xl text-brand-blue">Mi Perfil de Marca</h1>
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi Perfil de Marca</h1>
         <div className="bg-white rounded-xl shadow-sm p-6 border border-gray-200">
           <p className="text-gray-700">No encontramos datos de marca para este usuario.</p>
         </div>
@@ -80,7 +80,7 @@ export default async function MarcaPerfilPage() {
   return (
     <div className="space-y-6">
       <Suspense><SaveToast message="Perfil actualizado" /></Suspense>
-      <h1 className="font-serif font-bold text-3xl text-brand-blue">Mi Perfil de Marca</h1>
+      <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi Perfil de Marca</h1>
 
       <div className="grid gap-4 sm:grid-cols-3">
         <div className="bg-white rounded-xl border border-gray-200 p-4">

--- a/src/app/(marca)/marca/perfil/page.tsx
+++ b/src/app/(marca)/marca/perfil/page.tsx
@@ -69,7 +69,7 @@ export default async function MarcaPerfilPage() {
   if (!marca) {
     return (
       <div className="space-y-6">
-        <h1 className="font-overpass font-bold text-3xl text-brand-blue">Mi Perfil de Marca</h1>
+        <h1 className="font-serif font-bold text-3xl text-brand-blue">Mi Perfil de Marca</h1>
         <div className="bg-white rounded-xl shadow-sm p-6 border border-gray-200">
           <p className="text-gray-700">No encontramos datos de marca para este usuario.</p>
         </div>
@@ -80,7 +80,7 @@ export default async function MarcaPerfilPage() {
   return (
     <div className="space-y-6">
       <Suspense><SaveToast message="Perfil actualizado" /></Suspense>
-      <h1 className="font-overpass font-bold text-3xl text-brand-blue">Mi Perfil de Marca</h1>
+      <h1 className="font-serif font-bold text-3xl text-brand-blue">Mi Perfil de Marca</h1>
 
       <div className="grid gap-4 sm:grid-cols-3">
         <div className="bg-white rounded-xl border border-gray-200 p-4">

--- a/src/app/(taller)/taller/aprender/[id]/page.tsx
+++ b/src/app/(taller)/taller/aprender/[id]/page.tsx
@@ -56,7 +56,7 @@ export default async function AcademiaDetallePage({
       ]} />
 
       <div className="mt-2">
-        <h1 className="font-overpass font-bold text-2xl text-brand-blue">{coleccion.titulo}</h1>
+        <h1 className="font-serif font-bold text-2xl text-brand-blue">{coleccion.titulo}</h1>
         {coleccion.institucion && (
           <p className="text-sm text-gray-500 mt-0.5">Contenido curado por {coleccion.institucion}</p>
         )}

--- a/src/app/(taller)/taller/aprender/[id]/page.tsx
+++ b/src/app/(taller)/taller/aprender/[id]/page.tsx
@@ -56,7 +56,7 @@ export default async function AcademiaDetallePage({
       ]} />
 
       <div className="mt-2">
-        <h1 className="font-serif font-bold text-2xl text-brand-blue">{coleccion.titulo}</h1>
+        <h1 className="font-serif font-bold text-2xl text-ink-primary">{coleccion.titulo}</h1>
         {coleccion.institucion && (
           <p className="text-sm text-gray-500 mt-0.5">Contenido curado por {coleccion.institucion}</p>
         )}

--- a/src/app/(taller)/taller/aprender/page.tsx
+++ b/src/app/(taller)/taller/aprender/page.tsx
@@ -41,7 +41,7 @@ export default async function TallerAprenderPage() {
     <div className="space-y-6">
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="font-overpass font-bold text-3xl text-brand-blue">Academia</h1>
+          <h1 className="font-serif font-bold text-3xl text-brand-blue">Academia</h1>
           <p className="text-gray-500 mt-1">Cursos gratuitos para mejorar tu taller y ganar puntos de formalización.</p>
         </div>
       </div>
@@ -81,7 +81,7 @@ export default async function TallerAprenderPage() {
               <div className="flex items-start justify-between">
                 <div className="flex-1">
                   <div className="flex items-center gap-2 mb-1">
-                    <h2 className="font-overpass font-bold text-lg text-brand-blue">{col.titulo}</h2>
+                    <h2 className="font-serif font-bold text-lg text-brand-blue">{col.titulo}</h2>
                     {certificado && !certificado.revocado && (
                       <Badge variant="success">Certificado</Badge>
                     )}

--- a/src/app/(taller)/taller/aprender/page.tsx
+++ b/src/app/(taller)/taller/aprender/page.tsx
@@ -41,7 +41,7 @@ export default async function TallerAprenderPage() {
     <div className="space-y-6">
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="font-serif font-bold text-3xl text-brand-blue">Academia</h1>
+          <h1 className="font-serif font-bold text-3xl text-ink-primary">Academia</h1>
           <p className="text-gray-500 mt-1">Cursos gratuitos para mejorar tu taller y ganar puntos de formalización.</p>
         </div>
       </div>

--- a/src/app/(taller)/taller/formalizacion/page.tsx
+++ b/src/app/(taller)/taller/formalizacion/page.tsx
@@ -33,7 +33,7 @@ export default async function TallerFormalizacionPage() {
   if (!taller) {
     return (
       <div className="space-y-6">
-        <h1 className="font-overpass font-bold text-3xl text-brand-blue">Mi Formalización</h1>
+        <h1 className="font-serif font-bold text-3xl text-brand-blue">Mi Formalización</h1>
         <Card className="text-center py-12">
           <p className="text-gray-600 mb-4">Primero completá tu perfil para ver tu checklist de formalización.</p>
           <Link href="/taller/perfil/completar"><Button>Completar Perfil</Button></Link>
@@ -64,7 +64,7 @@ export default async function TallerFormalizacionPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="font-overpass font-bold text-3xl text-brand-blue">Mi Formalización</h1>
+      <h1 className="font-serif font-bold text-3xl text-brand-blue">Mi Formalización</h1>
 
       {/* Resumen */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/src/app/(taller)/taller/formalizacion/page.tsx
+++ b/src/app/(taller)/taller/formalizacion/page.tsx
@@ -33,7 +33,7 @@ export default async function TallerFormalizacionPage() {
   if (!taller) {
     return (
       <div className="space-y-6">
-        <h1 className="font-serif font-bold text-3xl text-brand-blue">Mi Formalización</h1>
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi Formalización</h1>
         <Card className="text-center py-12">
           <p className="text-gray-600 mb-4">Primero completá tu perfil para ver tu checklist de formalización.</p>
           <Link href="/taller/perfil/completar"><Button>Completar Perfil</Button></Link>
@@ -64,7 +64,7 @@ export default async function TallerFormalizacionPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="font-serif font-bold text-3xl text-brand-blue">Mi Formalización</h1>
+      <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi Formalización</h1>
 
       {/* Resumen */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/src/app/(taller)/taller/page.tsx
+++ b/src/app/(taller)/taller/page.tsx
@@ -171,7 +171,7 @@ export default async function TallerDashboardPage() {
     <div className="space-y-6">
       {/* Encabezado */}
       <div>
-        <h1 className="font-overpass font-bold text-3xl text-brand-blue">
+        <h1 className="font-serif font-bold text-3xl text-brand-blue">
           Bienvenido, {taller?.nombre ?? session.user.name}
         </h1>
         <p className="text-gray-500 mt-1">
@@ -300,7 +300,7 @@ export default async function TallerDashboardPage() {
       {/* Historial de nivel */}
       {historialNiveles.length > 1 && (
         <div className="bg-white rounded-xl border border-gray-100 p-6">
-          <h2 className="font-overpass font-bold text-gray-800 mb-4">Historial de nivel</h2>
+          <h2 className="font-serif font-bold text-gray-800 mb-4">Historial de nivel</h2>
           <div className="space-y-2">
             {historialNiveles.map(log => {
               const detalles = log.detalles as { nivelAnterior?: string; nivelNuevo?: string }
@@ -330,7 +330,7 @@ export default async function TallerDashboardPage() {
 
       {/* Acciones rápidas */}
       <div>
-        <h2 className="font-overpass font-bold text-lg text-gray-800 mb-3">Acciones rápidas</h2>
+        <h2 className="font-serif font-bold text-lg text-gray-800 mb-3">Acciones rápidas</h2>
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
           <Link
             href="/taller/perfil/completar"
@@ -363,7 +363,7 @@ export default async function TallerDashboardPage() {
       {taller && taller.ordenesManufactura.length > 0 && (
         <div>
           <div className="flex items-center justify-between mb-3">
-            <h2 className="font-overpass font-bold text-lg text-gray-800">Pedidos activos</h2>
+            <h2 className="font-serif font-bold text-lg text-gray-800">Pedidos activos</h2>
             <Link href="/taller/pedidos" className="text-sm text-brand-blue hover:underline">
               Ver todos →
             </Link>
@@ -398,7 +398,7 @@ export default async function TallerDashboardPage() {
       {coleccionesRecomendadas.length > 0 && (
         <div>
           <div className="flex items-center justify-between mb-3">
-            <h2 className="font-overpass font-bold text-lg text-gray-800">
+            <h2 className="font-serif font-bold text-lg text-gray-800">
               Capacitaciones recomendadas
             </h2>
             <Link href="/taller/aprender" className="text-sm text-brand-blue hover:underline">

--- a/src/app/(taller)/taller/page.tsx
+++ b/src/app/(taller)/taller/page.tsx
@@ -171,7 +171,7 @@ export default async function TallerDashboardPage() {
     <div className="space-y-6">
       {/* Encabezado */}
       <div>
-        <h1 className="font-serif font-bold text-3xl text-brand-blue">
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">
           Bienvenido, {taller?.nombre ?? session.user.name}
         </h1>
         <p className="text-gray-500 mt-1">

--- a/src/app/(taller)/taller/page.tsx
+++ b/src/app/(taller)/taller/page.tsx
@@ -382,7 +382,7 @@ export default async function TallerDashboardPage() {
                 <span
                   className={`text-xs font-semibold px-3 py-1 rounded-full ${
                     orden.estado === 'EN_EJECUCION'
-                      ? 'bg-blue-100 text-blue-700'
+                      ? 'bg-pastel-blue text-brand-blue-dark'
                       : 'bg-yellow-100 text-yellow-700'
                   }`}
                 >

--- a/src/app/(taller)/taller/page.tsx
+++ b/src/app/(taller)/taller/page.tsx
@@ -181,7 +181,7 @@ export default async function TallerDashboardPage() {
 
       {/* Banner taller no verificado */}
       {taller && !taller.verificadoAfip && (
-        <div className="border-l-4 border-l-amber-400 bg-amber-50 rounded-xl p-4">
+        <div className="border-l-4 border-l-amber-400 bg-amber-50 rounded-card p-4">
           <p className="font-overpass font-bold text-amber-800 mb-1">
             Tu taller esta en proceso de formalizacion
           </p>
@@ -200,7 +200,7 @@ export default async function TallerDashboardPage() {
       {/* Banner de cambio de nivel */}
       {cambioNivel && cambioNivel.nivelNuevo && (
         cambioNivel.accion === 'NIVEL_SUBIDO' ? (
-          <div className="border-l-4 border-l-green-500 bg-green-50 rounded-xl p-4 flex items-center gap-3">
+          <div className="border-l-4 border-l-green-500 bg-green-50 rounded-card p-4 flex items-center gap-3">
             <span className="text-2xl">
               {cambioNivel.nivelNuevo === 'ORO' ? '🥇' : '🥈'}
             </span>
@@ -214,7 +214,7 @@ export default async function TallerDashboardPage() {
             </div>
           </div>
         ) : (
-          <div className="border-l-4 border-l-amber-500 bg-amber-50 rounded-xl p-4 flex items-center gap-3">
+          <div className="border-l-4 border-l-amber-500 bg-amber-50 rounded-card p-4 flex items-center gap-3">
             <span className="text-2xl">⚠️</span>
             <div>
               <p className="font-overpass font-bold text-amber-800">
@@ -243,7 +243,7 @@ export default async function TallerDashboardPage() {
       {/* Progreso principal */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {/* Ring formalización */}
-        <div className="bg-white rounded-xl shadow-sm p-6 border border-gray-100">
+        <div className="bg-white rounded-card shadow-card p-6 border border-gray-100">
           <h3 className="font-overpass font-semibold text-gray-700 text-sm uppercase mb-4">
             Progreso de Formalización
           </h3>
@@ -276,21 +276,21 @@ export default async function TallerDashboardPage() {
 
         {/* Stats secundarios */}
         <div className="grid grid-cols-2 gap-4">
-          <div className="bg-white rounded-xl shadow-sm p-5 border border-gray-100">
+          <div className="bg-white rounded-card shadow-card p-5 border border-gray-100">
             <p className="text-xs uppercase text-gray-500 font-semibold mb-1">Formalización</p>
             <p className="text-3xl font-bold text-brand-blue">{completadas}/{totalValidaciones}</p>
             <p className="text-xs text-gray-400 mt-1">documentos completados</p>
           </div>
-          <div className="bg-white rounded-xl shadow-sm p-5 border border-gray-100">
+          <div className="bg-white rounded-card shadow-card p-5 border border-gray-100">
             <p className="text-xs uppercase text-gray-500 font-semibold mb-1">Capacidad</p>
             <p className="text-3xl font-bold text-green-600">{taller?.capacidadMensual ?? 0}</p>
             <p className="text-xs text-gray-400 mt-1">prendas/mes</p>
           </div>
-          <div className="bg-white rounded-xl shadow-sm p-5 border border-gray-100">
+          <div className="bg-white rounded-card shadow-card p-5 border border-gray-100">
             <p className="text-xs uppercase text-gray-500 font-semibold mb-1">Certificados</p>
             <p className="text-3xl font-bold text-brand-blue">{taller?.certificados.length ?? 0}</p>
           </div>
-          <div className="bg-white rounded-xl shadow-sm p-5 border border-gray-100">
+          <div className="bg-white rounded-card shadow-card p-5 border border-gray-100">
             <p className="text-xs uppercase text-gray-500 font-semibold mb-1">Pedidos activos</p>
             <p className="text-3xl font-bold text-gray-700">{taller?.ordenesManufactura.length ?? 0}</p>
           </div>
@@ -299,7 +299,7 @@ export default async function TallerDashboardPage() {
 
       {/* Historial de nivel */}
       {historialNiveles.length > 1 && (
-        <div className="bg-white rounded-xl border border-gray-100 p-6">
+        <div className="bg-white rounded-card border border-gray-100 p-6">
           <h2 className="font-serif font-bold text-gray-800 mb-4">Historial de nivel</h2>
           <div className="space-y-2">
             {historialNiveles.map(log => {
@@ -334,7 +334,7 @@ export default async function TallerDashboardPage() {
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
           <Link
             href="/taller/perfil/completar"
-            className="flex flex-col items-center gap-2 bg-white rounded-xl p-5 border border-gray-100 shadow-sm hover:shadow-md hover:border-brand-blue transition-all text-center"
+            className="flex flex-col items-center gap-2 bg-white rounded-card p-5 border border-gray-100 shadow-card hover:shadow-md hover:border-brand-blue transition-all text-center"
           >
             <span className="text-3xl">📝</span>
             <span className="font-overpass font-semibold text-gray-700">{taller?.sam ? 'Actualizar mi perfil' : 'Completar mi perfil'}</span>
@@ -342,7 +342,7 @@ export default async function TallerDashboardPage() {
           </Link>
           <Link
             href="/taller/aprender"
-            className="flex flex-col items-center gap-2 bg-white rounded-xl p-5 border border-gray-100 shadow-sm hover:shadow-md hover:border-brand-blue transition-all text-center"
+            className="flex flex-col items-center gap-2 bg-white rounded-card p-5 border border-gray-100 shadow-card hover:shadow-md hover:border-brand-blue transition-all text-center"
           >
             <span className="text-3xl">📚</span>
             <span className="font-overpass font-semibold text-gray-700">Ver cursos disponibles</span>
@@ -350,7 +350,7 @@ export default async function TallerDashboardPage() {
           </Link>
           <Link
             href="/directorio"
-            className="flex flex-col items-center gap-2 bg-white rounded-xl p-5 border border-gray-100 shadow-sm hover:shadow-md hover:border-brand-blue transition-all text-center"
+            className="flex flex-col items-center gap-2 bg-white rounded-card p-5 border border-gray-100 shadow-card hover:shadow-md hover:border-brand-blue transition-all text-center"
           >
             <span className="text-3xl">🔍</span>
             <span className="font-overpass font-semibold text-gray-700">Explorar marcas</span>
@@ -373,7 +373,7 @@ export default async function TallerDashboardPage() {
               <Link
                 key={orden.id}
                 href={`/taller/pedidos/${orden.id}`}
-                className="bg-white rounded-xl p-4 border border-gray-100 shadow-sm flex items-center justify-between hover:border-brand-blue hover:shadow-md transition-all"
+                className="bg-white rounded-card p-4 border border-gray-100 shadow-card flex items-center justify-between hover:border-brand-blue hover:shadow-md transition-all"
               >
                 <div>
                   <p className="font-semibold text-gray-800 text-sm">{orden.moId}</p>
@@ -405,7 +405,7 @@ export default async function TallerDashboardPage() {
               Ver todas →
             </Link>
           </div>
-          <div className="bg-white rounded-xl border border-gray-100 shadow-sm divide-y divide-gray-100">
+          <div className="bg-white rounded-card border border-gray-100 shadow-card divide-y divide-gray-100">
             {coleccionesRecomendadas.map((col) => {
               const progreso = taller?.progresoCapacitacion.find((p) => p.coleccionId === col.id)
               return (

--- a/src/app/(taller)/taller/pedidos/[id]/page.tsx
+++ b/src/app/(taller)/taller/pedidos/[id]/page.tsx
@@ -82,7 +82,7 @@ export default async function TallerOrdenDetallePage({
       {/* Encabezado */}
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="font-serif font-bold text-2xl text-brand-blue">{orden.moId}</h1>
+          <h1 className="font-serif font-bold text-2xl text-ink-primary">{orden.moId}</h1>
           <p className="text-gray-500 text-sm mt-0.5">Pedido {pedido.omId}</p>
         </div>
         <span className={`text-sm font-semibold px-3 py-1 rounded-full ${estadoColor[orden.estado] ?? 'bg-gray-100 text-gray-600'}`}>

--- a/src/app/(taller)/taller/pedidos/[id]/page.tsx
+++ b/src/app/(taller)/taller/pedidos/[id]/page.tsx
@@ -82,7 +82,7 @@ export default async function TallerOrdenDetallePage({
       {/* Encabezado */}
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="font-overpass font-bold text-2xl text-brand-blue">{orden.moId}</h1>
+          <h1 className="font-serif font-bold text-2xl text-brand-blue">{orden.moId}</h1>
           <p className="text-gray-500 text-sm mt-0.5">Pedido {pedido.omId}</p>
         </div>
         <span className={`text-sm font-semibold px-3 py-1 rounded-full ${estadoColor[orden.estado] ?? 'bg-gray-100 text-gray-600'}`}>
@@ -92,7 +92,7 @@ export default async function TallerOrdenDetallePage({
 
       {/* Detalle del pedido */}
       <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-5 space-y-3">
-        <h2 className="font-overpass font-semibold text-gray-700 text-sm uppercase">
+        <h2 className="font-serif font-semibold text-gray-700 text-sm uppercase">
           Detalle del pedido
         </h2>
         <div className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
@@ -121,7 +121,7 @@ export default async function TallerOrdenDetallePage({
 
       {/* Detalle de la orden */}
       <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-5 space-y-3">
-        <h2 className="font-overpass font-semibold text-gray-700 text-sm uppercase">
+        <h2 className="font-serif font-semibold text-gray-700 text-sm uppercase">
           Tu orden de manufactura
         </h2>
         <div className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
@@ -178,7 +178,7 @@ export default async function TallerOrdenDetallePage({
       {/* Acciones */}
       {(orden.estado === 'PENDIENTE' || orden.estado === 'EN_EJECUCION') && (
         <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-5 space-y-3">
-          <h2 className="font-overpass font-semibold text-gray-700 text-sm uppercase">
+          <h2 className="font-serif font-semibold text-gray-700 text-sm uppercase">
             {orden.estado === 'PENDIENTE' ? 'Responder propuesta' : 'Actualizar progreso'}
           </h2>
           <OrdenActions
@@ -191,7 +191,7 @@ export default async function TallerOrdenDetallePage({
 
       {/* Contacto marca */}
       <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-5">
-        <h2 className="font-overpass font-semibold text-gray-700 text-sm uppercase mb-3">
+        <h2 className="font-serif font-semibold text-gray-700 text-sm uppercase mb-3">
           Contacto marca
         </h2>
         <p className="text-sm font-medium text-gray-800 mb-3">{pedido.marca.nombre}</p>
@@ -220,7 +220,7 @@ export default async function TallerOrdenDetallePage({
 
       {actividad.length > 0 && (
         <Card>
-          <h2 className="font-overpass font-bold text-brand-blue mb-3">Actividad de tu orden</h2>
+          <h2 className="font-serif font-bold text-brand-blue mb-3">Actividad de tu orden</h2>
           <ActivityTimeline eventos={actividad} perspective="taller" />
         </Card>
       )}

--- a/src/app/(taller)/taller/pedidos/[id]/page.tsx
+++ b/src/app/(taller)/taller/pedidos/[id]/page.tsx
@@ -19,7 +19,7 @@ const estadoLabel: Record<string, string> = {
 
 const estadoColor: Record<string, string> = {
   PENDIENTE: 'bg-yellow-100 text-yellow-800',
-  EN_EJECUCION: 'bg-blue-100 text-blue-800',
+  EN_EJECUCION: 'bg-pastel-blue text-brand-blue-dark',
   COMPLETADO: 'bg-green-100 text-green-800',
   CANCELADO: 'bg-gray-100 text-gray-600',
 }

--- a/src/app/(taller)/taller/pedidos/disponibles/[id]/page.tsx
+++ b/src/app/(taller)/taller/pedidos/disponibles/[id]/page.tsx
@@ -39,7 +39,7 @@ export default async function PedidoDisponibleDetallePage({ params }: { params: 
       ]} />
 
       <div>
-        <h1 className="font-overpass font-bold text-3xl text-brand-blue">{pedido.tipoPrenda}</h1>
+        <h1 className="font-serif font-bold text-3xl text-brand-blue">{pedido.tipoPrenda}</h1>
         <p className="text-gray-500 mt-1">Publicado por {pedido.marca.nombre}</p>
       </div>
 

--- a/src/app/(taller)/taller/pedidos/disponibles/[id]/page.tsx
+++ b/src/app/(taller)/taller/pedidos/disponibles/[id]/page.tsx
@@ -39,7 +39,7 @@ export default async function PedidoDisponibleDetallePage({ params }: { params: 
       ]} />
 
       <div>
-        <h1 className="font-serif font-bold text-3xl text-brand-blue">{pedido.tipoPrenda}</h1>
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">{pedido.tipoPrenda}</h1>
         <p className="text-gray-500 mt-1">Publicado por {pedido.marca.nombre}</p>
       </div>
 

--- a/src/app/(taller)/taller/pedidos/disponibles/page.tsx
+++ b/src/app/(taller)/taller/pedidos/disponibles/page.tsx
@@ -156,7 +156,7 @@ export default async function PedidosDisponiblesPage({ searchParams }: { searchP
           { label: 'Taller', href: '/taller' },
           { label: 'Pedidos disponibles' },
         ]} />
-        <h1 className="font-overpass font-bold text-3xl text-brand-blue mt-2">Pedidos disponibles</h1>
+        <h1 className="font-serif font-bold text-3xl text-brand-blue mt-2">Pedidos disponibles</h1>
         <p className="text-gray-500 mt-1">Pedidos publicados por marcas que buscan talleres</p>
       </div>
 

--- a/src/app/(taller)/taller/pedidos/disponibles/page.tsx
+++ b/src/app/(taller)/taller/pedidos/disponibles/page.tsx
@@ -156,7 +156,7 @@ export default async function PedidosDisponiblesPage({ searchParams }: { searchP
           { label: 'Taller', href: '/taller' },
           { label: 'Pedidos disponibles' },
         ]} />
-        <h1 className="font-serif font-bold text-3xl text-brand-blue mt-2">Pedidos disponibles</h1>
+        <h1 className="font-serif font-bold text-3xl text-ink-primary mt-2">Pedidos disponibles</h1>
         <p className="text-gray-500 mt-1">Pedidos publicados por marcas que buscan talleres</p>
       </div>
 

--- a/src/app/(taller)/taller/pedidos/page.tsx
+++ b/src/app/(taller)/taller/pedidos/page.tsx
@@ -71,7 +71,7 @@ async function ListaOrdenes() {
     <>
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="font-overpass font-bold text-3xl text-brand-blue">Pedidos Recibidos</h1>
+          <h1 className="font-serif font-bold text-3xl text-brand-blue">Pedidos Recibidos</h1>
           <p className="text-gray-600 mt-2">Ordenes de manufactura asignadas a {taller.nombre}</p>
         </div>
         <Link

--- a/src/app/(taller)/taller/pedidos/page.tsx
+++ b/src/app/(taller)/taller/pedidos/page.tsx
@@ -118,7 +118,7 @@ async function ListaOrdenes() {
               <Link
                 key={orden.id}
                 href={`/taller/pedidos/${orden.id}`}
-                className="block border border-gray-100 rounded-lg p-4 flex flex-col md:flex-row md:items-center md:justify-between gap-3 hover:border-brand-blue hover:bg-blue-50/30 transition-colors"
+                className="block border border-gray-100 rounded-lg p-4 flex flex-col md:flex-row md:items-center md:justify-between gap-3 hover:border-brand-blue hover:bg-pastel-blue/30 transition-colors"
               >
                 <div className="space-y-1">
                   <div className="flex items-center gap-2">

--- a/src/app/(taller)/taller/pedidos/page.tsx
+++ b/src/app/(taller)/taller/pedidos/page.tsx
@@ -71,7 +71,7 @@ async function ListaOrdenes() {
     <>
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="font-serif font-bold text-3xl text-brand-blue">Pedidos Recibidos</h1>
+          <h1 className="font-serif font-bold text-3xl text-ink-primary">Pedidos Recibidos</h1>
           <p className="text-gray-600 mt-2">Ordenes de manufactura asignadas a {taller.nombre}</p>
         </div>
         <Link

--- a/src/app/(taller)/taller/perfil/completar/page.tsx
+++ b/src/app/(taller)/taller/perfil/completar/page.tsx
@@ -209,7 +209,7 @@ export default function WizardPage() {
 
   function RadioOption({ value, current, onChange, label, desc }: { value: string; current: string; onChange: (v: string) => void; label: string; desc?: string }) {
     return (
-      <label className={`block p-3 rounded-lg border cursor-pointer transition-colors ${current === value ? 'border-brand-blue bg-blue-50/50' : 'border-gray-200 hover:border-gray-300'}`}>
+      <label className={`block p-3 rounded-lg border cursor-pointer transition-colors ${current === value ? 'border-brand-blue bg-pastel-blue/50' : 'border-gray-200 hover:border-gray-300'}`}>
         <div className="flex items-center gap-2">
           <input type="radio" checked={current === value} onChange={() => onChange(value)} className="accent-[var(--color-brand-blue)]" />
           <span className="text-sm font-semibold">{label}</span>
@@ -268,7 +268,7 @@ export default function WizardPage() {
               <li>Recomendaciones personalizadas</li>
             </ul>
           </Card>
-          <Card className="bg-blue-50/50 text-sm text-gray-600 mb-6">
+          <Card className="bg-pastel-blue/50 text-sm text-gray-600 mb-6">
             Podés pausar y retomar después. Al terminar, tu perfil se guarda en la plataforma.
           </Card>
           <Button onClick={next} size="lg">Empezar</Button>
@@ -294,7 +294,7 @@ export default function WizardPage() {
               </Card>
             ))}
           </div>
-          <Card className="bg-blue-50/50 text-sm">
+          <Card className="bg-pastel-blue/50 text-sm">
             <p className="font-semibold">¿Por qué importa esto?</p>
             <p className="text-gray-600">Cada máquina contribuye a tu capacidad productiva. Con esta información calculamos tu potencial REAL.</p>
             <p className="text-gray-500 mt-1">El 70% de talleres tiene entre 3-8 máquinas.</p>
@@ -334,7 +334,7 @@ export default function WizardPage() {
       {step === 3 && (
         <div>
           <h2 className="font-overpass font-bold text-xl text-brand-blue mb-4">¿Cómo se compone tu equipo?</h2>
-          <Card className="bg-blue-50/50 text-sm mb-4">
+          <Card className="bg-pastel-blue/50 text-sm mb-4">
             Indicá cuántas personas tenés en cada categoría del oficio textil. Si no tenés trabajadores de alguna categoría, dejá en 0.
           </Card>
           <div className="space-y-3 mb-4">
@@ -375,7 +375,7 @@ export default function WizardPage() {
       {step === 4 && (
         <div>
           <h2 className="font-overpass font-bold text-xl text-brand-blue mb-4">¿Cómo organizan el trabajo?</h2>
-          <Card className="bg-blue-50/50 text-sm mb-4">
+          <Card className="bg-pastel-blue/50 text-sm mb-4">
             <p className="font-semibold mb-1">Tipos de organización productiva:</p>
             <p><strong>En línea:</strong> Cada persona hace UNA operación. Más rápido para grandes volúmenes.</p>
             <p><strong>Modular:</strong> Grupos pequeños hacen varias operaciones. Balance velocidad/flexibilidad.</p>
@@ -394,7 +394,7 @@ export default function WizardPage() {
         <div>
           <h2 className="font-overpass font-bold text-xl text-brand-blue mb-4">¿Cómo es tu espacio de trabajo?</h2>
           <Input label="Metros cuadrados del área de producción" type="number" value={metrosCuadrados} onChange={e => setMetrosCuadrados(e.target.value)} />
-          <Card className="bg-blue-50/50 text-sm my-4">
+          <Card className="bg-pastel-blue/50 text-sm my-4">
             {parseInt(metrosCuadrados) > 0 && <p>{metrosCuadrados} m² con {tamanoEquipo} personas. Recomendado: 10-15 m² por persona. Si tenes menos, no te preocupes — esto es solo referencia, no bloquea tu perfil.</p>}
           </Card>
           <p className="text-sm font-semibold mb-2">¿Tenés áreas separadas para cada proceso?</p>
@@ -413,7 +413,7 @@ export default function WizardPage() {
       {step === 6 && (
         <div>
           <h2 className="font-overpass font-bold text-xl text-brand-blue mb-4">¿Cuánto tardás en hacer una prenda?</h2>
-          <Card className="bg-blue-50/50 text-sm mb-4">
+          <Card className="bg-pastel-blue/50 text-sm mb-4">
             <p className="font-semibold">Tiempo estandar de confeccion</p>
             <p className="mb-2">Es el tiempo promedio que tarda tu taller en confeccionar una prenda completa.</p>
             <p className="font-semibold mt-2">Ejemplos típicos en Argentina:</p>
@@ -465,7 +465,7 @@ export default function WizardPage() {
       {step === 8 && (
         <div>
           <h2 className="font-overpass font-bold text-xl text-brand-blue mb-4">Calculemos tu eficiencia real</h2>
-          <Card className="bg-blue-50/50 text-sm mb-4">
+          <Card className="bg-pastel-blue/50 text-sm mb-4">
             La eficiencia real de un taller depende de muchos factores: organizacion, mantenimiento, tiempos muertos, cambios de modelo. En Argentina, la eficiencia promedio del sector ronda el 50% — esto es normal y no significa que tu taller funcione mal.
           </Card>
           <Input label="¿Cuántas horas por día trabaja tu taller?" type="number" value={horasDia} onChange={e => setHorasDia(e.target.value)} />
@@ -498,7 +498,7 @@ export default function WizardPage() {
               <p className="text-sm text-gray-500 mt-2">Eficiencia estimada: {Math.round(eficiencia * 100)}%</p>
             </div>
           </Card>
-          <Card className="bg-blue-50/50 text-sm text-left mb-4">
+          <Card className="bg-pastel-blue/50 text-sm text-left mb-4">
             <p className="font-semibold">¿Como mejorar?</p>
             <p>Si mejoras tu eficiencia de {Math.round(eficiencia * 100)}% a {Math.round(eficiencia * 100) + 8}%: +{Math.round(capacidadDiaria * 0.15)} prendas/dia.</p>
             <a href="/taller/aprender" className="text-brand-blue font-semibold hover:underline text-xs mt-1 block">Ver cursos de la academia que pueden ayudarte →</a>
@@ -556,7 +556,7 @@ export default function WizardPage() {
                     key={p.id}
                     type="button"
                     onClick={() => toggleProceso(p.id)}
-                    className={`p-4 rounded-xl border text-left transition-all ${seleccionado ? 'border-brand-blue bg-blue-50/60 ring-1 ring-brand-blue' : 'border-gray-200 hover:border-gray-300'}`}
+                    className={`p-4 rounded-xl border text-left transition-all ${seleccionado ? 'border-brand-blue bg-pastel-blue/60 ring-1 ring-brand-blue' : 'border-gray-200 hover:border-gray-300'}`}
                   >
                     <div className="flex items-start justify-between gap-2">
                       <p className="font-semibold text-sm">{p.nombre}</p>
@@ -590,7 +590,7 @@ export default function WizardPage() {
                     key={pr.id}
                     type="button"
                     onClick={() => togglePrenda(pr.id)}
-                    className={`p-4 rounded-xl border text-center transition-all ${seleccionada ? 'border-brand-blue bg-blue-50/60 ring-1 ring-brand-blue' : 'border-gray-200 hover:border-gray-300'}`}
+                    className={`p-4 rounded-xl border text-center transition-all ${seleccionada ? 'border-brand-blue bg-pastel-blue/60 ring-1 ring-brand-blue' : 'border-gray-200 hover:border-gray-300'}`}
                   >
                     <Shirt className={`w-6 h-6 mx-auto mb-1 ${seleccionada ? 'text-brand-blue' : 'text-gray-400'}`} />
                     <p className="font-semibold text-sm">{pr.nombre}</p>

--- a/src/app/(taller)/taller/perfil/completar/page.tsx
+++ b/src/app/(taller)/taller/perfil/completar/page.tsx
@@ -251,7 +251,7 @@ export default function WizardPage() {
           <div className="w-20 h-20 rounded-full bg-brand-blue/10 flex items-center justify-center mx-auto mb-4">
             <Factory className="w-10 h-10 text-brand-blue" />
           </div>
-          <h1 className="font-overpass font-bold text-2xl text-brand-blue mb-2">Perfil Productivo</h1>
+          <h1 className="font-serif font-bold text-2xl text-brand-blue mb-2">Perfil Productivo</h1>
           <p className="text-gray-600 mb-6">Vamos a completar tu perfil productivo</p>
           <Card className="text-left mb-6">
             <p className="text-sm mb-2"><span className="font-semibold">Duración:</span> ~15 minutos</p>
@@ -281,7 +281,7 @@ export default function WizardPage() {
       {/* Paso 2: Maquinaria */}
       {step === 1 && (
         <div>
-          <h2 className="font-overpass font-bold text-xl text-brand-blue mb-2">¿Qué máquinas de confección tenés?</h2>
+          <h2 className="font-serif font-bold text-xl text-brand-blue mb-2">¿Qué máquinas de confección tenés?</h2>
           <p className="text-sm text-gray-500 mb-4">Hacé click en cada tipo y poné la cantidad:</p>
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-4">
             {MAQUINAS.map(m => (
@@ -305,7 +305,7 @@ export default function WizardPage() {
       {/* Paso 3: Equipo */}
       {step === 2 && (
         <div>
-          <h2 className="font-overpass font-bold text-xl text-brand-blue mb-4">Contanos sobre tu equipo de trabajo</h2>
+          <h2 className="font-serif font-bold text-xl text-brand-blue mb-4">Contanos sobre tu equipo de trabajo</h2>
           <p className="text-sm font-semibold mb-2">¿Cuántas personas trabajan en producción?</p>
           <div className="flex gap-2 mb-4">
             {['1-2', '3-5', '6-10', '11-20', '+20'].map(v => (
@@ -333,7 +333,7 @@ export default function WizardPage() {
       {/* Paso 4: Composición del equipo */}
       {step === 3 && (
         <div>
-          <h2 className="font-overpass font-bold text-xl text-brand-blue mb-4">¿Cómo se compone tu equipo?</h2>
+          <h2 className="font-serif font-bold text-xl text-brand-blue mb-4">¿Cómo se compone tu equipo?</h2>
           <Card className="bg-pastel-blue/50 text-sm mb-4">
             Indicá cuántas personas tenés en cada categoría del oficio textil. Si no tenés trabajadores de alguna categoría, dejá en 0.
           </Card>
@@ -374,7 +374,7 @@ export default function WizardPage() {
       {/* Paso 5: Organización */}
       {step === 4 && (
         <div>
-          <h2 className="font-overpass font-bold text-xl text-brand-blue mb-4">¿Cómo organizan el trabajo?</h2>
+          <h2 className="font-serif font-bold text-xl text-brand-blue mb-4">¿Cómo organizan el trabajo?</h2>
           <Card className="bg-pastel-blue/50 text-sm mb-4">
             <p className="font-semibold mb-1">Tipos de organización productiva:</p>
             <p><strong>En línea:</strong> Cada persona hace UNA operación. Más rápido para grandes volúmenes.</p>
@@ -392,7 +392,7 @@ export default function WizardPage() {
       {/* Paso 6: Espacio */}
       {step === 5 && (
         <div>
-          <h2 className="font-overpass font-bold text-xl text-brand-blue mb-4">¿Cómo es tu espacio de trabajo?</h2>
+          <h2 className="font-serif font-bold text-xl text-brand-blue mb-4">¿Cómo es tu espacio de trabajo?</h2>
           <Input label="Metros cuadrados del área de producción" type="number" value={metrosCuadrados} onChange={e => setMetrosCuadrados(e.target.value)} />
           <Card className="bg-pastel-blue/50 text-sm my-4">
             {parseInt(metrosCuadrados) > 0 && <p>{metrosCuadrados} m² con {tamanoEquipo} personas. Recomendado: 10-15 m² por persona. Si tenes menos, no te preocupes — esto es solo referencia, no bloquea tu perfil.</p>}
@@ -412,7 +412,7 @@ export default function WizardPage() {
       {/* Paso 7: SAM */}
       {step === 6 && (
         <div>
-          <h2 className="font-overpass font-bold text-xl text-brand-blue mb-4">¿Cuánto tardás en hacer una prenda?</h2>
+          <h2 className="font-serif font-bold text-xl text-brand-blue mb-4">¿Cuánto tardás en hacer una prenda?</h2>
           <Card className="bg-pastel-blue/50 text-sm mb-4">
             <p className="font-semibold">Tiempo estandar de confeccion</p>
             <p className="mb-2">Es el tiempo promedio que tarda tu taller en confeccionar una prenda completa.</p>
@@ -439,7 +439,7 @@ export default function WizardPage() {
       {/* Paso 8: SAM Quiz */}
       {step === 7 && (
         <div>
-          <h2 className="font-overpass font-bold text-xl text-brand-blue mb-4">Verificamos que entendiste el concepto</h2>
+          <h2 className="font-serif font-bold text-xl text-brand-blue mb-4">Verificamos que entendiste el concepto</h2>
           <p className="text-sm font-semibold mb-3">¿Que es el tiempo estandar de confeccion?</p>
           <div className="space-y-2 mb-4">
             <RadioOption value="salario" current={samQuizResp} onChange={setSamQuizResp} label="El salario mensual de un operario" />
@@ -464,7 +464,7 @@ export default function WizardPage() {
       {/* Paso 9: Eficiencia */}
       {step === 8 && (
         <div>
-          <h2 className="font-overpass font-bold text-xl text-brand-blue mb-4">Calculemos tu eficiencia real</h2>
+          <h2 className="font-serif font-bold text-xl text-brand-blue mb-4">Calculemos tu eficiencia real</h2>
           <Card className="bg-pastel-blue/50 text-sm mb-4">
             La eficiencia real de un taller depende de muchos factores: organizacion, mantenimiento, tiempos muertos, cambios de modelo. En Argentina, la eficiencia promedio del sector ronda el 50% — esto es normal y no significa que tu taller funcione mal.
           </Card>
@@ -485,7 +485,7 @@ export default function WizardPage() {
       {/* Paso 10: Resultado Capacidad */}
       {step === 9 && (
         <div className="text-center">
-          <h2 className="font-overpass font-bold text-xl text-brand-blue mb-4">Tu Capacidad Calculada</h2>
+          <h2 className="font-serif font-bold text-xl text-brand-blue mb-4">Tu Capacidad Calculada</h2>
           <Card className="mb-4">
             <p className="text-sm text-gray-500 mb-2">Basado en tus datos:</p>
             <div className="text-sm text-gray-600 space-y-0.5 mb-4">
@@ -515,7 +515,7 @@ export default function WizardPage() {
       {/* Paso 11: Gestión */}
       {step === 10 && (
         <div>
-          <h2 className="font-overpass font-bold text-xl text-brand-blue mb-4">Gestión y Escalabilidad</h2>
+          <h2 className="font-serif font-bold text-xl text-brand-blue mb-4">Gestión y Escalabilidad</h2>
           <p className="text-sm font-semibold mb-2">¿Cómo es tu horario de trabajo?</p>
           <div className="space-y-2 mb-4">
             <RadioOption value="unico" current={horario} onChange={setHorario} label="Turno único (8 horas fijas)" />
@@ -543,7 +543,7 @@ export default function WizardPage() {
       {/* Paso 12: Procesos productivos */}
       {step === 11 && (
         <div>
-          <h2 className="font-overpass font-bold text-xl text-brand-blue mb-2">¿Qué procesos realizás?</h2>
+          <h2 className="font-serif font-bold text-xl text-brand-blue mb-2">¿Qué procesos realizás?</h2>
           <p className="text-sm text-gray-500 mb-4">Seleccioná todos los procesos que tu taller puede ofrecer a las marcas.</p>
           {catalogoProcesos.length === 0 ? (
             <Card className="text-center py-8 text-gray-500 text-sm">Cargando procesos...</Card>
@@ -577,7 +577,7 @@ export default function WizardPage() {
       {/* Paso 13: Tipos de prenda */}
       {step === 12 && (
         <div>
-          <h2 className="font-overpass font-bold text-xl text-brand-blue mb-2">¿Qué prendas fabricás?</h2>
+          <h2 className="font-serif font-bold text-xl text-brand-blue mb-2">¿Qué prendas fabricás?</h2>
           <p className="text-sm text-gray-500 mb-4">Seleccioná los tipos de prenda en los que tu taller está especializado.</p>
           {catalogoPrendas.length === 0 ? (
             <Card className="text-center py-8 text-gray-500 text-sm">Cargando prendas...</Card>
@@ -609,7 +609,7 @@ export default function WizardPage() {
       {/* Paso 14: Resumen */}
       {step === 13 && (
         <div className="text-center">
-          <h2 className="font-overpass font-bold text-2xl text-brand-blue mb-4">¡Perfil productivo completado!</h2>
+          <h2 className="font-serif font-bold text-2xl text-brand-blue mb-4">¡Perfil productivo completado!</h2>
           <p className="text-gray-600 mb-1">Las marcas pueden ver tu capacidad, maquinaria y procesos</p>
           <p className="text-xs text-gray-400 mb-6">Este diagnóstico ayuda al equipo de la plataforma a entender el sector textil</p>
 

--- a/src/app/(taller)/taller/perfil/completar/page.tsx
+++ b/src/app/(taller)/taller/perfil/completar/page.tsx
@@ -251,7 +251,7 @@ export default function WizardPage() {
           <div className="w-20 h-20 rounded-full bg-brand-blue/10 flex items-center justify-center mx-auto mb-4">
             <Factory className="w-10 h-10 text-brand-blue" />
           </div>
-          <h1 className="font-serif font-bold text-2xl text-brand-blue mb-2">Perfil Productivo</h1>
+          <h1 className="font-serif font-bold text-2xl text-ink-primary mb-2">Perfil Productivo</h1>
           <p className="text-gray-600 mb-6">Vamos a completar tu perfil productivo</p>
           <Card className="text-left mb-6">
             <p className="text-sm mb-2"><span className="font-semibold">Duración:</span> ~15 minutos</p>

--- a/src/app/(taller)/taller/perfil/editar/editar-form.tsx
+++ b/src/app/(taller)/taller/perfil/editar/editar-form.tsx
@@ -80,7 +80,7 @@ export function EditarPerfilForm({ taller }: Props) {
           ← Volver al perfil
         </Link>
       </div>
-      <h1 className="text-2xl font-bold font-overpass text-brand-blue">Editar datos básicos</h1>
+      <h1 className="text-2xl font-bold font-serif text-brand-blue">Editar datos básicos</h1>
 
       {error && (
         <p className="text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2">{error}</p>
@@ -88,7 +88,7 @@ export function EditarPerfilForm({ taller }: Props) {
 
       {/* Sección: Datos de la empresa */}
       <div className="bg-white rounded-xl border border-gray-100 p-6 space-y-4">
-        <h2 className="font-overpass font-bold text-gray-800">Datos de la empresa</h2>
+        <h2 className="font-serif font-bold text-gray-800">Datos de la empresa</h2>
         <div>
           <label className="text-sm font-medium text-gray-700">Nombre del taller</label>
           <input
@@ -142,7 +142,7 @@ export function EditarPerfilForm({ taller }: Props) {
 
       {/* Sección: Datos del responsable */}
       <div className="bg-white rounded-xl border border-gray-100 p-6 space-y-4">
-        <h2 className="font-overpass font-bold text-gray-800">Datos del responsable</h2>
+        <h2 className="font-serif font-bold text-gray-800">Datos del responsable</h2>
         <div>
           <label className="text-sm font-medium text-gray-700">Nombre completo</label>
           <input

--- a/src/app/(taller)/taller/perfil/editar/editar-form.tsx
+++ b/src/app/(taller)/taller/perfil/editar/editar-form.tsx
@@ -80,7 +80,7 @@ export function EditarPerfilForm({ taller }: Props) {
           ← Volver al perfil
         </Link>
       </div>
-      <h1 className="text-2xl font-bold font-serif text-brand-blue">Editar datos básicos</h1>
+      <h1 className="text-2xl font-bold font-serif text-ink-primary">Editar datos básicos</h1>
 
       {error && (
         <p className="text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2">{error}</p>

--- a/src/app/(taller)/taller/perfil/page.tsx
+++ b/src/app/(taller)/taller/perfil/page.tsx
@@ -37,7 +37,7 @@ export default async function TallerPerfilPage() {
   if (!taller) {
     return (
       <div className="space-y-6">
-        <h1 className="font-serif font-bold text-3xl text-brand-blue">Mi Perfil</h1>
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi Perfil</h1>
         <Card className="text-center py-12">
           <p className="text-gray-600 mb-4">Todavía no completaste tu perfil.</p>
           <Link href="/taller/perfil/completar">
@@ -62,7 +62,7 @@ export default async function TallerPerfilPage() {
       <div className="flex items-start justify-between">
         <div>
           <div className="flex items-center gap-3 mb-1">
-            <h1 className="font-serif font-bold text-3xl text-brand-blue">{taller.nombre}</h1>
+            <h1 className="font-serif font-bold text-3xl text-ink-primary">{taller.nombre}</h1>
             <Badge variant={nivelColor[taller.nivel]}>{taller.nivel}</Badge>
           </div>
           {taller.provincia && (

--- a/src/app/(taller)/taller/perfil/page.tsx
+++ b/src/app/(taller)/taller/perfil/page.tsx
@@ -114,7 +114,7 @@ export default async function TallerPerfilPage() {
           <p className="text-xs text-gray-500">Cap. mensual</p>
         </Card>
         <Card className="text-center p-4">
-          <Clock className="w-5 h-5 text-blue-500 mx-auto mb-1" />
+          <Clock className="w-5 h-5 text-brand-blue mx-auto mb-1" />
           <p className="font-overpass font-bold text-2xl text-brand-blue">{taller.ontimeRate}%</p>
           <p className="text-xs text-gray-500">On-time</p>
         </Card>

--- a/src/app/(taller)/taller/perfil/page.tsx
+++ b/src/app/(taller)/taller/perfil/page.tsx
@@ -37,7 +37,7 @@ export default async function TallerPerfilPage() {
   if (!taller) {
     return (
       <div className="space-y-6">
-        <h1 className="font-overpass font-bold text-3xl text-brand-blue">Mi Perfil</h1>
+        <h1 className="font-serif font-bold text-3xl text-brand-blue">Mi Perfil</h1>
         <Card className="text-center py-12">
           <p className="text-gray-600 mb-4">Todavía no completaste tu perfil.</p>
           <Link href="/taller/perfil/completar">
@@ -62,7 +62,7 @@ export default async function TallerPerfilPage() {
       <div className="flex items-start justify-between">
         <div>
           <div className="flex items-center gap-3 mb-1">
-            <h1 className="font-overpass font-bold text-3xl text-brand-blue">{taller.nombre}</h1>
+            <h1 className="font-serif font-bold text-3xl text-brand-blue">{taller.nombre}</h1>
             <Badge variant={nivelColor[taller.nivel]}>{taller.nivel}</Badge>
           </div>
           {taller.provincia && (

--- a/src/app/unauthorized/page.tsx
+++ b/src/app/unauthorized/page.tsx
@@ -50,7 +50,7 @@ export default async function UnauthorizedPage() {
             </div>
           </div>
 
-          <h1 className="font-overpass font-bold text-3xl text-brand-blue mb-3">
+          <h1 className="font-overpass font-bold text-3xl text-ink-primary mb-3">
             Acceso No Autorizado
           </h1>
 

--- a/src/compartido/componentes/activity-timeline.tsx
+++ b/src/compartido/componentes/activity-timeline.tsx
@@ -15,11 +15,11 @@ interface ActivityTimelineProps {
 }
 
 const iconByAction: Record<string, { icon: typeof Info; color: string }> = {
-  PEDIDO_PUBLICADO: { icon: Package, color: 'text-blue-500 bg-blue-50' },
-  COTIZACION_RECIBIDA: { icon: FileText, color: 'text-blue-500 bg-blue-50' },
+  PEDIDO_PUBLICADO: { icon: Package, color: 'text-brand-blue bg-pastel-blue' },
+  COTIZACION_RECIBIDA: { icon: FileText, color: 'text-brand-blue bg-pastel-blue' },
   COTIZACION_ACEPTADA: { icon: CheckCircle, color: 'text-green-500 bg-green-50' },
   COTIZACION_RECHAZADA: { icon: XCircle, color: 'text-red-500 bg-red-50' },
-  ORDEN_CREADA: { icon: Package, color: 'text-blue-500 bg-blue-50' },
+  ORDEN_CREADA: { icon: Package, color: 'text-brand-blue bg-pastel-blue' },
   ORDEN_ACEPTADA: { icon: CheckCircle, color: 'text-green-500 bg-green-50' },
   ORDEN_RECHAZADA: { icon: XCircle, color: 'text-red-500 bg-red-50' },
   PROGRESO_ACTUALIZADO: { icon: TrendingUp, color: 'text-yellow-500 bg-yellow-50' },

--- a/src/compartido/componentes/badge-arca.tsx
+++ b/src/compartido/componentes/badge-arca.tsx
@@ -12,11 +12,11 @@ function tiempoRelativo(fecha: Date): string {
 export function BadgeArca({ verificado, fecha }: { verificado: boolean; fecha?: Date | null }) {
   if (verificado) {
     return (
-      <span className="inline-flex items-center gap-1 text-xs bg-blue-50 text-blue-700 px-2 py-0.5 rounded font-medium">
+      <span className="inline-flex items-center gap-1 text-xs bg-pastel-blue text-brand-blue-dark px-2 py-0.5 rounded font-medium">
         <ShieldCheck className="w-3 h-3" />
         Verificado por ARCA
         {fecha && (
-          <span className="text-blue-400 font-normal">
+          <span className="text-brand-blue/70 font-normal">
             ({tiempoRelativo(fecha)})
           </span>
         )}

--- a/src/compartido/componentes/error-page.tsx
+++ b/src/compartido/componentes/error-page.tsx
@@ -70,7 +70,7 @@ export function ErrorPage({ error, reset, contexto = 'publico' }: Props) {
           Si el problema persiste, podes{' '}
           <button
             onClick={() => abrirFeedback(error.digest)}
-            className="underline text-brand-blue hover:text-blue-800"
+            className="underline text-brand-blue hover:text-brand-blue-dark"
           >
             reportarlo aca
           </button>

--- a/src/compartido/componentes/feedback-widget.tsx
+++ b/src/compartido/componentes/feedback-widget.tsx
@@ -6,7 +6,7 @@ import { useSession } from 'next-auth/react'
 
 const TIPOS = [
   { value: 'bug', label: '🐛 Algo no funciona', color: 'text-red-600' },
-  { value: 'mejora', label: '✨ Podria mejorar', color: 'text-blue-600' },
+  { value: 'mejora', label: '✨ Podria mejorar', color: 'text-brand-blue' },
   { value: 'falta', label: '🔍 Me falta algo', color: 'text-amber-600' },
   { value: 'confusion', label: '😕 No entendi como usar esto', color: 'text-purple-600' },
 ]

--- a/src/compartido/componentes/layout/notificaciones-bell.tsx
+++ b/src/compartido/componentes/layout/notificaciones-bell.tsx
@@ -121,7 +121,7 @@ export function NotificacionesBell() {
           setOpen(prev => !prev)
           if (!open) fetchNotificaciones()
         }}
-        className="hover:text-blue-200 transition-colors relative"
+        className="hover:text-white/70 transition-colors relative"
         aria-label={`Notificaciones${sinLeer > 0 ? ` (${sinLeer} sin leer)` : ''}`}
       >
         <Bell className="w-4 h-4" />

--- a/src/compartido/componentes/layout/user-sidebar.tsx
+++ b/src/compartido/componentes/layout/user-sidebar.tsx
@@ -171,7 +171,7 @@ export function UserSidebar({
               </div>
               <div className="flex-1 min-w-0">
                 <h2 className="font-overpass font-bold text-lg truncate">{userName}</h2>
-                <p className="text-blue-200 text-sm">
+                <p className="text-white/70 text-sm">
                   {userRole === 'TALLER' && `${userLevel} - ${userProgress}%`}
                   {userRole === 'MARCA' && 'Marca'}
                   {userRole === 'ESTADO' && 'Ente Estatal'}
@@ -183,7 +183,7 @@ export function UserSidebar({
             {/* Progress bar (solo para talleres) */}
             {userRole === 'TALLER' && (
               <div className="space-y-1">
-                <div className="flex justify-between text-xs text-blue-100">
+                <div className="flex justify-between text-xs text-white/60">
                   <span>Progreso de formalización</span>
                   <span className="font-semibold">{userProgress}%</span>
                 </div>

--- a/src/compartido/componentes/ui/progress-ring.tsx
+++ b/src/compartido/componentes/ui/progress-ring.tsx
@@ -18,10 +18,9 @@ export function ProgressRing({
   return (
     <div className={`relative ${className}`} style={{ width: size, height: size }}>
       <svg className="w-full h-full transform -rotate-90" viewBox={`0 0 ${size} ${size}`}>
-        <circle cx={size / 2} cy={size / 2} r={radius} stroke="#e5e7eb" strokeWidth={strokeWidth} fill="none" />
-        <circle cx={size / 2} cy={size / 2} r={radius} stroke="#fa3c4b" strokeWidth={strokeWidth} fill="none"
-          strokeDasharray={circumference} strokeDashoffset={offset} strokeLinecap="round"
-          className="transition-all duration-1000 ease-out" />
+        <circle cx={size / 2} cy={size / 2} r={radius} className="stroke-gray-200" strokeWidth={strokeWidth} fill="none" />
+        <circle cx={size / 2} cy={size / 2} r={radius} className="stroke-brand-red transition-all duration-1000 ease-out" strokeWidth={strokeWidth} fill="none"
+          strokeDasharray={circumference} strokeDashoffset={offset} strokeLinecap="round" />
       </svg>
       <div className="absolute inset-0 flex flex-col items-center justify-center">
         <span className="text-4xl font-overpass font-bold text-brand-red">{percentage}%</span>

--- a/src/compartido/componentes/ui/section-error.tsx
+++ b/src/compartido/componentes/ui/section-error.tsx
@@ -15,7 +15,7 @@ export function SectionError({ section, reset }: { section: string; reset: () =>
       <div className="flex gap-3">
         <button
           onClick={reset}
-          className="px-5 py-2.5 bg-brand-blue text-white rounded-lg font-overpass font-semibold text-sm hover:bg-blue-800 transition-colors"
+          className="px-5 py-2.5 bg-brand-blue text-white rounded-lg font-overpass font-semibold text-sm hover:bg-brand-blue-dark transition-colors"
         >
           Reintentar
         </button>

--- a/src/compartido/componentes/ui/toast.tsx
+++ b/src/compartido/componentes/ui/toast.tsx
@@ -52,7 +52,7 @@ const colorByType = {
   success: 'bg-green-600 text-white',
   error: 'bg-red-600 text-white',
   warning: 'bg-amber-500 text-white',
-  info: 'bg-blue-600 text-white',
+  info: 'bg-brand-blue text-white',
 }
 
 export function ToastProvider({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary

Aplica paleta V4 a dashboards, cerrando el gap visual entre landing (V4) y dashboards (V3).

### Incluye:
- **9 componentes UI** migrados (toast + 8 layout/secundarios): 0 residuales `text-blue-*`/`bg-blue-*` en `src/compartido/componentes/`
- **21 paginas** con clases blue inline migradas a tokens V4
- **148 H1/H2** en 63 archivos con `font-serif` (antes `font-overpass`)
- `progress-ring.tsx` sin hex hardcoded (ahora usa `stroke-gray-200` + `stroke-brand-red`)

### NO incluye (queda para X-07b):
- H3, eyebrows, subtitulares con serif
- 78 grays inline (mapeo gray → ink-*)
- public/auth pages
- recharts (no se usa actualmente)
- PDFs con hex hardcoded

### Commits:
1. `8cccda2` — componentes UI base (toast.tsx)
2. `7d58d2b` — componentes layout y secundarios (8 archivos)
3. `60192c1` — 21 paginas con clases blue inline
4. `8dcf0b0` — font-serif en 148 H1/H2 de dashboards

### Tests E2E
0 afectados (no usan `toHaveCSS` ni screenshots). Pre-flight ejecutado 18-05.

### Refs
spec: `.claude/specs/v4-x-07a-paleta-dashboards-critico.md`
pre-flight: transcripcion 18-05