### PR TITLE
feat: leyenda institucional oficial de OIT en toda la UI

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,14 @@
 # Daily Log
 
+## 2026-05-25
+
+### Gerardo Breard
+- **12:05** `612b951` — feat(leyenda): aplicar leyenda institucional oficial de OIT
+  - `src/app/page.tsx`
+  - `src/compartido/lib/content/institutional.ts`
+  - `src/compartido/lib/email.ts`
+
+
 ## 2026-05-24
 
 ### Gerardo Breard

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -228,9 +228,9 @@ export default async function Home() {
         <div className="max-w-4xl mx-auto px-6 lg:px-8 text-center">
           <p className="text-xs text-ink-secondary">
             <span className="font-overpass font-bold">Programa piloto en curso.</span>{' '}
-            Plataforma Digital Textil es una iniciativa de OIT Argentina y UNTREF
-            en fase de piloto, Conurbano Sur, mayo 2026. Los datos y funcionalidades
-            pueden evolucionar durante esta etapa.
+            Plataforma Digital Textil — desarrollada por UNTREF con el apoyo de
+            la OIT — se encuentra en fase de piloto, Conurbano Sur, mayo 2026.
+            Los datos y funcionalidades pueden evolucionar durante esta etapa.
           </p>
         </div>
       </section>

--- a/src/compartido/lib/content/institutional.ts
+++ b/src/compartido/lib/content/institutional.ts
@@ -1,10 +1,10 @@
 export const INSTITUTIONAL = {
   brandName: 'Plataforma Digital Textil',
-  brandSubtitle: 'OIT \u00b7 UNTREF',
-  brandDescription: 'Una iniciativa de OIT Argentina y la Universidad Nacional de Tres de Febrero.',
+  brandSubtitle: 'Desarrollado por UNTREF con el apoyo de la OIT',
+  brandDescription: 'Desarrollado por UNTREF con el apoyo de la OIT',
   developedBy: 'Desarrollado por UNTREF con el apoyo de la OIT',
   copyrightHolder: 'Plataforma Digital Textil',
-  endorsement: 'Con el respaldo de OIT \u00b7 UNTREF',
+  endorsement: 'Desarrollado por UNTREF con el apoyo de la OIT',
 } as const
 
 export const FOOTER_LINKS = {
@@ -49,13 +49,13 @@ export const TABS_BY_ROLE = {
 export const LANDING_COPY = {
   hero: {
     titleParts: ['Hacé crecer tu taller.', 'Conectá tu marca.', 'Empezá desde donde estés.'],
-    subtitle: 'Plataforma pública de OIT y UNTREF que acompaña a talleres y marcas del sector textil argentino. Capacitaciones gratuitas, perfil profesional y conexión directa entre quienes producen y quienes buscan.',
+    subtitle: 'Plataforma que acompaña a talleres y marcas del sector textil argentino. Capacitaciones gratuitas, perfil profesional y conexión directa entre quienes producen y quienes buscan. Desarrollada por UNTREF con el apoyo de la OIT.',
     ctaTaller: { label: 'Soy taller', href: '/registro?rol=TALLER' },
     ctaMarca: { label: 'Soy marca', href: '/registro?rol=MARCA' },
     imageAlt: 'Trabajadores en taller textil con máquinas de coser',
     cardTrazabilidad: {
       title: 'Acompañamiento institucional',
-      subtitle: 'OIT y UNTREF respaldan tu recorrido.',
+      subtitle: 'Desarrollado por UNTREF con el apoyo de la OIT.',
     },
   },
   impacto: {

--- a/src/compartido/lib/email.ts
+++ b/src/compartido/lib/email.ts
@@ -271,7 +271,7 @@ export function buildInvitacionRegistroEmail(data: {
   const registroUrl = `${appBaseUrl}/registro`
   const guiaUrl = `${appBaseUrl}/ayuda/onboarding-taller`
   return {
-    subject: 'Te invitamos a la Plataforma Digital Textil — UNTREF/OIT',
+    subject: 'Te invitamos a la Plataforma Digital Textil',
     html: emailWrapper(`
       <h2 style="margin: 0 0 12px;">Hola ${data.nombreDestinatario}</h2>
       <p>Soy <strong>${data.nombreReferente}</strong> de ${data.cargoReferente}. Estamos lanzando la <strong>Plataforma Digital Textil</strong>, una herramienta gratuita que conecta talleres como el tuyo con marcas formales.</p>


### PR DESCRIPTION
## Summary
- Aplica la leyenda oficial confirmada por OIT (9/5): **"Desarrollado por UNTREF con el apoyo de la OIT"** en todos los lugares de leyenda institucional
- Corrige 8 variantes viejas: `brandSubtitle`, `brandDescription`, `endorsement`, hero subtitle, hero card flotante, disclaimer piloto, subject email invitación
- Footer + 2 headers se corrigen automáticamente (consumen `institutional.ts`)
- NO toca: certificados/PDF/RAG (ya correctos), menciones narrativas aceptables

## Archivos tocados
- `src/compartido/lib/content/institutional.ts` — 5 strings
- `src/app/page.tsx` — disclaimer piloto
- `src/compartido/lib/email.ts` — subject email

## Test plan
- [ ] Verificar footer global: leyenda correcta en subtítulo, descripción y pie inferior
- [ ] Verificar header público (landing): subtítulo bajo logo
- [ ] Verificar header logueado: subtítulo bajo logo
- [ ] Verificar hero landing: subtítulo y card flotante
- [ ] Verificar disclaimer piloto amarillo al pie del landing
- [ ] Verificar que certificados PDF y orden PDF no cambiaron (ya correctos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)