### PR TITLE
feat: X-07c fase 2 — ocultar niveles en ESTADO/ADMIN

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -26,6 +26,19 @@
   - `src/app/(taller)/taller/perfil/page.tsx`
   - `src/taller/componentes/asistente-chat.tsx`
 
+- **22:50** `8d8ddc5` — feat(x-07c): ocultar niveles en ESTADO y ADMIN (fase 2)
+  - `src/app/(admin)/admin/notificaciones/notificaciones-client.tsx`
+  - `src/app/(admin)/admin/reportes/page.tsx`
+  - `src/app/(admin)/admin/talleres/[id]/page.tsx`
+  - `src/app/(admin)/admin/talleres/page.tsx`
+  - `src/app/(estado)/estado/configuracion-niveles/page.tsx`
+  - `src/app/(estado)/estado/documentos/page.tsx`
+  - `src/app/(estado)/estado/exportar/page.tsx`
+  - `src/app/(estado)/estado/page.tsx`
+  - `src/app/(estado)/estado/talleres/[id]/page.tsx`
+  - `src/app/(estado)/estado/talleres/page.tsx`
+  - `src/compartido/lib/formalizacion.ts`
+
 - **22:27** `f14f47e` — feat(x-07b): ocultar niveles en UI de taller y marca (fase 1)
   - `src/app/(auth)/acceso-rapido/page.tsx`
   - `src/app/(marca)/marca/directorio/page.tsx`

--- a/DAILY.md
+++ b/DAILY.md
@@ -13,6 +13,11 @@
 - **11:11** `98c63da` — fix(x-06b): recortar aire vertical del diagrama de proceso (QA Sergio)
   - `src/app/page.tsx`
 
+- **10:52** `9913013` — fix(x-07c): resolver 4 bugs del QA de Sergio
+  - `src/app/(estado)/estado/documentos/page.tsx`
+  - `src/compartido/componentes/layout/user-sidebar.tsx`
+  - `src/compartido/lib/content/institutional.ts`
+
 
 ## 2026-05-24
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -10,6 +10,9 @@
 
 - **11:41** `e8b69db` — chore: trigger e2e after rebase to develop
 
+- **11:19** `eb835f5` — fix(test): desambiguar selectores en configuracion-niveles e2e
+  - `tests/e2e/configuracion-niveles.spec.ts`
+
 - **11:11** `98c63da` — fix(x-06b): recortar aire vertical del diagrama de proceso (QA Sergio)
   - `src/app/page.tsx`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -13,6 +13,9 @@
 - **11:11** `98c63da` — fix(x-06b): recortar aire vertical del diagrama de proceso (QA Sergio)
   - `src/app/page.tsx`
 
+- **11:04** `90e35ff` — fix(x-07c): corregir textos de nivel en seed reglas_nivel (BUG 1)
+  - `prisma/seed.ts`
+
 - **10:52** `9913013` — fix(x-07c): resolver 4 bugs del QA de Sergio
   - `src/app/(estado)/estado/documentos/page.tsx`
   - `src/compartido/componentes/layout/user-sidebar.tsx`

--- a/DAILY.md
+++ b/DAILY.md
@@ -10,6 +10,9 @@
 
 - **11:41** `e8b69db` — chore: trigger e2e after rebase to develop
 
+- **11:25** `401a8fc` — fix(test): exact:true en los 3 selectores de etapa (no solo Etapa inicial)
+  - `tests/e2e/configuracion-niveles.spec.ts`
+
 - **11:19** `eb835f5` — fix(test): desambiguar selectores en configuracion-niveles e2e
   - `tests/e2e/configuracion-niveles.spec.ts`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -26,6 +26,9 @@
   - `src/app/(taller)/taller/perfil/page.tsx`
   - `src/taller/componentes/asistente-chat.tsx`
 
