### PR TITLE
feat: renombrar tabs del taller (Mi vidriera, Mi recorrido, Cursos)

### DIFF
--- a/.claude/specs/v4-renombres-tabs-taller.md
+++ b/.claude/specs/v4-renombres-tabs-taller.md
@@ -1,0 +1,57 @@
+# Renombres de tabs del rol TALLER
+
+## Contexto
+
+Informe de navegacion de Sergio: los labels actuales de tabs y sidebar del rol TALLER no estan alineados con el modelo Showcase+Match del master V4 (secciones 3.1, 3.7, 3.14). Ademas, la capitalizacion es inconsistente (mezcla de Title Case y sentence case).
+
+## Que cambiar
+
+### Renombres (solo rol TALLER)
+
+| Antes | Despues | Justificacion master |
+|---|---|---|
+| Tablero / Mi Tablero | Inicio | Coherencia con modelo 3.14 |
+| Mis pedidos / Mis Pedidos | Pedidos | Simplificacion |
+| Mi formalizacion / Mi Formalizacion | Mi recorrido | Master 3.7 — concepto de recorrido |
+| Mi perfil / Mi Perfil | Mi vidriera | Master 3.1 — Showcase+Match |
+| Academia | Cursos | Cercanía con el usuario (3.14) |
+| Ayuda y Soporte | Ayuda | Simplificacion |
+
+### Capitalizacion
+
+Unificar a sentence case en header Y sidebar (todos los roles).
+
+### aria-label
+
+`"Menu de navegacion personal"` → `"Menu principal"`
+
+## Archivos a modificar
+
+1. `src/compartido/lib/content/institutional.ts` — TABS_BY_ROLE.TALLER (5 labels)
+2. `src/compartido/componentes/layout/user-sidebar.tsx`:
+   - TALLER: 5 labels renombrados
+   - MARCA: capitalizacion (Directorio Talleres, Mis Pedidos, Mi Perfil)
+   - ESTADO: capitalizacion (Exportar Datos)
+   - Todos: Mi Cuenta → Mi cuenta
+   - Footer: Ayuda y Soporte → Ayuda, Cerrar Sesion → Cerrar sesion
+   - aria-label sidebar
+3. `src/app/(taller)/taller/perfil/page.tsx` — h1 "Mi Perfil" → "Mi vidriera", Card "Certificados de Academia" → "Certificados de cursos"
+4. `src/app/(taller)/taller/formalizacion/page.tsx` — h1 "Mi Formalizacion" → "Mi recorrido" (x2)
+5. `src/app/(taller)/taller/aprender/page.tsx` — h1 "Academia" → "Cursos"
+6. `src/app/(taller)/taller/aprender/[id]/page.tsx` — breadcrumb "Academia" → "Cursos"
+7. `src/app/(taller)/taller/perfil/completar/page.tsx` — boton "Guardar e ir a Academia" → "Guardar e ir a Cursos"
+8. `src/app/(public)/ayuda/page.tsx` — h1 "Ayuda y Soporte" → "Ayuda"
+9. `tests/e2e/smoke.spec.ts` — selectores "Mis pedidos" y "Mi perfil"
+
+## Decision clave
+
+SOLO labels visibles. NO se tocan rutas (`/taller/perfil`), schema (`certificadosAcademiaMin`), ni nombres internos de componentes (`AcademiaCliente`, `AcademiaDetallePage`). Feature flags internos (`academia`) tambien quedan igual.
+
+## Criterio de aceptacion
+
+1. Header TALLER muestra: Inicio | Pedidos | Mi recorrido | Mi vidriera | Cursos
+2. Sidebar TALLER muestra los mismos labels en sentence case
+3. h1 y breadcrumbs de las paginas del taller reflejan los nuevos nombres
+4. Sidebar de MARCA/ESTADO sin errores de capitalizacion
+5. Test e2e smoke pasa con los nuevos selectores
+6. Build sin errores

