### PR TITLE
fix: J-04 flujo de publicacion de cursos

### DIFF
--- a/.claude/specs/v4-j-04-flujo-publicacion-cursos.md
+++ b/.claude/specs/v4-j-04-flujo-publicacion-cursos.md
@@ -1,0 +1,61 @@
+# J-04: Flujo de publicación de cursos (hallazgo B)
+
+## Contexto
+
+Hallazgo B del QA de Sergio: Sofía (CONTENIDO) crea una colección/curso, pero este no aparece en el carrusel del landing ni en `/taller/aprender`.
+
+Causas diagnosticadas:
+1. **Colección nace en borrador**: la API `POST /api/colecciones` hace `activa: body.activa ?? false`. El formulario de crear no envía `activa`, así que toda colección nueva nace con `activa: false`.
+2. **Carrusel limitado a 2**: el landing (`src/app/page.tsx:45`) hace `take: 2` para colecciones, así que aunque estén publicadas, solo se muestran las 2 más recientes.
+3. **Sin señal de estado**: tras crear, Sofía es redirigida a la edición sin ningún aviso de que la colección quedó en borrador y que debe publicarla manualmente.
+
+## Qué construir
+
+### 1. UX cue post-creación
+
+Archivo: `src/app/(contenido)/contenido/colecciones/nueva/page.tsx`
+
+- Tras crear la colección, redirigir a `/contenido/colecciones/[id]?created=1` (ya redirige a la edición, solo agregar query param)
+
+Archivo: `src/app/(contenido)/contenido/colecciones/[id]/page.tsx`
+
+- Detectar `?created=1` con `useSearchParams()`
+- Mostrar un banner informativo (azul, no error) arriba del formulario:
+  - Título: "Tu colección se creó como borrador"
+  - Texto: "Agregá videos y cuando esté lista, cambiá el estado a «Publicada» para que aparezca en el inicio y en Cursos."
+  - Botón/link: "Entendido" que cierra el banner (o simplemente se va al scroll down)
+- El banner solo aparece cuando `created=1` está en la URL. No persiste después de navegar.
+
+### 2. Subir límite del carrusel
+
+Archivo: `src/app/page.tsx` (~línea 45)
+
+- Cambiar `take: 2` → `take: 6`
+- El carrusel ya es scroll horizontal con flechas, soporta N items
+- Mantener `orderBy: { createdAt: 'desc' }` y `where: { activa: true }`
+
+## Datos
+
+Sin cambios de schema. Sin migraciones.
+
+## Prescripciones técnicas
+
+- El banner es un div condicional en el client component existente, no un componente nuevo
+- Usar `useSearchParams()` de `next/navigation` para detectar `created=1`
+- Colores del banner: `bg-blue-50 border-blue-200 text-blue-800` (informativo, no warning)
+- Ícono: `Info` de lucide-react
+- No agregar toast — el banner en la misma página es más visible y contextual
+
+## Casos borde
+
+- Sofía recarga la página sin `?created=1` → no aparece el banner (correcto)
+- Sofía crea y el redirect falla → queda en `/contenido/colecciones` sin banner (aceptable)
+- Carrusel con 0 cursos publicados → no muestra nada (ya manejado)
+- Carrusel con 7+ cursos publicados → se scrollean con flechas (ya soportado)
+
+## Criterio de aceptación
+
+1. Sofía crea colección → ve banner "se creó como borrador" en la página de edición
+2. El banner desaparece si recarga sin `?created=1`
+3. Carrusel del landing muestra hasta 6 cursos (no solo 2)
+4. Build pasa sin errores

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,12 @@
 ## 2026-05-25
 
 ### Gerardo Breard
+- **23:23** `de790d3` — fix(j-04): flujo de publicacion de cursos (hallazgo B)
+  - `.claude/specs/v4-j-04-flujo-publicacion-cursos.md`
+  - `src/app/(contenido)/contenido/colecciones/[id]/page.tsx`
+  - `src/app/(contenido)/contenido/colecciones/nueva/page.tsx`
+  - `src/app/page.tsx`
+
 - **21:31** `9968623` — fix(e2e): renombrar prefijo tipoPrenda del test para que no sea filtrado
   - `tests/e2e/flujo-comercial.spec.ts`
 