+- **22:57** `37c4ee8` — fix(x-07c): actualizar e2e test de configuracion-niveles al nuevo copy
+  - `tests/e2e/configuracion-niveles.spec.ts`
+
 - **22:50** `8d8ddc5` — feat(x-07c): ocultar niveles en ESTADO y ADMIN (fase 2)
   - `src/app/(admin)/admin/notificaciones/notificaciones-client.tsx`
   - `src/app/(admin)/admin/reportes/page.tsx`

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -230,7 +230,7 @@ async function main() {
         puntosMinimos: 0,
         requiereVerificadoAfip: false,
         certificadosAcademiaMin: 0,
-        descripcion: 'Nivel inicial — el taller esta registrado en la plataforma',
+        descripcion: 'Etapa inicial — el taller está registrado en la plataforma',
         beneficios: ['Aparece en el directorio publico', 'Recibe pedidos compatibles con su capacidad'],
       },
       {
@@ -239,7 +239,7 @@ async function main() {
         requiereVerificadoAfip: true,
         certificadosAcademiaMin: 1,
         descripcion: 'El taller demuestra formalizacion basica y compromiso con la capacitacion',
-        beneficios: ['Aparece mas arriba en el directorio', 'Acceso a pedidos de marcas medianas', 'Distintivo PLATA visible'],
+        beneficios: ['Aparece mas arriba en el directorio', 'Acceso a pedidos de marcas medianas', 'Distintivo de formalización visible en el directorio'],
       },
       {
         nivel: 'ORO',
@@ -247,7 +247,7 @@ async function main() {
         requiereVerificadoAfip: true,
         certificadosAcademiaMin: 0,
         descripcion: 'Taller plenamente formalizado con capacitacion avanzada',
-        beneficios: ['Top del directorio', 'Acceso a marcas grandes', 'Invitaciones directas a pedidos premium', 'Distintivo ORO visible'],
+        beneficios: ['Top del directorio', 'Acceso a marcas grandes', 'Invitaciones directas a pedidos premium', 'Distintivo de formalización consolidada visible en el directorio'],
       },
     ],
   })