--- a/DAILY.md
+++ b/DAILY.md
@@ -16,6 +16,25 @@
 ## 2026-05-25
 
 ### Gerardo Breard
+- **23:44** `860b82e` — feat(nav): renombrar tabs del taller segun modelo Showcase+Match
+  - `.claude/specs/v4-renombres-tabs-taller.md`
+  - `src/app/(admin)/logout-button.tsx`
+  - `src/app/(auth)/mi-cuenta/page.tsx`
+  - `src/app/(marca)/marca/pedidos/page.tsx`
+  - `src/app/(marca)/marca/perfil/page.tsx`
+  - `src/app/(public)/ayuda/page.tsx`
+  - `src/app/(public)/cuenta/page.tsx`
+  - `src/app/(taller)/taller/aprender/[id]/page.tsx`
+  - `src/app/(taller)/taller/aprender/page.tsx`
+  - `src/app/(taller)/taller/formalizacion/page.tsx`
+  - `src/app/(taller)/taller/perfil/completar/page.tsx`
+  - `src/app/(taller)/taller/perfil/page.tsx`
+  - `src/compartido/componentes/layout/user-sidebar.tsx`
+  - `src/compartido/componentes/ui/logout-button.tsx`
+  - `src/compartido/lib/content/institutional.ts`
+  - `tests/e2e/roles-estado.spec.ts`
+  - `tests/e2e/smoke.spec.ts`
+
 - **23:23** `de790d3` — fix(j-04): flujo de publicacion de cursos (hallazgo B)
   - `.claude/specs/v4-j-04-flujo-publicacion-cursos.md`
   - `src/app/(contenido)/contenido/colecciones/[id]/page.tsx`

--- a/src/app/(admin)/logout-button.tsx
+++ b/src/app/(admin)/logout-button.tsx
@@ -10,7 +10,7 @@ export function AdminLogoutButton() {
       className="flex items-center gap-2 text-sm hover:text-red-200 transition-colors"
     >
       <LogOut className="w-4 h-4" />
-      Cerrar Sesión
+      Cerrar sesión
     </button>
   )
 }

