### PR TITLE
feat: W-A2 a W-A5 — completar formulario de taller

### DIFF
--- a/.claude/auditorias/QA_v4-w-a-formulario-taller.md
+++ b/.claude/auditorias/QA_v4-w-a-formulario-taller.md
@@ -1,0 +1,144 @@
+# QA V4 — W-A: Completar formulario de perfil del taller (W-A2 a W-A5)
+
+| Campo | Valor |
+|---|---|
+| **Versión** | v4 |
+| **Spec auditado** | `v4-w-a-formulario-taller.md` |
+| **Categoría** | MVP no negociable |
+| **Auditor** | Sergio |
+| **Fecha** | 2026-05-25 |
+| **URL auditada** | `https://dev.plataformatextil.com.ar` (o preview de PR #363) |
+| **Commit auditado** | b218e0a |
+| **PR vinculado** | #363 |
+| **Issue vinculado** | #299, #300, #301, #302, #303, #304 |
+| **Tipo de QA** | browser-manual |
+
+---
+
+## Contexto institucional
+
+Plataforma Digital Textil (PDT) — proyecto OIT-UNTREF para formalización del sector textil argentino. Modelo: Showcase + Match con backend institucional invisible. Versión actual: V4. El formulario de completar perfil del taller es donde los talleres del piloto cargan su información productiva.
+
+---
+
+## Objetivo del QA
+
+Verificar que los cuatro ajustes del formulario de perfil del taller (W-A2 a W-A5) funcionan correctamente: nuevas opciones de organización y registro, desdoblamiento de la pregunta de capacidad, y los 10 roles funcionales que ahora se persisten.
+
+---
+
+## Instrucciones de trabajo
+
+1. Iniciar sesión como TALLER: `roberto.gimenez@pdt.org.ar` (contraseña: pdt2026)
+2. Ir a completar/editar el perfil del taller
+3. Ejecutar cada flujo del Eje 1
+4. Verificar los Ejes 2 a 6
+5. Reportar cada bug vía el widget de Feedback (se crea issue automático)
+
+---
+
+## Eje 1 — Flujos funcionales
+
+### Flujo 1: W-A2 — Organización mixta
+
+- **Rol:** Taller
+- **Pasos:** Ir al paso "Tipo de organización productiva" → verificar que existe la opción "Organización mixta" (además de En línea / Modular / Prenda completa) → seleccionarla → confirmar que aparece un campo de texto para describir → escribir algo → avanzar y guardar → reabrir el formulario.
+- **Esperado:** La opción existe; el campo de texto aparece solo al elegir "mixta"; el detalle se guarda y se precarga al reabrir.
+- **Resultado:** [✅/⚠️/❌]
+- **Notas:**
+
+### Flujo 2: W-A3 — Sin registro sistemático
+
+- **Rol:** Taller
+- **Pasos:** Ir al paso "¿Llevan registro de producción diaria?" → verificar que existe la opción "Sin registro sistemático" (entre "No llevamos registro" y "Anotamos en papel/cuaderno").
+- **Esperado:** La opción existe y se puede seleccionar y guardar.
+- **Resultado:** [✅/⚠️/❌]
+- **Notas:**
+
+### Flujo 3: W-A4 — Capacidad desdoblada en dos preguntas
+
+- **Rol:** Taller
+- **Pasos:** Ir al paso de capacidad productiva → verificar que ahora hay DOS preguntas separadas:
+  - Pregunta 1 "Disponibilidad para tomar nuevos pedidos" con 4 opciones (sin cambios relevantes / algunos con límites / baja disponibilidad / no puede).
+  - Pregunta 2 "Cómo podría aumentar capacidad productiva" con 4 opciones (ampliar turnos / contratar / tercerizar / invertir en maquinaria).
+- **Esperado:** Las dos preguntas aparecen separadas con sus opciones; ambas se guardan.
+- **Resultado:** [✅/⚠️/❌]
+- **Notas:**
+
+### Flujo 4: W-A5 — Roles funcionales a 10 (persistidos)
+
+- **Rol:** Taller
+- **Pasos:** Ir al paso "Roles del equipo" → verificar que aparecen los 10 roles (moldería, tizado, corte, confección, terminación y planchado, control de calidad, coordinación, administración, compras, logística) → seleccionar varios → guardar → reabrir el formulario.
+- **Esperado:** Los 10 roles aparecen; la selección se guarda y se precarga al reabrir (antes se perdía).
+- **Resultado:** [✅/⚠️/❌]
+- **Notas:**
+
+---
+
+## Eje 2 — Navegabilidad
+
+| # | Rol | URL | Acción | Esperado | Resultado |
+|---|---|---|---|---|---|
+| 1 | Taller | /taller/perfil/completar | Avanzar por todos los pasos del wizard | Cada paso carga, se puede avanzar y retroceder | [✅/⚠️/❌] |
+| 2 | Taller | /taller/perfil/completar | Guardar y salir, volver a entrar | Los datos cargados se mantienen | [✅/⚠️/❌] |
+
+---
+
+## Eje 3 — Casos borde
+
+| # | Caso borde | Acción | Esperado | Resultado |
+|---|---|---|---|---|
+| 1 | Org. mixta sin completar el detalle | Elegir "mixta", dejar el texto vacío, avanzar | No bloquea; queda vacío | [✅/⚠️/❌] |
+| 2 | Taller sin roles previos | Abrir el formulario con un taller que nunca eligió roles | Aparece sin selección, sin error | [✅/⚠️/❌] |
+| 3 | Taller con escalabilidad obsoleta | Taller que tenía 'no-puedo'/'horas-extra' antes | El campo aparece sin valor (limpiado por migración) | [✅/⚠️/❌] |
+
+---
+
+## Eje 4 — Performance
+
+| # | Verificación | Resultado | Notas |
+|---|---|---|---|
+| 1 | El wizard carga sin demoras notorias | [✅/⚠️/❌] | |
+| 2 | Sin errores en consola del browser | [✅/⚠️/❌] | |
+| 3 | Guardar el perfil responde rápido | [✅/⚠️/❌] | |
+
+---
+
+## Eje 5 — Consistencia visual
+
+| # | Verificación | Resultado | Notas |
+|---|---|---|---|
+| 1 | Las opciones nuevas usan el mismo estilo que las existentes | [✅/⚠️/❌] | |
+| 2 | Español argentino (vos) en labels y opciones | [✅/⚠️/❌] | |
+| 3 | El campo de texto de "mixta" se integra bien visualmente | [✅/⚠️/❌] | |
+| 4 | Sin texto roto ni opciones duplicadas | [✅/⚠️/❌] | |
+
+---
+
+## Eje 6 — Verificación (no genera nuevo)
+
+| # | Verificación | Resultado | Notas |
+|---|---|---|---|
+| 1 | Los datos guardados se reflejan en el perfil del taller | [✅/⚠️/❌] | |
+| 2 | Los datos llegan a la base (verificable en detalle del taller desde ESTADO/ADMIN) | [✅/⚠️/❌] | |
+
+---
+
+## Verificación de handover
+
+- [ ] Migración aplicada en el entorno auditado (3 campos nuevos)
+- [ ] Los 4 flujos del Eje 1 verificados
+- [ ] Sin regresiones en el resto del wizard
+
+---
+
+## Resultado global
+
+**Estado:** [✅ Aprobado / ⚠️ Aprobado con fixes / ❌ Rechazado]
+
+**Decisión:** [Mergear / Iterar / Bloquear]
+
+**Resumen ejecutivo:**
+
+**Issues abiertos en este QA:**
+-

--- a/.claude/specs/v4-w-a-formulario-taller.md
+++ b/.claude/specs/v4-w-a-formulario-taller.md
@@ -1,0 +1,197 @@
+# SPEC W-A — Completar formulario de perfil del taller (W-A2 a W-A5)
+
+> **Spec consolidado** que agrupa los cuatro ajustes del formulario de completar perfil del taller definidos en el master V4 (decisiones 3.16, 3.17, 3.18) e issues #299–304.
+> Documentado de forma retroactiva: la implementación se realizó en el PR #363. Este documento deja el registro formal según la metodología V4.
+
+---
+
+## 1. Metadata
+
+| Campo | Valor |
+|---|---|
+| **Tipo** | refactor funcional |
+| **Bloque** | W-A |
+| **Categoría** | MVP no negociable |
+| **Estimación** | 10h (W-A2: 2h · W-A3: 1h · W-A4: 4h · W-A5: 3h) |
+| **Riesgo** | Medio (toca schema con 3 campos nuevos + migración) |
+| **Dependencias** | Ninguna |
+| **Branch** | `feature/v4-w-a-formulario-taller` |
+| **Validación sectorial** | N/A — Diferida a validación grupal post-MVP V4 |
+| **Perspectivas relevantes** | Sociólogo, Sectorial |
+| **Autor** | Gerardo Breard |
+| **Fecha de creación** | 2026-05-25 (retroactivo) |
+| **Aprobado por** | Equipo PDT |
+| **Issue GitHub vinculado** | #299, #300, #301, #302, #303, #304 |
+| **PR vinculado** | #363 |
+
+---
+
+## 2. Contexto
+
+### Por qué existe este spec
+
+Los talleres del piloto van a completar su perfil productivo en la plataforma. El formulario actual de completar perfil quedó corto frente a la realidad del sector textil del Conurbano Sur: faltaban opciones que reflejan formas reales de organización y de registro de producción, la pregunta de capacidad mezclaba dos conceptos distintos, y la lista de roles funcionales no cubría toda la cadena de valor de un taller.
+
+Estos ajustes provienen de las decisiones 3.16, 3.17 y 3.18 del master V4, que a su vez recogen observaciones del trabajo de campo previo (issues #299 a #304).
+
+### Qué resuelve
+
+Después de implementar este spec, el formulario de perfil del taller:
+- Contempla la organización productiva mixta (no solo línea / modular / prenda completa).
+- Permite declarar que no se lleva un registro sistemático de producción.
+- Separa la disponibilidad para tomar nuevos pedidos de la estrategia para aumentar capacidad (eran una sola pregunta confusa).
+- Ofrece los 10 roles funcionales que cubren la cadena completa, y los persiste en la base de datos (antes se perdían).
+
+### Documentación de referencia
+
+- Master V4, decisiones 3.16 (categorías productivas), 3.17 (desdoblamiento capacidad), 3.18 (roles funcionales)
+- Issues #299, #300, #301, #302, #303, #304
+
+---
+
+## 3. Validación interdisciplinaria
+
+**Sociólogo:** APLICA
+- Observación: las categorías cerradas de organización y de registro de producción dejaban afuera a talleres reales que funcionan de manera mixta o informal. Forzar una respuesta que no corresponde distorsiona el dato y hace sentir al taller "fuera de lugar".
+- Decisión: se agregan "Organización mixta" (con campo abierto para describir) y "Sin registro sistemático", usando lenguaje no estigmatizante.
+
+**Sectorial:** APLICA
+- Observación: la cadena de valor textil incluye roles (moldería, tizado, control de calidad, compras de insumos, etc.) que la lista de 6 roles no contemplaba. La pregunta única de capacidad mezclaba "cuánto podés tomar ahora" con "cómo crecerías", que son decisiones distintas.
+- Decisión: roles ampliados a 10; pregunta de capacidad desdoblada en disponibilidad actual + estrategia de crecimiento.
+
+---
+
+## 4. Qué construir
+
+### Funcionalidades
+
+1. **W-A2** — En "Tipo de organización productiva", agregar opción "Organización mixta" + campo de texto abierto para describirla.
+2. **W-A3** — En "¿Llevan registro de producción diaria?", agregar opción "Sin registro sistemático".
+3. **W-A4** — Desdoblar la pregunta de capacidad en dos:
+   - Pregunta 1 (nueva): disponibilidad para tomar nuevos pedidos.
+   - Pregunta 2 (reusa el campo escalabilidad con opciones nuevas): cómo aumentaría capacidad.
+4. **W-A5** — Reemplazar la lista de 6 roles funcionales por los 10 del master, y persistirlos en la base de datos.
+
+### Consideraciones de lenguaje
+
+- "Organización mixta" y "Sin registro sistemático" usan lenguaje neutral, no estigmatizante (alineado con el espíritu de acompañamiento del master).
+- Las opciones de disponibilidad describen la situación sin juzgarla ("Tiene baja disponibilidad actual; solo pequeños/simples", no "Taller poco productivo").
+
+---
+
+## 5. Datos (schema, modelos, queries)
+
+### Cambios en schema Prisma
+
+Tres campos nuevos en el modelo `Taller`:
+
+```prisma
+model Taller {
+  // ... campos existentes
+  organizacionDetalle  String?   // W-A2: detalle de organización mixta (campo abierto)
+  disponibilidad       String?   // W-A4: disponibilidad para nuevos pedidos
+  rolesFuncionales     Json?     // W-A5: roles funcionales del taller (persistidos)
+}
+```
+
+### Migraciones SQL
+
+Migración `agregar_campos_formulario_taller`:
+- `ALTER TABLE talleres ADD COLUMN organizacion_detalle TEXT;`
+- `ALTER TABLE talleres ADD COLUMN disponibilidad TEXT;`
+- `ALTER TABLE talleres ADD COLUMN roles_funcionales JSONB;`
+- Limpieza de valores obsoletos de escalabilidad (W-A4):
+  ```sql
+  UPDATE talleres SET escalabilidad = NULL
+  WHERE escalabilidad IN ('no-puedo', 'horas-extra');
+  ```
+
+### Seed o data inicial
+
+N/A — Los campos nuevos son opcionales; los talleres los completan al llenar el formulario.
+
+---
+
+## 6. Prescripciones técnicas
+
+- Los campos nuevos son opcionales (`String?` / `Json?`) para no romper talleres existentes.
+- `organizacionDetalle` solo se muestra/persiste cuando `organizacion === 'mixta'`.
+- W-A4 reusa el campo existente `escalabilidad` para la Pregunta 2 (no crear campo nuevo para ella); solo `disponibilidad` es campo nuevo.
+- Los roles funcionales se incluyen en `buildPayload()` y en el array de campos del PUT `talleres/[id]/route.ts`; al cargar el formulario, precargar `rolesFuncionales` si ya existen.
+- Mantener la lógica de scoring existente, agregando los componentes nuevos.
+
+### Scoring (decisión de Gerardo)
+
+| Campo | Valor | Score |
+|---|---|---|
+| organizacion | mixta | 75 |
+| registro | sin-sistematico | 30 |
+| disponibilidad | sin-cambios / con-limites / baja / no-puede | 90 / 70 / 40 / 15 |
+| escalabilidad | maquinaria / contratar / turnos / tercerizar | 85 / 80 / 70 / 60 |
+
+`scoreGeneral` pasa a promediar 6 componentes (antes 5) al incluir `scoreDisponibilidad`. Los scores de escalabilidad siguen la óptica de "solidez productiva": capacidad propia y formal puntúa más alto que dependencia de terceros.
+
+### Convenciones del proyecto a mantener
+
+- Todo el formulario vive en `src/app/(taller)/taller/perfil/completar/page.tsx` (client component).
+- Opciones de radio como `RadioOption` hardcodeadas en el componente (patrón existente).
+
+---
+
+## 7. Edge cases
+
+| # | Caso límite | Comportamiento esperado |
+|---|---|---|
+| 1 | Talleres existentes con `escalabilidad` obsoleta ('no-puedo'/'horas-extra') | Migración los limpia a NULL; vuelven a responder la pregunta |
+| 2 | Taller selecciona "Organización mixta" pero no completa el detalle | El campo de texto queda vacío (`organizacionDetalle = null`); no bloquea el envío |
+| 3 | Taller cargado antes de W-A5 sin roles guardados | `rolesFuncionales = null`; el formulario aparece sin selección previa |
+| 4 | Taller con roles ya seleccionados | Se precargan al abrir el formulario |
+
+---
+
+## 8. Validación sectorial
+
+**N/A — Diferida a validación grupal post-MVP V4**
+
+> Las opciones nuevas provienen de observaciones de campo recogidas en el master. La validación con talleres reales ocurre en el propio piloto (completan el formulario en vivo).
+
+---
+
+## 9. Criterios de aceptación
+
+- [x] Build de producción pasa sin errores (`npm run build`)
+- [x] Tests E2E existentes siguen pasando
+- [x] No hay warnings nuevos de TypeScript
+- [x] W-A2: opción "Organización mixta" + campo abierto condicional
+- [x] W-A3: opción "Sin registro sistemático"
+- [x] W-A4: dos preguntas separadas (disponibilidad + escalabilidad con opciones nuevas)
+- [x] W-A5: 10 roles funcionales, persistidos en BD
+- [x] Migración aplicada (3 campos nuevos + limpieza de escalabilidad obsoleta)
+- [x] PR #363 creado, CI verde
+- [ ] Verificación visual en `dev.plataformatextil.com.ar` OK
+- [ ] Merge a develop
+- [ ] Merge a main exitoso
+
+---
+
+## 10. Flujos para QA
+
+1. **W-A2 — Organización mixta:** completar perfil → paso "Tipo de organización" → seleccionar "Organización mixta" → aparece campo de texto → completar y avanzar → verificar que persiste.
+2. **W-A3 — Sin registro:** paso "Registro de producción" → verificar que existe la opción "Sin registro sistemático" entre "No llevamos registro" y "Anotamos en papel".
+3. **W-A4 — Capacidad desdoblada:** verificar que hay DOS preguntas separadas (disponibilidad para nuevos pedidos + cómo aumentaría capacidad) con las opciones del master.
+4. **W-A5 — Roles a 10:** paso "Roles del equipo" → verificar los 10 roles → seleccionar algunos → guardar → reabrir el formulario y verificar que se precargan.
+
+---
+
+## 11. Verificación de handover
+
+- Migración versionada en Prisma (no cambios manuales en dashboard).
+- Campos nuevos documentados en este spec (sección 5).
+- Scoring documentado en sección 6 para futuras revisiones.
+
+---
+
+## 12. Notas
+
+- Spec documentado de forma retroactiva tras la implementación en PR #363, para mantener el registro formal de la metodología V4.
+- Pendiente recordatorio para producción: si se promociona a main, verificar que los campos nuevos y la limpieza de escalabilidad se apliquen también en la base de prod.

--- a/DAILY.md
+++ b/DAILY.md
@@ -17,6 +17,9 @@
   - `src/app/(contenido)/contenido/colecciones/page.tsx`
   - `src/middleware.ts`
 
+- **15:49** `ac01d3f` — fix(w-a): ajustar scores de escalabilidad (optica solidez productiva)
+  - `src/app/(taller)/taller/perfil/completar/page.tsx`
+
 - **15:37** `ba5f0f0` — feat(w-a): completar formulario taller (W-A2 a W-A5)
   - `prisma/migrations/20260525180000_agregar_campos_formulario_taller/migration.sql`
   - `prisma/schema.prisma`

--- a/DAILY.md
+++ b/DAILY.md
@@ -17,6 +17,12 @@
   - `src/app/(contenido)/contenido/colecciones/page.tsx`
   - `src/middleware.ts`
 
+- **15:37** `ba5f0f0` — feat(w-a): completar formulario taller (W-A2 a W-A5)
+  - `prisma/migrations/20260525180000_agregar_campos_formulario_taller/migration.sql`
+  - `prisma/schema.prisma`
+  - `src/app/(taller)/taller/perfil/completar/page.tsx`
+  - `src/app/api/talleres/[id]/route.ts`
+
 - **12:05** `612b951` — feat(leyenda): aplicar leyenda institucional oficial de OIT
   - `src/app/page.tsx`
   - `src/compartido/lib/content/institutional.ts`

--- a/DAILY.md
+++ b/DAILY.md
@@ -17,6 +17,10 @@
   - `src/app/(contenido)/contenido/colecciones/page.tsx`
   - `src/middleware.ts`
 
+- **16:28** `8d1c49d` — docs(w-a): spec retroactivo + QA del formulario taller
+  - `.claude/auditorias/QA_v4-w-a-formulario-taller.md`
+  - `.claude/specs/v4-w-a-formulario-taller.md`
+
 - **15:49** `ac01d3f` — fix(w-a): ajustar scores de escalabilidad (optica solidez productiva)
   - `src/app/(taller)/taller/perfil/completar/page.tsx`
 

--- a/prisma/migrations/20260525180000_agregar_campos_formulario_taller/migration.sql
+++ b/prisma/migrations/20260525180000_agregar_campos_formulario_taller/migration.sql
@@ -1,0 +1,12 @@
+-- W-A2: detalle de organización mixta
+ALTER TABLE "talleres" ADD COLUMN "organizacionDetalle" TEXT;
+
+-- W-A4: disponibilidad para tomar nuevos pedidos
+ALTER TABLE "talleres" ADD COLUMN "disponibilidad" TEXT;
+
+-- W-A5: roles funcionales del taller
+ALTER TABLE "talleres" ADD COLUMN "rolesFuncionales" JSONB;
+
+-- W-A4: limpiar valores de escalabilidad que ya no se ofrecen
+UPDATE "talleres" SET "escalabilidad" = NULL
+WHERE "escalabilidad" IN ('no-puedo', 'horas-extra');

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -272,16 +272,19 @@ model Taller {
   portfolioFotos     String[]
 
   // Wizard perfil (pasos 1-11)
-  sam                 Int?
-  prendaPrincipal     String?
-  organizacion        String?
-  metrosCuadrados     Int?
-  areas               String[]
-  polivalencia        String?
-  horario             String?
-  registroProduccion  String?
-  escalabilidad       String?
-  paradasFrecuencia   String?
+  sam                  Int?
+  prendaPrincipal      String?
+  organizacion         String?
+  organizacionDetalle  String?    // W-A2: detalle de organización mixta
+  metrosCuadrados      Int?
+  areas                String[]
+  polivalencia         String?
+  horario              String?
+  registroProduccion   String?
+  escalabilidad        String?
+  disponibilidad       String?    // W-A4: disponibilidad para nuevos pedidos
+  paradasFrecuencia    String?
+  rolesFuncionales     Json?      // W-A5: roles funcionales del taller
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/src/app/(taller)/taller/perfil/completar/page.tsx
+++ b/src/app/(taller)/taller/perfil/completar/page.tsx
@@ -35,7 +35,18 @@ const MAQUINAS = [
   { nombre: 'Plancha industrial', icono: '🔥' },
 ]
 
-const ROLES_EQUIPO = ['Cortador/a', 'Costurero/a', 'Terminación/Planchado', 'Control calidad', 'Encargado/a', 'Logística']
+const ROLES_EQUIPO = [
+  'Moldería / desarrollo de moldes',
+  'Tizado / marcada',
+  'Corte',
+  'Confección / costura',
+  'Terminación y planchado',
+  'Control de calidad',
+  'Coordinación / encargado/a de taller',
+  'Administración / gestión de pedidos',
+  'Compras / gestión de insumos',
+  'Logística / entregas',
+]
 const AREAS = ['Área de corte', 'Área de confección', 'Área de terminación/planchado', 'Almacén de insumos', 'Área de control de calidad']
 
 interface ProcesoProductivo {
@@ -79,7 +90,9 @@ export default function WizardPage() {
   const [horario, setHorario] = useState('extendido')
   const [horasExtra, setHorasExtra] = useState('a-veces')
   const [registro, setRegistro] = useState('excel')
-  const [escalabilidad, setEscalabilidad] = useState('contratar')
+  const [escalabilidad, setEscalabilidad] = useState('turnos')
+  const [disponibilidad, setDisponibilidad] = useState('')
+  const [organizacionDetalle, setOrganizacionDetalle] = useState('')
   const [procesosSeleccionados, setProcesosSeleccionados] = useState<string[]>([])
   const [prendasSeleccionadas, setPrendasSeleccionadas] = useState<string[]>([])
 
@@ -114,7 +127,12 @@ export default function WizardPage() {
         if (t.horario) setHorario(t.horario)
         if (t.registroProduccion) setRegistro(t.registroProduccion)
         if (t.escalabilidad) setEscalabilidad(t.escalabilidad)
+        if (t.disponibilidad) setDisponibilidad(t.disponibilidad)
+        if (t.organizacionDetalle) setOrganizacionDetalle(t.organizacionDetalle)
         if (t.paradasFrecuencia) setParadas(t.paradasFrecuencia)
+        if (t.rolesFuncionales && typeof t.rolesFuncionales === 'object') {
+          setRoles(t.rolesFuncionales as Record<string, number>)
+        }
         if (t.trabajadoresRegistrados) setTamanoEquipo(
           t.trabajadoresRegistrados <= 2 ? '1-2' : t.trabajadoresRegistrados <= 5 ? '3-5' : t.trabajadoresRegistrados <= 10 ? '6-10' : t.trabajadoresRegistrados <= 20 ? '11-20' : '+20'
         )
@@ -145,11 +163,12 @@ export default function WizardPage() {
   const scoreEquipo = totalPlantilla > 0
     ? Math.round((plantilla.APRENDIZ * 30 + plantilla.MEDIO_OFICIAL * 50 + plantilla.OFICIAL * 75 + plantilla.OFICIAL_CALIFICADO * 90) / totalPlantilla)
     : 0
-  const scoreOrg = organizacion === 'linea' ? 80 : organizacion === 'modular' ? 70 : 55
+  const scoreOrg = organizacion === 'linea' ? 80 : organizacion === 'modular' ? 70 : organizacion === 'mixta' ? 75 : 55
   const scoreMaq = Math.min(Object.values(maquinaria).reduce((a, b) => a + b, 0) * 12, 100)
-  const scoreGestion = registro === 'software' ? 90 : registro === 'excel' ? 65 : registro === 'papel' ? 40 : 20
-  const scoreEscalabilidad = escalabilidad === 'turno' || escalabilidad === 'tercerizar' ? 85 : escalabilidad === 'contratar' ? 75 : escalabilidad === 'horas-extra' ? 55 : 30
-  const scoreGeneral = Math.round((scoreEquipo + scoreOrg + scoreMaq + scoreGestion + scoreEscalabilidad) / 5)
+  const scoreGestion = registro === 'software' ? 90 : registro === 'excel' ? 65 : registro === 'papel' ? 40 : registro === 'sin-sistematico' ? 30 : 20
+  const scoreEscalabilidad = escalabilidad === 'tercerizar' ? 85 : escalabilidad === 'contratar' ? 75 : escalabilidad === 'turnos' ? 70 : escalabilidad === 'maquinaria' ? 65 : 30
+  const scoreDisponibilidad = disponibilidad === 'sin-cambios' ? 90 : disponibilidad === 'con-limites' ? 70 : disponibilidad === 'baja' ? 40 : disponibilidad === 'no-puede' ? 15 : 0
+  const scoreGeneral = Math.round((scoreEquipo + scoreOrg + scoreMaq + scoreGestion + scoreEscalabilidad + scoreDisponibilidad) / 6)
 
   const buildPayload = useCallback(() => {
     const numMaq = Object.values(maquinaria).reduce((a, b) => a + b, 0)
@@ -161,6 +180,7 @@ export default function WizardPage() {
       sam: parseInt(sam) || undefined,
       prendaPrincipal: prendaPrincipal || undefined,
       organizacion: organizacion || undefined,
+      organizacionDetalle: organizacion === 'mixta' ? (organizacionDetalle || undefined) : undefined,
       metrosCuadrados: parseInt(metrosCuadrados) || undefined,
       areas,
       plantilla,
@@ -168,16 +188,18 @@ export default function WizardPage() {
       horario: horario || undefined,
       registroProduccion: registro || undefined,
       escalabilidad: escalabilidad || undefined,
+      disponibilidad: disponibilidad || undefined,
       paradasFrecuencia: paradas || undefined,
       capacidadMensual: capMensual || undefined,
       trabajadoresRegistrados: tamanoEquipo === '1-2' ? 2 : tamanoEquipo === '3-5' ? 4 : tamanoEquipo === '6-10' ? 8 : tamanoEquipo === '11-20' ? 15 : 25,
+      rolesFuncionales: Object.keys(roles).length > 0 ? roles : undefined,
       maquinaria: Object.entries(maquinaria)
         .filter(([, c]) => c > 0)
         .map(([nombre, cantidad]) => ({ nombre, cantidad, tipo: numMaq > 0 ? 'confeccion' : undefined })),
       procesosIds: procesosSeleccionados,
       prendasIds: prendasSeleccionadas,
     }
-  }, [maquinaria, sam, prendaPrincipal, organizacion, metrosCuadrados, areas, plantilla, polivalencia, horario, registro, escalabilidad, paradas, roles, tamanoEquipo, procesosSeleccionados, prendasSeleccionadas])
+  }, [maquinaria, sam, prendaPrincipal, organizacion, organizacionDetalle, metrosCuadrados, areas, plantilla, polivalencia, horario, registro, escalabilidad, disponibilidad, paradas, roles, tamanoEquipo, procesosSeleccionados, prendasSeleccionadas])
 
   async function handleSave(redirectTo: string) {
     if (!tallerId) {
@@ -380,12 +402,24 @@ export default function WizardPage() {
             <p><strong>En línea:</strong> Cada persona hace UNA operación. Más rápido para grandes volúmenes.</p>
             <p><strong>Modular:</strong> Grupos pequeños hacen varias operaciones. Balance velocidad/flexibilidad.</p>
             <p><strong>Prenda completa:</strong> Cada persona hace toda la prenda. Mayor control de calidad.</p>
+            <p><strong>Mixta:</strong> Combina distintos modos según el tipo de trabajo o pedido.</p>
           </Card>
           <div className="space-y-2">
             <RadioOption value="linea" current={organizacion} onChange={setOrganizacion} label="En línea" desc="Cada uno hace una operación específica" />
             <RadioOption value="modular" current={organizacion} onChange={setOrganizacion} label="Modular" desc="Grupos hacen varias operaciones juntas" />
             <RadioOption value="completa" current={organizacion} onChange={setOrganizacion} label="Prenda completa" desc="Cada persona hace la prenda de principio a fin" />
+            <RadioOption value="mixta" current={organizacion} onChange={setOrganizacion} label="Organización mixta" desc="Combina distintos modos según el tipo de trabajo" />
           </div>
+          {organizacion === 'mixta' && (
+            <div className="mt-3">
+              <Input
+                label="Describí cómo combinás los modos de organización"
+                value={organizacionDetalle}
+                onChange={e => setOrganizacionDetalle(e.target.value)}
+                placeholder="Ej: línea para producción en serie, modular para muestras"
+              />
+            </div>
+          )}
         </div>
       )}
 
@@ -525,17 +559,24 @@ export default function WizardPage() {
           <p className="text-sm font-semibold mb-2">¿Llevan registro de producción diaria?</p>
           <div className="space-y-2 mb-4">
             <RadioOption value="no" current={registro} onChange={setRegistro} label="No llevamos registro" />
+            <RadioOption value="sin-sistematico" current={registro} onChange={setRegistro} label="Sin registro sistemático" desc="Anotamos algo pero no de forma regular" />
             <RadioOption value="papel" current={registro} onChange={setRegistro} label="Anotamos en papel/cuaderno" />
             <RadioOption value="excel" current={registro} onChange={setRegistro} label="Usamos planilla Excel o similar" />
             <RadioOption value="software" current={registro} onChange={setRegistro} label="Tenemos sistema/software" />
           </div>
-          <p className="text-sm font-semibold mb-2">Si te piden el DOBLE de producción, ¿cómo responderías?</p>
+          <p className="text-sm font-semibold mb-2">Disponibilidad para tomar nuevos pedidos</p>
+          <div className="space-y-2 mb-4">
+            <RadioOption value="sin-cambios" current={disponibilidad} onChange={setDisponibilidad} label="Puede incorporar nuevos pedidos sin cambios relevantes" />
+            <RadioOption value="con-limites" current={disponibilidad} onChange={setDisponibilidad} label="Puede tomar algunos pedidos adicionales, con límites" />
+            <RadioOption value="baja" current={disponibilidad} onChange={setDisponibilidad} label="Tiene baja disponibilidad actual; solo pequeños/simples" />
+            <RadioOption value="no-puede" current={disponibilidad} onChange={setDisponibilidad} label="No puede tomar nuevos pedidos" />
+          </div>
+          <p className="text-sm font-semibold mb-2">¿Cómo podría aumentar su capacidad productiva?</p>
           <div className="space-y-2">
-            <RadioOption value="no-puedo" current={escalabilidad} onChange={setEscalabilidad} label="No podría, estoy al máximo" />
-            <RadioOption value="horas-extra" current={escalabilidad} onChange={setEscalabilidad} label="Con horas extras del equipo actual" />
-            <RadioOption value="contratar" current={escalabilidad} onChange={setEscalabilidad} label="Contratar más gente temporalmente" />
-            <RadioOption value="turno" current={escalabilidad} onChange={setEscalabilidad} label="Agregar un turno adicional" />
-            <RadioOption value="tercerizar" current={escalabilidad} onChange={setEscalabilidad} label="Tercerizar a otro taller" />
+            <RadioOption value="turnos" current={escalabilidad} onChange={setEscalabilidad} label="Ampliando turnos u horas de trabajo" />
+            <RadioOption value="contratar" current={escalabilidad} onChange={setEscalabilidad} label="Contratando personal" />
+            <RadioOption value="tercerizar" current={escalabilidad} onChange={setEscalabilidad} label="Tercerizando parte de la producción" />
+            <RadioOption value="maquinaria" current={escalabilidad} onChange={setEscalabilidad} label="Invirtiendo en maquinaria/equipamiento" />
           </div>
         </div>
       )}

--- a/src/app/(taller)/taller/perfil/completar/page.tsx
+++ b/src/app/(taller)/taller/perfil/completar/page.tsx
@@ -166,7 +166,7 @@ export default function WizardPage() {
   const scoreOrg = organizacion === 'linea' ? 80 : organizacion === 'modular' ? 70 : organizacion === 'mixta' ? 75 : 55
   const scoreMaq = Math.min(Object.values(maquinaria).reduce((a, b) => a + b, 0) * 12, 100)
   const scoreGestion = registro === 'software' ? 90 : registro === 'excel' ? 65 : registro === 'papel' ? 40 : registro === 'sin-sistematico' ? 30 : 20
-  const scoreEscalabilidad = escalabilidad === 'tercerizar' ? 85 : escalabilidad === 'contratar' ? 75 : escalabilidad === 'turnos' ? 70 : escalabilidad === 'maquinaria' ? 65 : 30
+  const scoreEscalabilidad = escalabilidad === 'maquinaria' ? 85 : escalabilidad === 'contratar' ? 80 : escalabilidad === 'turnos' ? 70 : escalabilidad === 'tercerizar' ? 60 : 30
   const scoreDisponibilidad = disponibilidad === 'sin-cambios' ? 90 : disponibilidad === 'con-limites' ? 70 : disponibilidad === 'baja' ? 40 : disponibilidad === 'no-puede' ? 15 : 0
   const scoreGeneral = Math.round((scoreEquipo + scoreOrg + scoreMaq + scoreGestion + scoreEscalabilidad + scoreDisponibilidad) / 6)
 

--- a/src/app/api/talleres/[id]/route.ts
+++ b/src/app/api/talleres/[id]/route.ts
@@ -54,9 +54,10 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
     const fields = [
       'nombre', 'ubicacion', 'website', 'provincia', 'partido', 'ubicacionDetalle', 'descripcion',
       'capacidadMensual', 'trabajadoresRegistrados', 'fundado',
-      'sam', 'prendaPrincipal', 'organizacion', 'metrosCuadrados',
+      'sam', 'prendaPrincipal', 'organizacion', 'organizacionDetalle', 'metrosCuadrados',
       'areas', 'polivalencia', 'horario',
-      'registroProduccion', 'escalabilidad', 'paradasFrecuencia',
+      'registroProduccion', 'escalabilidad', 'disponibilidad', 'paradasFrecuencia',
+      'rolesFuncionales',
       'portfolioFotos',
     ]
     for (const f of fields) {


### PR DESCRIPTION
## Summary
- **W-A2:** Opción "Organización mixta" + campo texto abierto (`organizacionDetalle`)
- **W-A3:** Opción "Sin registro sistemático" en registro de producción
- **W-A4:** Desdoblar capacidad en 2 preguntas: disponibilidad (campo nuevo) + escalabilidad (opciones nuevas)
- **W-A5:** Roles funcionales 6→10, ahora se persisten en BD (`rolesFuncionales Json?`)

## Migración
- 3 campos nuevos: `organizacionDetalle`, `disponibilidad`, `rolesFuncionales`
- Limpieza: `escalabilidad IN ('no-puedo', 'horas-extra')` → NULL

## Test plan
- [ ] Verificar paso 5 (organización): aparece opción "mixta", input condicional
- [ ] Verificar paso 11 (gestión): opción "sin registro sistemático" visible
- [ ] Verificar paso 11: 2 preguntas separadas (disponibilidad + escalabilidad)
- [ ] Verificar paso 3 (equipo): 10 roles funcionales visibles
- [ ] Completar wizard completo y verificar que se guarda en BD
- [ ] Recargar wizard: datos precargados correctamente

Refs: master 3.16-3.18

🤖 Generated with [Claude Code](https://claude.com/claude-code)