--- a/src/app/(admin)/admin/notificaciones/notificaciones-client.tsx
+++ b/src/app/(admin)/admin/notificaciones/notificaciones-client.tsx
@@ -114,9 +114,9 @@ export default function NotificacionesClient() {
               {[
                 { value: 'todos', label: 'Todos los usuarios' },
                 { value: 'talleres', label: 'Todos los talleres' },
-                { value: 'talleres_bronce', label: 'Talleres Bronce' },
-                { value: 'talleres_plata', label: 'Talleres Plata' },
-                { value: 'talleres_oro', label: 'Talleres Oro' },
+                { value: 'talleres_bronce', label: 'Talleres — Etapa inicial' },
+                { value: 'talleres_plata', label: 'Talleres — En proceso' },
+                { value: 'talleres_oro', label: 'Talleres — Consolidados' },
                 { value: 'marcas', label: 'Todas las marcas' },
               ].map(opt => (
                 <label key={opt.value} className="flex items-center gap-2 cursor-pointer">

--- a/src/app/(admin)/admin/reportes/page.tsx
+++ b/src/app/(admin)/admin/reportes/page.tsx
@@ -45,9 +45,9 @@ export default async function AdminReportesPage() {
     nivelMap[g.nivel] = g._count
   }
   const niveles = [
-    { nivel: 'Oro', count: nivelMap.ORO, color: 'bg-yellow-400' },
-    { nivel: 'Plata', count: nivelMap.PLATA, color: 'bg-gray-400' },
-    { nivel: 'Bronce', count: nivelMap.BRONCE, color: 'bg-amber-600' },
+    { nivel: 'Consolidada', count: nivelMap.ORO, color: 'bg-blue-600' },
+    { nivel: 'En proceso', count: nivelMap.PLATA, color: 'bg-blue-400' },
+    { nivel: 'Etapa inicial', count: nivelMap.BRONCE, color: 'bg-blue-300' },
   ]
   const totalNivel = totalTalleres || 1
 

--- a/src/app/(admin)/admin/talleres/[id]/page.tsx
+++ b/src/app/(admin)/admin/talleres/[id]/page.tsx
@@ -12,6 +12,7 @@ import { MapPin, Mail, Phone, AlertTriangle, Award } from 'lucide-react'
 import { Breadcrumbs } from '@/compartido/componentes/ui/breadcrumbs'
 import { BotonEnviarMensaje } from '@/admin/componentes/boton-enviar-mensaje'
 import { NotasSeguimiento } from '@/admin/componentes/notas-seguimiento'
+import { nivelAEtapa } from '@/compartido/lib/formalizacion'
 
 export default async function AdminDetalleTallerPage({ params, searchParams }: {
   params: Promise<{ id: string }>
@@ -111,7 +112,7 @@ export default async function AdminDetalleTallerPage({ params, searchParams }: {
               {taller.user.phone && <span className="flex items-center gap-1"><Phone className="w-3.5 h-3.5" /> {taller.user.phone}</span>}
             </div>
             <div className="flex items-center gap-3 mt-3">
-              <Badge variant={nivelVariant}>{taller.nivel}</Badge>
+              <Badge variant={nivelVariant}>{nivelAEtapa(taller.nivel)}</Badge>
               <Badge variant="outline">{taller.puntaje} pts</Badge>
               <Badge variant={taller.user.active ? 'success' : 'warning'}>{taller.user.active ? 'Activo' : 'Inactivo'}</Badge>
               <BotonEnviarMensaje

--- a/src/app/(admin)/admin/talleres/page.tsx
+++ b/src/app/(admin)/admin/talleres/page.tsx
@@ -11,6 +11,7 @@ import { StatCard } from '@/compartido/componentes/ui/stat-card'
 import { Select } from '@/compartido/componentes/ui/select'
 import { Eye, Edit } from 'lucide-react'
 import { EmptyState } from '@/compartido/componentes/ui/empty-state'
+import { nivelAEtapa } from '@/compartido/lib/formalizacion'
 
 interface TallerRow {
   id: string
@@ -51,8 +52,8 @@ export default function AdminTalleresPage() {
       </div>
     )},
     { header: 'CUIT', accessor: 'cuit' as const, sortable: true },
-    { header: 'Nivel', accessor: (row: TallerRow) => (
-      <Badge variant={row.nivel === 'ORO' ? 'success' : row.nivel === 'PLATA' ? 'default' : 'warning'}>{row.nivel}</Badge>
+    { header: 'Etapa', accessor: (row: TallerRow) => (
+      <Badge variant={row.nivel === 'ORO' ? 'success' : row.nivel === 'PLATA' ? 'default' : 'warning'}>{nivelAEtapa(row.nivel)}</Badge>
     )},
     { header: 'Estado', accessor: (row: TallerRow) => (
       <Badge variant={row.user.active ? 'success' : 'warning'}>{row.user.active ? 'Activo' : 'Inactivo'}</Badge>
@@ -73,9 +74,9 @@ export default function AdminTalleresPage() {
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
         <StatCard value={String(talleres.length)} label="Total" variant="success" />
-        <StatCard value={String(byNivel('ORO'))} label="Oro" variant="success" />
-        <StatCard value={String(byNivel('PLATA'))} label="Plata" variant="muted" />
-        <StatCard value={String(byNivel('BRONCE'))} label="Bronce" variant="warning" />
+        <StatCard value={String(byNivel('ORO'))} label="Consolidada" variant="success" />
+        <StatCard value={String(byNivel('PLATA'))} label="En proceso" variant="muted" />
+        <StatCard value={String(byNivel('BRONCE'))} label="Etapa inicial" variant="warning" />
       </div>
 
       <div className="flex gap-3 mb-4">
@@ -84,10 +85,10 @@ export default function AdminTalleresPage() {
           value={filtroNivel}
           onChange={e => setFiltroNivel(e.target.value)}
           options={[
-            { value: '', label: 'Todos los niveles' },
-            { value: 'ORO', label: 'Oro' },
-            { value: 'PLATA', label: 'Plata' },
-            { value: 'BRONCE', label: 'Bronce' },
+            { value: '', label: 'Todas las etapas' },
+            { value: 'ORO', label: 'Consolidada' },
+            { value: 'PLATA', label: 'En proceso' },
+            { value: 'BRONCE', label: 'Etapa inicial' },
           ]}
         />
       </div>

--- a/src/app/(estado)/estado/configuracion-niveles/page.tsx
+++ b/src/app/(estado)/estado/configuracion-niveles/page.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/compartido/componentes/ui/badge'
 import { Modal } from '@/compartido/componentes/ui/modal'
 import { useToast } from '@/compartido/componentes/ui/toast'
 import { Edit, AlertTriangle } from 'lucide-react'
+import { nivelAEtapa } from '@/compartido/lib/formalizacion'
 
 interface ReglaNivel {
   id: string
@@ -102,7 +103,7 @@ export default function EstadoConfiguracionNivelesPage() {
         body: JSON.stringify(editData),
       })
       if (!res.ok) { toast({ mensaje: 'Error al guardar', tipo: 'error' }); return }
-      toast({ mensaje: `Regla ${editModal.nivel} actualizada`, tipo: 'success' })
+      toast({ mensaje: `Regla "${nivelAEtapa(editModal.nivel)}" actualizada`, tipo: 'success' })
       setEditModal(null)
       fetchReglas()
     } finally {
@@ -112,8 +113,8 @@ export default function EstadoConfiguracionNivelesPage() {
 
   return (
     <div className="max-w-4xl mx-auto py-6 px-4">
-      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Configuracion de Niveles</h1>
-      <p className="text-gray-500 text-sm mb-6">Criterios para que los talleres alcancen cada nivel — configuracion regulatoria del Estado</p>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Configuración de etapas</h1>
+      <p className="text-gray-500 text-sm mb-6">Criterios para que los talleres alcancen cada etapa de formalización — configuración regulatoria del Estado</p>
 
       {loading ? (
         <p className="text-sm text-gray-500 text-center py-8">Cargando...</p>
@@ -124,7 +125,7 @@ export default function EstadoConfiguracionNivelesPage() {
               <div className="flex items-start justify-between">
                 <div className="flex-1">
                   <div className="flex items-center gap-2 mb-2">
-                    <Badge variant={nivelVariant[regla.nivel] || 'default'} className="text-sm px-3 py-1">{regla.nivel}</Badge>
+                    <Badge variant={nivelVariant[regla.nivel] || 'default'} className="text-sm px-3 py-1">{nivelAEtapa(regla.nivel)}</Badge>
                     <span className="text-sm text-gray-500">{regla.puntosMinimos} pts minimos</span>
                   </div>
                   {regla.descripcion && <p className="text-sm text-gray-600 mb-3">{regla.descripcion}</p>}
@@ -152,7 +153,7 @@ export default function EstadoConfiguracionNivelesPage() {
         </div>
       )}
 
-      <Modal open={!!editModal} onClose={() => setEditModal(null)} title={`Editar regla ${editModal?.nivel}`} size="lg">
+      <Modal open={!!editModal} onClose={() => setEditModal(null)} title={`Editar regla — ${editModal ? nivelAEtapa(editModal.nivel) : ''}`} size="lg">
         {editModal && (
           <div className="space-y-4">
             <div>
@@ -184,22 +185,22 @@ export default function EstadoConfiguracionNivelesPage() {
                 <div className="mt-3 rounded-lg bg-gray-50 p-3">
                   <p className="text-sm font-semibold text-gray-700 mb-1">
                     {preview.talleresAfectados === 0
-                      ? 'Ningun taller cambiaria de nivel con esta configuracion.'
-                      : `${preview.talleresAfectados} de ${preview.totalTalleres} talleres cambiarian de nivel:`}
+                      ? 'Ningún taller cambiaría de etapa con esta configuración.'
+                      : `${preview.talleresAfectados} de ${preview.totalTalleres} talleres cambiarían de etapa:`}
                   </p>
                   {preview.bajan > 0 && (
                     <div className="flex items-center gap-1 text-sm text-red-600 mt-1">
                       <AlertTriangle className="w-4 h-4" />
-                      {preview.bajan} taller{preview.bajan > 1 ? 'es' : ''} bajaria{preview.bajan > 1 ? 'n' : ''} de nivel
+                      {preview.bajan} taller{preview.bajan > 1 ? 'es' : ''} retrocedería{preview.bajan > 1 ? 'n' : ''} de etapa
                     </div>
                   )}
                   {preview.suben > 0 && (
-                    <p className="text-sm text-green-600 mt-1">{preview.suben} taller{preview.suben > 1 ? 'es' : ''} subiria{preview.suben > 1 ? 'n' : ''} de nivel</p>
+                    <p className="text-sm text-green-600 mt-1">{preview.suben} taller{preview.suben > 1 ? 'es' : ''} avanzaría{preview.suben > 1 ? 'n' : ''} de etapa</p>
                   )}
                   {preview.detalle.length > 0 && (
                     <div className="mt-2 space-y-1">
                       {preview.detalle.map((d, i) => (
-                        <p key={i} className="text-xs text-gray-600">{d.nombre}: {d.nivelActual} → {d.nivelNuevo}</p>
+                        <p key={i} className="text-xs text-gray-600">{d.nombre}: {nivelAEtapa(d.nivelActual)} → {nivelAEtapa(d.nivelNuevo)}</p>
                       ))}
                     </div>
                   )}

--- a/src/app/(estado)/estado/documentos/page.tsx
+++ b/src/app/(estado)/estado/documentos/page.tsx
@@ -142,12 +142,12 @@ export default function EstadoDocumentosPage() {
             )}
             {!editando.id && (
               <div>
-                <label className="block text-sm font-semibold text-gray-700 mb-1">Nivel minimo</label>
+                <label className="block text-sm font-semibold text-gray-700 mb-1">Etapa mínima</label>
                 <select value={editando.nivelMinimo} onChange={e => setEditando({ ...editando, nivelMinimo: e.target.value })}
                   className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue focus:border-transparent">
-                  <option value="BRONCE">Bronce</option>
-                  <option value="PLATA">Plata</option>
-                  <option value="ORO">Oro</option>
+                  <option value="BRONCE">Etapa inicial</option>
+                  <option value="PLATA">En proceso de formalización</option>
+                  <option value="ORO">Formalización consolidada</option>
                 </select>
               </div>
             )}

--- a/src/app/(estado)/estado/documentos/page.tsx
+++ b/src/app/(estado)/estado/documentos/page.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/compartido/componentes/ui/input'
 import { Modal } from '@/compartido/componentes/ui/modal'
 import { Badge } from '@/compartido/componentes/ui/badge'
 import { Plus, Edit } from 'lucide-react'
+import { nivelAEtapa } from '@/compartido/lib/formalizacion'
 
 interface TipoDocumento {
   id: string
@@ -94,7 +95,7 @@ export default function EstadoDocumentosPage() {
                     <div className="flex items-center gap-2">
                       <p className="font-semibold text-sm">{doc.nombre}</p>
                       <Badge variant="muted">{doc.puntosOtorgados} pts</Badge>
-                      <Badge variant="default">{doc.nivelMinimo}</Badge>
+                      <Badge variant="default">{nivelAEtapa(doc.nivelMinimo)}</Badge>
                       {!doc.activo && <Badge variant="warning">Inactivo</Badge>}
                     </div>
                     {doc.descripcion && (
@@ -118,7 +119,7 @@ export default function EstadoDocumentosPage() {
       <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1">Tipos de Documento</h1>
-          <p className="text-gray-500 text-sm">Requisitos de formalizacion por nivel — configuracion regulatoria del Estado</p>
+          <p className="text-gray-500 text-sm">Requisitos de formalización por etapa — configuración regulatoria del Estado</p>
         </div>
         <Button icon={<Plus className="w-4 h-4" />} onClick={handleNew}>Nuevo Requisito</Button>
       </div>

--- a/src/app/(estado)/estado/exportar/page.tsx
+++ b/src/app/(estado)/estado/exportar/page.tsx
@@ -200,10 +200,10 @@ export default function ExportarReportePage() {
                     onChange={e => setFiltro(r.value, 'nivel', e.target.value)}
                     className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-xs"
                   >
-                    <option value="">Todos los niveles</option>
-                    <option value="BRONCE">Bronce</option>
-                    <option value="PLATA">Plata</option>
-                    <option value="ORO">Oro</option>
+                    <option value="">Todas las etapas</option>
+                    <option value="BRONCE">Etapa inicial</option>
+                    <option value="PLATA">En proceso de formalización</option>
+                    <option value="ORO">Formalización consolidada</option>
                   </select>
                 )}
               </div>

--- a/src/app/(estado)/estado/page.tsx
+++ b/src/app/(estado)/estado/page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'
 import { Card } from '@/compartido/componentes/ui/card'
 import { Badge } from '@/compartido/componentes/ui/badge'
 import { Factory, Store, FileCheck, Award, Clock, TrendingUp, TrendingDown, AlertCircle, BookOpen, ShoppingBag } from 'lucide-react'
+import { nivelAEtapa } from '@/compartido/lib/formalizacion'
 
 export default async function EstadoDashboardPage() {
   const session = await auth()
@@ -118,12 +119,12 @@ export default async function EstadoDashboardPage() {
         </div>
 
         <Card title="Progreso de formalización">
-          <p className="text-xs text-gray-400 mb-3">Porcentaje de documentos completados sobre el total requerido por nivel. Bronce = requisitos básicos, Plata = intermedios, Oro = avanzados.</p>
+          <p className="text-xs text-gray-400 mb-3">Distribución de talleres por etapa de formalización.</p>
           <div className="space-y-3">
             {[
-              { label: 'Bronce', count: bronce, color: 'bg-orange-400', textColor: 'text-orange-600' },
-              { label: 'Plata', count: plata, color: 'bg-gray-400', textColor: 'text-gray-500' },
-              { label: 'Oro', count: oro, color: 'bg-yellow-400', textColor: 'text-yellow-600' },
+              { label: nivelAEtapa('BRONCE'), count: bronce, color: 'bg-blue-300', textColor: 'text-blue-600' },
+              { label: nivelAEtapa('PLATA'), count: plata, color: 'bg-blue-400', textColor: 'text-blue-700' },
+              { label: nivelAEtapa('ORO'), count: oro, color: 'bg-blue-600', textColor: 'text-blue-800' },
             ].map(({ label, count, color, textColor }) => (
               <div key={label}>
                 <div className="flex justify-between text-sm mb-1">
@@ -141,7 +142,7 @@ export default async function EstadoDashboardPage() {
           </div>
           <div className="mt-4 pt-3 border-t border-gray-100 flex justify-between text-xs text-gray-400">
             <span>{totalTalleres} talleres en total</span>
-            <span>{totalTalleres > 0 ? Math.round(((plata + oro) / totalTalleres) * 100) : 0}% formalizados (Plata+Oro)</span>
+            <span>{totalTalleres > 0 ? Math.round(((plata + oro) / totalTalleres) * 100) : 0}% en proceso o consolidados</span>
           </div>
         </Card>
       </div>

--- a/src/app/(estado)/estado/talleres/[id]/page.tsx
+++ b/src/app/(estado)/estado/talleres/[id]/page.tsx
@@ -13,6 +13,7 @@ import { Badge } from '@/compartido/componentes/ui/badge'
 import { SubmitButton } from '@/compartido/componentes/ui/button'
 import { ChecklistItem } from '@/compartido/componentes/ui/checklist-item'
 import { MapPin, Mail, Phone, FileText, Award } from 'lucide-react'
+import { nivelAEtapa } from '@/compartido/lib/formalizacion'
 import { Breadcrumbs } from '@/compartido/componentes/ui/breadcrumbs'
 import { BadgeArca } from '@/compartido/componentes/badge-arca'
 import { ReverificarButton } from './reverificar-button'
@@ -221,7 +222,7 @@ export default async function EstadoDetalleTallerPage({ params, searchParams }: 
               {taller.user.phone && <span className="flex items-center gap-1"><Phone className="w-3.5 h-3.5" /> {taller.user.phone}</span>}
             </div>
             <div className="flex items-center gap-3 mt-3">
-              <Badge variant={nivelVariant}>{taller.nivel}</Badge>
+              <Badge variant={nivelVariant}>{nivelAEtapa(taller.nivel)}</Badge>
               <Badge variant="outline">{taller.puntaje} pts</Badge>
               <Badge variant={taller.user.active ? 'success' : 'warning'}>{taller.user.active ? 'Activo' : 'Inactivo'}</Badge>
             </div>

--- a/src/app/(estado)/estado/talleres/page.tsx
+++ b/src/app/(estado)/estado/talleres/page.tsx
@@ -9,6 +9,7 @@ import { StatCard } from '@/compartido/componentes/ui/stat-card'
 import { Eye } from 'lucide-react'
 import { BadgeArca } from '@/compartido/componentes/badge-arca'
 import { SyncArcaButton } from './sync-arca-button'
+import { nivelAEtapa } from '@/compartido/lib/formalizacion'
 
 export default async function EstadoTalleresPage({
   searchParams,
@@ -61,9 +62,9 @@ export default async function EstadoTalleresPage({
 
       <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">
         <StatCard value={String(talleres.length)} label="Total" variant="success" />
-        <StatCard value={String(byNivel('ORO'))} label="Oro" variant="success" />
-        <StatCard value={String(byNivel('PLATA'))} label="Plata" variant="muted" />
-        <StatCard value={String(byNivel('BRONCE'))} label="Bronce" variant="warning" />
+        <StatCard value={String(byNivel('ORO'))} label="Consolidada" variant="success" />
+        <StatCard value={String(byNivel('PLATA'))} label="En proceso" variant="muted" />
+        <StatCard value={String(byNivel('BRONCE'))} label="Etapa inicial" variant="warning" />
         <StatCard value={String(sinVerificar)} label="Sin verificar" variant={sinVerificar > 0 ? 'warning' : 'muted'} />
       </div>
 
@@ -84,10 +85,10 @@ export default async function EstadoTalleresPage({
       <Card className="mb-4">
         <form method="get" className="grid grid-cols-1 sm:grid-cols-4 gap-3">
           <select name="nivel" defaultValue={nivel || ''} className="rounded-lg border border-gray-300 px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue">
-            <option value="">Todos los niveles</option>
-            <option value="BRONCE">Bronce</option>
-            <option value="PLATA">Plata</option>
-            <option value="ORO">Oro</option>
+            <option value="">Todas las etapas</option>
+            <option value="BRONCE">Etapa inicial</option>
+            <option value="PLATA">En proceso de formalización</option>
+            <option value="ORO">Formalización consolidada</option>
           </select>
           <select name="provincia" defaultValue={provincia || ''} className="rounded-lg border border-gray-300 px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue">
             <option value="">Todas las provincias</option>
@@ -119,7 +120,7 @@ export default async function EstadoTalleresPage({
             <thead>
               <tr className="border-b border-gray-200">
                 <th className="text-left px-4 py-3 text-sm font-overpass font-semibold text-gray-600">Taller</th>
-                <th className="text-left px-4 py-3 text-sm font-overpass font-semibold text-gray-600">Nivel</th>
+                <th className="text-left px-4 py-3 text-sm font-overpass font-semibold text-gray-600">Etapa</th>
                 <th className="text-left px-4 py-3 text-sm font-overpass font-semibold text-gray-600">Provincia</th>
                 <th className="text-left px-4 py-3 text-sm font-overpass font-semibold text-gray-600">Docs pendientes</th>
                 <th className="text-left px-4 py-3 text-sm font-overpass font-semibold text-gray-600">Progreso</th>
@@ -137,7 +138,7 @@ export default async function EstadoTalleresPage({
                     <BadgeArca verificado={t.verificadoAfip} fecha={t.verificadoAfipAt} />
                   </td>
                   <td className="px-4 py-3">
-                    <Badge variant={t.nivel === 'ORO' ? 'success' : t.nivel === 'PLATA' ? 'default' : 'warning'}>{t.nivel}</Badge>
+                    <Badge variant={t.nivel === 'ORO' ? 'success' : t.nivel === 'PLATA' ? 'default' : 'warning'}>{nivelAEtapa(t.nivel)}</Badge>
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-600">{t.provincia || '-'}</td>
                   <td className="px-4 py-3">

--- a/src/compartido/componentes/layout/user-sidebar.tsx
+++ b/src/compartido/componentes/layout/user-sidebar.tsx
@@ -67,7 +67,7 @@ const menuItemsByRole: Record<string, MenuItem[]> = {
     { id: 'talleres', label: 'Talleres', href: '/estado/talleres', icon: Building2 },
     { id: 'documentos', label: 'Documentos', href: '/estado/documentos', icon: FileText },
     { id: 'auditorias', label: 'Auditorias', href: '/estado/auditorias', icon: ClipboardCheck },
-    { id: 'niveles', label: 'Niveles', href: '/estado/configuracion-niveles', icon: Sliders },
+    { id: 'niveles', label: 'Etapas', href: '/estado/configuracion-niveles', icon: Sliders },
     { id: 'demanda', label: 'Demanda insatisfecha', href: '/estado/demanda-insatisfecha', icon: AlertTriangle },
     { id: 'sector', label: 'Datos sectoriales', href: '/estado/sector', icon: BarChart3 },
     { id: 'exportar', label: 'Exportar Datos', href: '/estado/exportar', icon: Download },

--- a/src/compartido/lib/content/institutional.ts
+++ b/src/compartido/lib/content/institutional.ts
@@ -38,6 +38,10 @@ export const TABS_BY_ROLE = {
   ],
   ESTADO: [
     { label: 'Dashboard', href: '/estado' },
+    { label: 'Talleres', href: '/estado/talleres' },
+    { label: 'Documentos', href: '/estado/documentos' },
+    { label: 'Etapas', href: '/estado/configuracion-niveles' },
+    { label: 'Auditorías', href: '/estado/auditorias' },
     { label: 'Demanda insatisfecha', href: '/estado/demanda-insatisfecha' },
     { label: 'Datos sectoriales', href: '/estado/sector' },
     { label: 'Exportar', href: '/estado/exportar' },

--- a/src/compartido/lib/formalizacion.ts
+++ b/src/compartido/lib/formalizacion.ts
@@ -8,7 +8,6 @@ const MAPA_ETAPAS: Record<NivelTaller, string> = {
 
 /**
  * Convierte el nivel interno (BRONCE/PLATA/ORO) a la etapa visible para el usuario.
- * Solo para UI de cara a taller/marca. Estado/Admin siguen viendo el nivel.
  */
 export function nivelAEtapa(nivel: NivelTaller | string): string {
   return MAPA_ETAPAS[nivel as NivelTaller] ?? 'Etapa inicial'

--- a/tests/e2e/configuracion-niveles.spec.ts
+++ b/tests/e2e/configuracion-niveles.spec.ts
@@ -17,7 +17,7 @@ test.describe('D-02 Configuracion de niveles y tipos de documento', () => {
     await page.goto('/estado/configuracion-niveles')
     await expect(page.getByRole('heading', { name: 'Configuración de etapas' })).toBeVisible()
     // Debe haber 3 cards (etapas de formalización)
-    await expect(page.getByText('Etapa inicial')).toBeVisible()
+    await expect(page.getByText('Etapa inicial', { exact: true })).toBeVisible()
     await expect(page.getByText('En proceso de formalización')).toBeVisible()
     await expect(page.getByText('Formalización consolidada')).toBeVisible()
   })
@@ -42,7 +42,7 @@ test.describe('D-02 Configuracion de niveles y tipos de documento', () => {
     await ensureNotProduction(page)
     await loginAs(page, 'admin')
     await page.goto('/estado/configuracion-niveles')
-    await expect(page.getByText('Etapa inicial')).toBeVisible()
+    await expect(page.getByText('Etapa inicial', { exact: true })).toBeVisible()
   })
 
   test('TALLER no puede acceder a configuracion-niveles API', async ({ page, playwright }) => {

--- a/tests/e2e/configuracion-niveles.spec.ts
+++ b/tests/e2e/configuracion-niveles.spec.ts
@@ -18,8 +18,8 @@ test.describe('D-02 Configuracion de niveles y tipos de documento', () => {
     await expect(page.getByRole('heading', { name: 'Configuración de etapas' })).toBeVisible()
     // Debe haber 3 cards (etapas de formalización)
     await expect(page.getByText('Etapa inicial', { exact: true })).toBeVisible()
-    await expect(page.getByText('En proceso de formalización')).toBeVisible()
-    await expect(page.getByText('Formalización consolidada')).toBeVisible()
+    await expect(page.getByText('En proceso de formalización', { exact: true })).toBeVisible()
+    await expect(page.getByText('Formalización consolidada', { exact: true })).toBeVisible()
   })
 
   test('ESTADO puede ver puntos en /estado/documentos', async ({ page }) => {

--- a/tests/e2e/configuracion-niveles.spec.ts
+++ b/tests/e2e/configuracion-niveles.spec.ts
@@ -15,11 +15,11 @@ test.describe('D-02 Configuracion de niveles y tipos de documento', () => {
     await ensureNotProduction(page)
     await loginEstado(page)
     await page.goto('/estado/configuracion-niveles')
-    await expect(page.getByRole('heading', { name: 'Configuracion de Niveles' })).toBeVisible()
-    // Debe haber 3 cards (BRONCE, PLATA, ORO)
-    await expect(page.getByText('BRONCE', { exact: true })).toBeVisible()
-    await expect(page.getByText('PLATA', { exact: true })).toBeVisible()
-    await expect(page.getByText('ORO', { exact: true })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Configuración de etapas' })).toBeVisible()
+    // Debe haber 3 cards (etapas de formalización)
+    await expect(page.getByText('Etapa inicial')).toBeVisible()
+    await expect(page.getByText('En proceso de formalización')).toBeVisible()
+    await expect(page.getByText('Formalización consolidada')).toBeVisible()
   })
 
   test('ESTADO puede ver puntos en /estado/documentos', async ({ page }) => {
@@ -42,7 +42,7 @@ test.describe('D-02 Configuracion de niveles y tipos de documento', () => {
     await ensureNotProduction(page)
     await loginAs(page, 'admin')
     await page.goto('/estado/configuracion-niveles')
-    await expect(page.getByText('BRONCE')).toBeVisible()
+    await expect(page.getByText('Etapa inicial')).toBeVisible()
   })
 
   test('TALLER no puede acceder a configuracion-niveles API', async ({ page, playwright }) => {


### PR DESCRIPTION
## Summary

- Completa el mapeo Bronce/Plata/Oro → etapas de formalización en pantallas de ESTADO y ADMIN
- Decisión OIT: cambiar denominación en TODOS lados, incluyendo config técnica
- 11 archivos tocados, 0 errores TypeScript

### Archivos modificados

| Pantalla | Cambio |
|---|---|
| Estado dashboard | Barra niveles → barra etapas |
| Estado talleres | StatCards + filtro + badge → etapas |
| Estado taller detalle | Badge nivel → etapa |
| Estado exportar | Filtro nivel → etapa |
| Estado config niveles | Títulos, badges, preview → etapas |
| Estado documentos | "Nivel mínimo" → "Etapa mínima" |
| Admin talleres | StatCards + filtro + badge → etapas |
| Admin taller detalle | Badge nivel → etapa |
| Admin reportes | Gráfico barras → etapas |
| Admin notificaciones | Segmentos targeting → etapas |

### Nota sobre merge con fase 1

`formalizacion.ts` se crea idéntico en ambas branches. Al mergear ambas a develop, git resolverá sin conflicto (mismo contenido).

## Test plan

- [ ] Login como Estado: dashboard muestra "Etapa inicial / En proceso / Consolidada"
- [ ] Estado talleres: StatCards, filtros y badges muestran etapas
- [ ] Estado config niveles: badges y preview usan etapas
- [ ] Login como Admin: talleres muestra etapas en todo
- [ ] Admin reportes: gráfico muestra etapas
- [ ] Filtros siguen funcionando (value interno BRONCE/PLATA/ORO intacto)
- [ ] CI pasa

🤖 Generated with [Claude Code](https://claude.com/claude-code)