--- a/src/app/(auth)/mi-cuenta/page.tsx
+++ b/src/app/(auth)/mi-cuenta/page.tsx
@@ -112,7 +112,7 @@ export default function MiCuentaPage() {
 
   return (
     <div className="max-w-2xl mx-auto py-8 px-4">
-      <h1 className="font-overpass font-bold text-2xl text-ink-primary mb-6">Mi Cuenta</h1>
+      <h1 className="font-overpass font-bold text-2xl text-ink-primary mb-6">Mi cuenta</h1>
 
       <Card title="Información de la cuenta" className="mb-6">
         <div className="flex items-center gap-3 mb-3 pb-3 border-b border-gray-100">

--- a/src/app/(marca)/marca/pedidos/page.tsx
+++ b/src/app/(marca)/marca/pedidos/page.tsx
@@ -82,7 +82,7 @@ async function PedidosContent({ query, estado, created }: { query: string; estad
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mis Pedidos</h1>
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mis pedidos</h1>
         <p className="text-gray-600 mt-2">Seguimiento de pedidos de {marca.nombre}</p>
       </div>
 

--- a/src/app/(marca)/marca/perfil/page.tsx
+++ b/src/app/(marca)/marca/perfil/page.tsx
@@ -69,7 +69,7 @@ export default async function MarcaPerfilPage() {
   if (!marca) {
     return (
       <div className="space-y-6">
-        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi Perfil de Marca</h1>
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi perfil de marca</h1>
         <div className="bg-white rounded-xl shadow-sm p-6 border border-gray-200">
           <p className="text-gray-700">No encontramos datos de marca para este usuario.</p>
         </div>
@@ -80,7 +80,7 @@ export default async function MarcaPerfilPage() {
   return (
     <div className="space-y-6">
       <Suspense><SaveToast message="Perfil actualizado" /></Suspense>
-      <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi Perfil de Marca</h1>
+      <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi perfil de marca</h1>
 
       <div className="grid gap-4 sm:grid-cols-3">
         <div className="bg-white rounded-xl border border-gray-200 p-4">

--- a/src/app/(public)/ayuda/page.tsx
+++ b/src/app/(public)/ayuda/page.tsx
@@ -23,7 +23,7 @@ const faqItems = [
 export default function AyudaPage() {
   return (
     <div className="space-y-6">
-      <h1 className="font-overpass font-bold text-3xl text-brand-blue">Ayuda y Soporte</h1>
+      <h1 className="font-overpass font-bold text-3xl text-brand-blue">Ayuda</h1>
 
       <div className="grid gap-4 sm:grid-cols-2">
         <Link href="/ayuda/onboarding-taller" className="rounded-xl border border-gray-200 bg-white p-5 hover:border-brand-blue hover:shadow-card transition-all">

--- a/src/app/(public)/cuenta/page.tsx
+++ b/src/app/(public)/cuenta/page.tsx
@@ -34,7 +34,7 @@ export default async function CuentaPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="font-overpass font-bold text-3xl text-brand-blue">Mi Cuenta</h1>
+      <h1 className="font-overpass font-bold text-3xl text-brand-blue">Mi cuenta</h1>
 
       <section className="rounded-xl border border-gray-200 bg-white p-6">
         <h2 className="font-overpass font-bold text-lg text-brand-blue mb-4">Resumen</h2>

--- a/src/app/(taller)/taller/aprender/[id]/page.tsx
+++ b/src/app/(taller)/taller/aprender/[id]/page.tsx
@@ -51,7 +51,7 @@ export default async function AcademiaDetallePage({
     <div className="max-w-4xl mx-auto space-y-6">
       <Breadcrumbs items={[
         { label: 'Taller', href: '/taller' },
-        { label: 'Academia', href: '/taller/aprender' },
+        { label: 'Cursos', href: '/taller/aprender' },
         { label: coleccion.titulo },
       ]} />
 

--- a/src/app/(taller)/taller/aprender/page.tsx
+++ b/src/app/(taller)/taller/aprender/page.tsx
@@ -41,7 +41,7 @@ export default async function TallerAprenderPage() {
     <div className="space-y-6">
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="font-serif font-bold text-3xl text-ink-primary">Academia</h1>
+          <h1 className="font-serif font-bold text-3xl text-ink-primary">Cursos</h1>
           <p className="text-gray-500 mt-1">Cursos gratuitos para mejorar tu taller y ganar puntos de formalización.</p>
         </div>
       </div>

--- a/src/app/(taller)/taller/formalizacion/page.tsx
+++ b/src/app/(taller)/taller/formalizacion/page.tsx
@@ -34,7 +34,7 @@ export default async function TallerFormalizacionPage() {
   if (!taller) {
     return (
       <div className="space-y-6">
-        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi Formalización</h1>
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi recorrido</h1>
         <Card className="text-center py-12">
           <p className="text-gray-600 mb-4">Primero completá tu perfil para ver tu checklist de formalización.</p>
           <Link href="/taller/perfil/completar"><Button>Completar Perfil</Button></Link>
@@ -65,7 +65,7 @@ export default async function TallerFormalizacionPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi Formalización</h1>
+      <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi recorrido</h1>
 
       {/* Resumen */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/src/app/(taller)/taller/perfil/completar/page.tsx
+++ b/src/app/(taller)/taller/perfil/completar/page.tsx
@@ -695,7 +695,7 @@ export default function WizardPage() {
               {saving ? 'Guardando...' : 'Ver mi perfil'}
             </Button>
             <Button onClick={() => handleSave('/taller/aprender')} disabled={saving}>
-              {saving ? 'Guardando...' : 'Guardar e ir a Academia'}
+              {saving ? 'Guardando...' : 'Guardar e ir a Cursos'}
             </Button>
           </div>
         </div>

--- a/src/app/(taller)/taller/perfil/page.tsx
+++ b/src/app/(taller)/taller/perfil/page.tsx
@@ -36,7 +36,7 @@ export default async function TallerPerfilPage() {
   if (!taller) {
     return (
       <div className="space-y-6">
-        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi Perfil</h1>
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi vidriera</h1>
         <Card className="text-center py-12">
           <p className="text-gray-600 mb-4">Todavía no completaste tu perfil.</p>
           <Link href="/taller/perfil/completar">
@@ -283,7 +283,7 @@ export default async function TallerPerfilPage() {
       )}
 
       {taller.certificados.length > 0 && (
-        <Card title="Certificados de Academia">
+        <Card title="Certificados de cursos">
           <div className="space-y-2">
             {taller.certificados.map((c) => (
               <div key={c.id} className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0">

--- a/src/compartido/componentes/layout/user-sidebar.tsx
+++ b/src/compartido/componentes/layout/user-sidebar.tsx
@@ -45,22 +45,22 @@ interface UserSidebarProps {
 
 const menuItemsByRole: Record<string, MenuItem[]> = {
   TALLER: [
-    { id: 'tablero', label: 'Mi Tablero', href: '/taller', icon: Home },
-    { id: 'perfil', label: 'Mi Perfil', href: '/taller/perfil', icon: User },
-    { id: 'formalizacion', label: 'Mi Formalización', href: '/taller/formalizacion', icon: ClipboardCheck },
-    { id: 'academia', label: 'Academia', href: '/taller/aprender', icon: BookOpen },
-    { id: 'pedidos', label: 'Mis Pedidos', href: '/taller/pedidos', icon: ClipboardList },
+    { id: 'tablero', label: 'Inicio', href: '/taller', icon: Home },
+    { id: 'perfil', label: 'Mi vidriera', href: '/taller/perfil', icon: User },
+    { id: 'formalizacion', label: 'Mi recorrido', href: '/taller/formalizacion', icon: ClipboardCheck },
+    { id: 'academia', label: 'Cursos', href: '/taller/aprender', icon: BookOpen },
+    { id: 'pedidos', label: 'Pedidos', href: '/taller/pedidos', icon: ClipboardList },
     { id: 'disponibles', label: 'Pedidos disponibles', href: '/taller/pedidos/disponibles', icon: Search },
     { id: 'notificaciones', label: 'Notificaciones', href: '/cuenta/notificaciones', icon: Bell },
-    { id: 'cuenta', label: 'Mi Cuenta', href: '/cuenta', icon: Settings },
+    { id: 'cuenta', label: 'Mi cuenta', href: '/cuenta', icon: Settings },
   ],
   MARCA: [
-    { id: 'inicio', label: 'Mi Panel', href: '/marca', icon: Home },
-    { id: 'directorio', label: 'Directorio Talleres', href: '/marca/directorio', icon: Search },
-    { id: 'pedidos', label: 'Mis Pedidos', href: '/marca/pedidos', icon: ClipboardList },
-    { id: 'perfil', label: 'Mi Perfil', href: '/marca/perfil', icon: Building2 },
+    { id: 'inicio', label: 'Mi panel', href: '/marca', icon: Home },
+    { id: 'directorio', label: 'Directorio talleres', href: '/marca/directorio', icon: Search },
+    { id: 'pedidos', label: 'Mis pedidos', href: '/marca/pedidos', icon: ClipboardList },
+    { id: 'perfil', label: 'Mi perfil', href: '/marca/perfil', icon: Building2 },
     { id: 'notificaciones', label: 'Notificaciones', href: '/cuenta/notificaciones', icon: Bell },
-    { id: 'cuenta', label: 'Mi Cuenta', href: '/cuenta', icon: Settings },
+    { id: 'cuenta', label: 'Mi cuenta', href: '/cuenta', icon: Settings },
   ],
   ESTADO: [
     { id: 'dashboard', label: 'Dashboard', href: '/estado', icon: Home },
@@ -70,9 +70,9 @@ const menuItemsByRole: Record<string, MenuItem[]> = {
     { id: 'niveles', label: 'Etapas', href: '/estado/configuracion-niveles', icon: Sliders },
     { id: 'demanda', label: 'Demanda insatisfecha', href: '/estado/demanda-insatisfecha', icon: AlertTriangle },
     { id: 'sector', label: 'Datos sectoriales', href: '/estado/sector', icon: BarChart3 },
-    { id: 'exportar', label: 'Exportar Datos', href: '/estado/exportar', icon: Download },
+    { id: 'exportar', label: 'Exportar datos', href: '/estado/exportar', icon: Download },
     { id: 'notificaciones', label: 'Notificaciones', href: '/cuenta/notificaciones', icon: Bell },
-    { id: 'cuenta', label: 'Mi Cuenta', href: '/cuenta', icon: Settings },
+    { id: 'cuenta', label: 'Mi cuenta', href: '/cuenta', icon: Settings },
   ],
   ADMIN: [
     { id: 'dashboard', label: 'Dashboard', href: '/admin', icon: Home },
@@ -149,7 +149,7 @@ export function UserSidebar({
           'fixed top-0 left-0 h-full w-80 bg-white shadow-2xl z-[60] transform transition-transform duration-300 ease-out',
           isOpen ? 'translate-x-0' : '-translate-x-full'
         )}
-        aria-label="Menú de navegación personal"
+        aria-label="Menú principal"
       >
         <div className="flex flex-col h-full">
           {/* Header del sidebar */}
@@ -244,14 +244,14 @@ export function UserSidebar({
               className="flex items-center gap-3 px-4 py-3 rounded-lg font-overpass font-medium text-sm text-gray-700 hover:bg-gray-50 hover:text-brand-blue transition-colors group"
             >
               <HelpCircle className="w-5 h-5 text-gray-400 group-hover:text-brand-blue" />
-              <span>Ayuda y Soporte</span>
+              <span>Ayuda</span>
             </Link>
             <button
               onClick={() => { onClose(); signOut({ callbackUrl: '/login' }); }}
               className="w-full flex items-center gap-3 px-4 py-3 rounded-lg font-overpass font-medium text-sm text-gray-700 hover:bg-red-50 hover:text-red-600 transition-colors group"
             >
               <LogOut className="w-5 h-5 text-gray-400 group-hover:text-red-600" />
-              <span>Cerrar Sesión</span>
+              <span>Cerrar sesión</span>
             </button>
           </div>
         </div>

--- a/src/compartido/componentes/ui/logout-button.tsx
+++ b/src/compartido/componentes/ui/logout-button.tsx
@@ -10,7 +10,7 @@ export function LogoutButton() {
       className="flex items-center gap-2 text-sm hover:text-red-200 transition-colors"
     >
       <LogOut className="w-4 h-4" />
-      Cerrar Sesión
+      Cerrar sesión
     </button>
   )
 }

--- a/src/compartido/lib/content/institutional.ts
+++ b/src/compartido/lib/content/institutional.ts
@@ -24,11 +24,11 @@ export const FOOTER_LINKS = {
 
 export const TABS_BY_ROLE = {
   TALLER: [
-    { label: 'Tablero', href: '/taller' },
-    { label: 'Mis pedidos', href: '/taller/pedidos' },
-    { label: 'Mi formalizaci\u00f3n', href: '/taller/formalizacion' },
-    { label: 'Mi perfil', href: '/taller/perfil' },
-    { label: 'Academia', href: '/taller/aprender' },
+    { label: 'Inicio', href: '/taller' },
+    { label: 'Pedidos', href: '/taller/pedidos' },
+    { label: 'Mi recorrido', href: '/taller/formalizacion' },
+    { label: 'Mi vidriera', href: '/taller/perfil' },
+    { label: 'Cursos', href: '/taller/aprender' },
   ],
   MARCA: [
     { label: 'Tablero', href: '/marca' },

--- a/tests/e2e/roles-estado.spec.ts
+++ b/tests/e2e/roles-estado.spec.ts
@@ -44,8 +44,8 @@ test.describe('D-01 Roles ESTADO — flujos principales', () => {
       await menuBtn.click()
     }
     // Contar items de navegacion en el sidebar (scoped al aside)
-    // 10 items: Dashboard, Talleres, Documentos, Auditorias, Niveles, Demanda insatisfecha, Datos sectoriales, Exportar Datos, Notificaciones, Mi Cuenta
-    const sidebar = page.locator('aside[aria-label="Menú de navegación personal"]')
+    // 10 items: Dashboard, Talleres, Documentos, Auditorias, Etapas, Demanda insatisfecha, Datos sectoriales, Exportar datos, Notificaciones, Mi cuenta
+    const sidebar = page.locator('aside[aria-label="Menú principal"]')
     await expect(sidebar).toBeVisible()
     const navItems = sidebar.locator('nav ul li')
     await expect(navItems).toHaveCount(10)

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -25,8 +25,8 @@ test.describe('Smoke test — setup basico funciona', () => {
 
     // El header debe mostrar tabs del taller (scoped al header) y boton de menu
     const header = page.locator('header')
-    await expect(header.getByText('Mis pedidos').first()).toBeVisible()
-    await expect(header.getByText('Mi perfil').first()).toBeVisible()
+    await expect(header.getByText('Pedidos').first()).toBeVisible()
+    await expect(header.getByText('Mi vidriera').first()).toBeVisible()
     await expect(page.locator('button[aria-label="Abrir menú"]')).toBeVisible()
   })
 


### PR DESCRIPTION
## Summary

- Renombra 6 labels de navegación del rol TALLER alineados al master Showcase+Match (3.1, 3.7, 3.14)
- Unifica capitalización a sentence case en sidebar y header de todos los roles
- Actualiza h1, breadcrumbs y botones en las páginas del taller para coherencia
- Actualiza tests e2e (smoke + roles-estado) con nuevos selectores y aria-label

## Cambios de labels (TALLER)

| Antes | Después |
|---|---|
| Tablero / Mi Tablero | Inicio |
| Mis pedidos / Mis Pedidos | Pedidos |
| Mi formalización | Mi recorrido |
| Mi perfil / Mi Perfil | Mi vidriera |
| Academia | Cursos |
| Ayuda y Soporte | Ayuda |

Solo labels visibles. NO toca rutas, schema ni nombres internos.

## Archivos (17)

- `institutional.ts` — TABS_BY_ROLE
- `user-sidebar.tsx` — sidebar items + footer + aria-label
- 5 páginas taller — h1, breadcrumbs, botón
- 3 páginas compartidas — capitalización h1
- 2 componentes logout — sentence case
- 2 tests e2e — selectores actualizados

## Test plan

- [ ] Login como TALLER: header muestra Inicio | Pedidos | Mi recorrido | Mi vidriera | Cursos
- [ ] Sidebar TALLER: mismos labels, sentence case
- [ ] h1 de /taller/perfil dice "Mi vidriera"
- [ ] h1 de /taller/formalizacion dice "Mi recorrido"
- [ ] h1 de /taller/aprender dice "Cursos"
- [ ] Breadcrumb en detalle de curso dice "Cursos"
- [ ] Sidebar MARCA/ESTADO: sin Title Case residual
- [ ] e2e smoke y roles-estado pasan

🤖 Generated with [Claude Code](https://claude.com/claude-code)