### PR TITLE
feat: U-02 schema multi-rol con CUIT y ARCA centralizados

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,10 @@
 ## 2026-05-19
 
 ### Gerardo Breard
+- **18:01** `41a50fd` — feat(u-02): schema multi-rol con CUIT y ARCA centralizados
+  - `prisma/migrations/20260519200000_agregar_multirol_y_arca_a_user/migration.sql`
+  - `prisma/schema.prisma`
+
 - **17:35** `cbf0b39` — docs(u-01): corregir tipos ARCA tras pre-flight U-02 (v2.1)
   - `docs/analisis/U-01_multi-rol-airbnb.md`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,16 @@
 # Daily Log
 
+## 2026-05-20
+
+### Gerardo Breard
+- **13:53** `9f29dc5` — fix(tests): resolver duplicacion RSC streaming en 5 tests
+  - `KNOWN_ISSUES.md`
+  - `tests/e2e/acceso-verificado.spec.ts`
+  - `tests/e2e/demanda-insatisfecha.spec.ts`
+  - `tests/e2e/roles-estado.spec.ts`
+  - `tests/e2e/smoke.spec.ts`
+
+
 ## 2026-05-19
 
 ### Gerardo Breard

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -59,3 +59,107 @@ gh run view <id> --log-failed | grep -E "FAIL|✘"
 # Si UN mismo test aparece en >50% de los fallos: bug deterministico
 # Si tests DISTINTOS aparecen cada vez: state leak o timing
 ```
+
+---
+
+## React Server Components streaming duplication (descubierto 20-mayo-2026)
+
+### Sintoma
+
+Tests E2E con `getByText` en headers, navs o tabs fallan intermitentemente
+con "strict mode violation: resolved to 2 elements" en Vercel preview.
+El re-run muchas veces pasa.
+
+### Causa raiz
+
+Next.js RSC streaming usa suspense boundaries (`<div id="S:0">`) para
+stream HTML al cliente. Durante el SSR streaming:
+
+1. HTML del componente se inserta en `<div id="S:0">`
+2. React lo mueve al lugar correcto via JS
+3. Entre estos 2 momentos, el DOM tiene 2 COPIAS del componente
+4. Tests que evaluan el DOM en esa ventana ven 2 elementos
+
+La ventana es mas larga en Vercel preview (cold-start) que en
+ambientes con cache caliente (develop deploy fijo).
+
+### Como identificar
+
+Si el test falla con "resolved to 2 elements" en preview pero pasa
+en develop, verificar los parent chains:
+- Match 0: `... < body`
+- Match 1: `... < div#S:0` ← este es el indicador de RSC streaming
+
+### Verificacion empirica (script de reproduccion)
+
+```js
+// Ejecutar con: NODE_PATH="$PWD/node_modules" node script.js
+const { chromium } = require('playwright-core')
+async function main() {
+  const browser = await chromium.launch({ headless: true })
+  const page = await (await browser.newContext()).newPage()
+  // login...
+  await page.goto(BASE + '/estado')
+  await page.waitForLoadState('domcontentloaded')
+  const matches = await page.locator('header nav').getByText('Demanda insatisfecha').all()
+  for (const m of matches) {
+    const chain = await m.evaluate(el => {
+      const c = []; let p = el
+      for (let i = 0; i < 8 && p; i++) { c.push(p.tagName + (p.id ? '#' + p.id : '')); p = p.parentElement }
+      return c.join(' < ')
+    })
+    console.log(chain) // Si ves "DIV#S:0" en un chain, es RSC streaming
+  }
+  await browser.close()
+}
+```
+
+### Soluciones (segun caso)
+
+Opcion A — waitForLoadState (cuando el test necesita estabilizacion):
+
+```ts
+await page.goto('/...')
+await page.waitForLoadState('networkidle')  // espera a que streaming termine
+await expect(...).toBeVisible(...)
+```
+
+Opcion B — .first() (cuando aceptamos primer match):
+
+```ts
+await expect(page.getByText('...').first()).toBeVisible(...)
+```
+
+Opcion C — Scope a main (cuando el elemento esta en main, no en header):
+
+```ts
+await expect(page.locator('main').getByText('...')).toBeVisible(...)
+```
+
+### Cuando usar cada opcion
+
+- **waitForLoadState**: tests que verifican elementos del header/nav
+- **.first()**: tests rapidos (smoke) o cuando hay OR de selectores
+- **Scope a main**: solo si el elemento esta confirmado dentro de main
+
+### NO usar como solucion
+
+- Aumentar timeouts no funciona: los 2 elementos coexisten durante toda la ventana de streaming.
+- Aceptar "es flaky" sin investigar. Investigar siempre primero.
+
+### Tests arreglados con este patron (20-mayo-2026)
+
+| Test | Archivo:linea | Fix aplicado |
+|------|--------------|-------------|
+| Tab Demanda insatisfecha | demanda-insatisfecha.spec.ts:47 | waitForLoadState |
+| Directorio Proveedores | acceso-verificado.spec.ts:10 | waitForLoadState |
+| Boton Abrir menu | roles-estado.spec.ts:42 | .first() |
+| Header Mis pedidos | smoke.spec.ts:28 | .first() |
+| Header Mi perfil | smoke.spec.ts:29 | .first() |
+
+### Tests ya protegidos (sin tocar)
+
+- layout-consistency: wrapped en try/catch → test.skip()
+- notificaciones-bell: usa .first() en todos los selectores
+- desglose-plantilla: usa { waitUntil: 'load' } en page.goto()
+- exportes-estado: usa waitForLoadState + scoped a main