--- a/src/app/(contenido)/contenido/colecciones/[id]/page.tsx
+++ b/src/app/(contenido)/contenido/colecciones/[id]/page.tsx
@@ -1,14 +1,14 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { useParams, useRouter } from 'next/navigation'
+import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { Card } from '@/compartido/componentes/ui/card'
 import { Button } from '@/compartido/componentes/ui/button'
 import { Input } from '@/compartido/componentes/ui/input'
 import { Select } from '@/compartido/componentes/ui/select'
 import { Badge } from '@/compartido/componentes/ui/badge'
-import { Trash2, Plus, CheckCircle, AlertCircle } from 'lucide-react'
+import { Trash2, Plus, CheckCircle, AlertCircle, Info } from 'lucide-react'
 import { Breadcrumbs } from '@/compartido/componentes/ui/breadcrumbs'
 
 const categorias = ['Formalización', 'Costos', 'Calidad', 'Plataforma', 'Otro']
@@ -25,6 +25,8 @@ interface Video {
 export default function AdminEditarColeccionPage() {
   const params = useParams()
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const justCreated = searchParams.get('created') === '1'
   const coleccionId = params.id as string
 
   const [titulo, setTitulo] = useState('')
@@ -118,6 +120,18 @@ export default function AdminEditarColeccionPage() {
         <h1 className="font-serif font-bold text-2xl text-ink-primary">Editar Colección</h1>
         <Badge variant={activa ? 'success' : 'default'}>{activa ? 'Publicada' : 'Borrador'}</Badge>
       </div>
+
+      {justCreated && (
+        <div className="mb-4 rounded-xl border border-blue-200 bg-blue-50 px-5 py-4 flex items-start gap-3">
+          <Info className="w-5 h-5 text-blue-600 mt-0.5 shrink-0" />
+          <div>
+            <p className="font-overpass font-semibold text-blue-900">Tu colección se creó como borrador</p>
+            <p className="text-sm text-blue-700 mt-0.5">
+              Agregá videos y cuando esté lista, cambiá el estado a «Publicada» para que aparezca en el inicio y en Cursos.
+            </p>
+          </div>
+        </div>
+      )}
 
       {msg && (
         <div className={`mb-4 rounded-lg border px-4 py-3 text-sm flex items-center gap-2 ${msg.type === 'ok' ? 'bg-green-50 border-green-200 text-green-700' : 'bg-red-50 border-red-200 text-red-600'}`}>

--- a/src/app/(contenido)/contenido/colecciones/nueva/page.tsx
+++ b/src/app/(contenido)/contenido/colecciones/nueva/page.tsx
@@ -30,7 +30,7 @@ export default function NuevaColeccionPage() {
       })
       if (res.ok) {
         const data = await res.json()
-        router.push(`/contenido/colecciones/${data.id}`)
+        router.push(`/contenido/colecciones/${data.id}?created=1`)
       }
     } catch {
       // Error silencioso

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,7 +42,7 @@ export default async function Home() {
     prisma.coleccion.findMany({
       where: { activa: true },
       orderBy: { createdAt: 'desc' },
-      take: 2,
+      take: 6,
       select: { id: true, titulo: true, duracion: true, videos: { select: { id: true } } },
     }),
   ]).catch(() => [0, 0, 0, 0, [], []] as const)


### PR DESCRIPTION
## Summary
- Hallazgo B del QA de Sergio: curso creado por Sofía (CONTENIDO) no aparecía en el carrusel del landing
- **Causa 1**: colección nace con `activa: false` (borrador) y el formulario no avisa
- **Causa 2**: carrusel del landing limitado a `take: 2`

## Cambios
- **UX cue post-creación**: redirect a edición con `?created=1` + banner azul informativo ("Tu colección se creó como borrador. Agregá videos y publicala para que aparezca en inicio y Cursos.")
- **Carrusel landing**: `take: 2` → `take: 6` para mostrar más cursos publicados
- **Spec**: `.claude/specs/v4-j-04-flujo-publicacion-cursos.md`

## Test plan
- [ ] Sofía crea colección → redirige a edición con banner azul "se creó como borrador"
- [ ] Recargar la página sin `?created=1` → banner desaparece
- [ ] Publicar la colección (radio "Publicada" + Guardar) → aparece en carrusel del landing
- [ ] Carrusel del landing muestra hasta 6 cursos activos
- [ ] Build CI pasa sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)