### PR TITLE
fix: K-02 preparar codigo para bucket documentos privado

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,13 @@
 # Daily Log
 
+## 2026-05-24
+
+### Gerardo Breard
+- **21:31** `6295a46` — fix(k-02): preparar codigo para bucket documentos privado
+  - `src/app/(estado)/estado/talleres/[id]/page.tsx`
+  - `src/app/api/validaciones/[id]/signed-url/route.ts`
+
+
 ## 2026-05-20
 
 ### Gerardo Breard

--- a/src/app/(estado)/estado/talleres/[id]/page.tsx
+++ b/src/app/(estado)/estado/talleres/[id]/page.tsx
@@ -16,6 +16,7 @@ import { MapPin, Mail, Phone, FileText, Award } from 'lucide-react'
 import { Breadcrumbs } from '@/compartido/componentes/ui/breadcrumbs'
 import { BadgeArca } from '@/compartido/componentes/badge-arca'
 import { ReverificarButton } from './reverificar-button'
+import { VerDocumentoButton } from '@/taller/componentes/ver-documento-button'
 
 const estadoToStatus: Record<string, 'completed' | 'pending' | 'warning' | 'optional'> = {
   COMPLETADO: 'completed',
@@ -288,18 +289,13 @@ export default async function EstadoDetalleTallerPage({ params, searchParams }: 
                     </a>
                   </div>
                 )}
-                {/* Link del documento */}
+                {/* Link del documento (signed URL on-the-fly) */}
                 {v.documentoUrl && (
                   <div className="mt-2 ml-8">
-                    <a
-                      href={v.documentoUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-brand-blue underline text-sm inline-flex items-center gap-1"
-                    >
-                      <FileText className="w-3.5 h-3.5" />
-                      Ver documento
-                    </a>
+                    <VerDocumentoButton
+                      validacionId={v.id}
+                      fileName="Ver documento"
+                    />
                   </div>
                 )}
                 {/* Acciones para PENDIENTE — solo ESTADO */}

--- a/src/app/api/validaciones/[id]/signed-url/route.ts
+++ b/src/app/api/validaciones/[id]/signed-url/route.ts
@@ -18,8 +18,9 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 
     if (!validacion) return NextResponse.json({ error: 'No encontrada' }, { status: 404 })
 
-    // Solo el taller dueño o ADMIN pueden ver el documento
-    if (role !== 'ADMIN' && validacion.taller.userId !== session.user.id) {
+    // Solo el taller dueño, ADMIN o ESTADO pueden ver el documento
+    const canAccess = role === 'ADMIN' || role === 'ESTADO' || validacion.taller.userId === session.user.id
+    if (!canAccess) {
       return NextResponse.json({ error: 'Sin acceso' }, { status: 403 })
     }
 


### PR DESCRIPTION
## Summary

- Permitir rol ESTADO en `/api/validaciones/[id]/signed-url` (ESTADO revisa documentos para aprobar/rechazar)
- Pantalla `/estado/talleres/[id]` usa `VerDocumentoButton` (signed URL on-the-fly) en vez de URL pública directa

## Contexto

El bucket `documentos` en prod está como `public=true` (K-02, issue #354). Antes de cambiarlo a privado, el código debe generar signed URLs en vez de usar URLs públicas directas.

**Este PR NO cambia el bucket todavía.** Solo prepara el código para que el cambio de bucket no rompa nada.

## Test plan

- [ ] ESTADO puede ver documentos de validación en `/estado/talleres/[id]` (via signed URL)
- [ ] TALLER sigue viendo sus documentos en `/taller/formalizacion`
- [ ] MARCA no puede acceder a documentos de otros talleres (403)
- [ ] Build pasa en CI

Closes #354 (parcialmente — falta el cambio de bucket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)