--- a/prisma/migrations/20260519200000_agregar_multirol_y_arca_a_user/migration.sql
+++ b/prisma/migrations/20260519200000_agregar_multirol_y_arca_a_user/migration.sql
@@ -1,0 +1,64 @@
+-- DropIndex
+DROP INDEX "talleres_cuit_key";
+
+-- DropIndex
+DROP INDEX "marcas_cuit_key";
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "activeMode" "UserRole",
+ADD COLUMN     "actividadesAfip" TEXT[],
+ADD COLUMN     "categoriaMonotributo" TEXT,
+ADD COLUMN     "cuit" TEXT,
+ADD COLUMN     "domicilioFiscalAfip" JSONB,
+ADD COLUMN     "empleadosRegistradosSipa" INTEGER,
+ADD COLUMN     "empleadosSipaActualizadoAt" TIMESTAMP(3),
+ADD COLUMN     "estadoCuitAfip" "EstadoCuit",
+ADD COLUMN     "fechaInscripcionAfip" TIMESTAMP(3),
+ADD COLUMN     "roles" "UserRole"[] DEFAULT ARRAY[]::"UserRole"[],
+ADD COLUMN     "tipoInscripcionAfip" "TipoInscripcionAfip",
+ADD COLUMN     "verificadoAfip" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "verificadoAfipAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_cuit_key" ON "users"("cuit");
+
+-- Backfill: roles desde role actual
+UPDATE "users" SET "roles" = ARRAY["role"::"UserRole"];
+
+-- Backfill: activeMode desde role actual
+UPDATE "users" SET "activeMode" = "role";
+
+-- Backfill: CUIT desde Taller (prioridad)
+UPDATE "users"
+   SET "cuit" = t."cuit"
+  FROM "talleres" t
+ WHERE t."userId" = "users"."id";
+
+-- Backfill: CUIT desde Marca (si no hay Taller)
+UPDATE "users"
+   SET "cuit" = m."cuit"
+  FROM "marcas" m
+ WHERE m."userId" = "users"."id"
+   AND "users"."cuit" IS NULL;
+
+-- Backfill: data ARCA desde Taller (10 campos)
+UPDATE "users"
+   SET "verificadoAfip"             = t."verificadoAfip",
+       "verificadoAfipAt"           = t."verificadoAfipAt",
+       "tipoInscripcionAfip"        = t."tipoInscripcionAfip",
+       "categoriaMonotributo"       = t."categoriaMonotributo",
+       "estadoCuitAfip"             = t."estadoCuitAfip",
+       "fechaInscripcionAfip"       = t."fechaInscripcionAfip",
+       "actividadesAfip"            = t."actividadesAfip",
+       "domicilioFiscalAfip"        = t."domicilioFiscalAfip",
+       "empleadosRegistradosSipa"   = t."empleadosRegistradosSipa",
+       "empleadosSipaActualizadoAt" = t."empleadosSipaActualizadoAt"
+  FROM "talleres" t
+ WHERE t."userId" = "users"."id";
+
+-- Backfill: verificadoAfip desde Marca (si no hay Taller)
+UPDATE "users"
+   SET "verificadoAfip" = m."verificadoAfip"
+  FROM "marcas" m
+ WHERE m."userId" = "users"."id"
+   AND "users"."verificadoAfip" = false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -147,6 +147,26 @@ model User {
   role             UserRole  @default(TALLER)
   active           Boolean   @default(true)
   registroCompleto Boolean   @default(true)
+
+  // Multi-rol (U-02, decisión D1)
+  roles                        UserRole[]            @default([])
+  activeMode                   UserRole?
+
+  // CUIT centralizado (U-02, decisión D2)
+  cuit                         String?               @unique
+
+  // ARCA centralizado (U-02, decisión D7) — tipos exactos del Taller actual
+  verificadoAfip               Boolean               @default(false)
+  verificadoAfipAt             DateTime?
+  tipoInscripcionAfip          TipoInscripcionAfip?
+  categoriaMonotributo         String?
+  estadoCuitAfip               EstadoCuit?
+  fechaInscripcionAfip         DateTime?
+  actividadesAfip              String[]
+  domicilioFiscalAfip          Json?
+  empleadosRegistradosSipa     Int?
+  empleadosSipaActualizadoAt   DateTime?
+
   createdAt        DateTime  @default(now())
   updatedAt        DateTime  @updatedAt
 
@@ -220,7 +240,7 @@ model Taller {
   id                      String      @id @default(cuid())
   userId                  String      @unique
   nombre                  String
-  cuit                    String      @unique
+  cuit                    String
   nivel                   NivelTaller @default(BRONCE)
   puntaje                 Int         @default(0)
   rating                  Float       @default(0)
@@ -295,7 +315,7 @@ model Marca {
   id                String   @id @default(cuid())
   userId            String   @unique
   nombre            String
-  cuit              String   @unique
+  cuit              String
   ubicacion         String?
   tipo              String?
   website           String?

--- a/tests/e2e/acceso-verificado.spec.ts
+++ b/tests/e2e/acceso-verificado.spec.ts
@@ -7,6 +7,7 @@ test.describe('Acceso pre-formalizacion y niveles privados', () => {
     await ensureNotProduction(page)
 
     await page.goto('/directorio')
+    await page.waitForLoadState('networkidle')
 
     // El directorio deberia cargar sin error
     // Timeout 30s: streaming SSR + cold start en preview puede tardar >15s

--- a/tests/e2e/demanda-insatisfecha.spec.ts
+++ b/tests/e2e/demanda-insatisfecha.spec.ts
@@ -44,6 +44,7 @@ test.describe('F-05 Dashboard de demanda insatisfecha', () => {
     await loginEstado(page)
 
     await page.goto('/estado')
+    await page.waitForLoadState('networkidle')
     await expect(page.locator('header nav').getByText('Demanda insatisfecha')).toBeVisible({ timeout: 30000 })
   })
 

--- a/tests/e2e/roles-estado.spec.ts
+++ b/tests/e2e/roles-estado.spec.ts
@@ -39,7 +39,7 @@ test.describe('D-01 Roles ESTADO — flujos principales', () => {
     await ensureNotProduction(page)
     await loginEstado(page)
     // Abrir sidebar hamburger
-    const menuBtn = page.locator('button[aria-label="Abrir menú"]').or(page.locator('button[aria-label="Menu"]'))
+    const menuBtn = page.locator('button[aria-label="Abrir menú"]').or(page.locator('button[aria-label="Menu"]')).first()
     if (await menuBtn.isVisible()) {
       await menuBtn.click()
     }

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -25,8 +25,8 @@ test.describe('Smoke test — setup basico funciona', () => {
 
     // El header debe mostrar tabs del taller (scoped al header) y boton de menu
     const header = page.locator('header')
-    await expect(header.getByText('Mis pedidos')).toBeVisible()
-    await expect(header.getByText('Mi perfil')).toBeVisible()
+    await expect(header.getByText('Mis pedidos').first()).toBeVisible()
+    await expect(header.getByText('Mi perfil').first()).toBeVisible()
     await expect(page.locator('button[aria-label="Abrir menú"]')).toBeVisible()
   })
 


### PR DESCRIPTION
## Summary

Implementa los cambios de schema de U-01 v2.1 (decisiones D1, D2, D7).

- **User:** +13 campos (roles[], activeMode, cuit @unique, 10 campos ARCA)
- **Taller:** cuit pierde @unique (queda como cache/display)
- **Marca:** cuit pierde @unique
- **Migration SQL:** incluye backfill automatico de roles, activeMode, CUIT y datos ARCA
- **Backward compat:** User.role se mantiene (deprecated hasta U-08)
- **ARCA en Taller/Marca:** se mantiene hasta U-08

NO toca codigo de la app. El sistema sigue funcionando con User.role.

## Archivos cambiados

- `prisma/schema.prisma` — 13 campos nuevos en User, -2 @unique
- `prisma/migrations/20260519200000_agregar_multirol_y_arca_a_user/migration.sql` — DDL + backfill

## Test plan

- [ ] CI verde (build + E2E)
- [ ] Verificar en Vercel preview que login funciona para los 5 roles
- [ ] Verificar en Prisma Studio que los 8 users seed tienen roles[] y cuit correctos
- [ ] Verificar que ADMIN/ESTADO/CONTENIDO tienen cuit=NULL

## Refs

- `docs/analisis/U-01_multi-rol-airbnb.md` (v2.1)
- Decisiones: D1 (array roles), D2 (CUIT centralizado), D7 (ARCA centralizado)
- Pre-flight U-02 aprobado por Gerardo

🤖 Generated with [Claude Code](https://claude.com/claude-code)