### PR TITLE
feat: J-05 imagen en colecciones (hallazgo A)

### DIFF
--- a/.claude/specs/v4-j-05-imagen-colecciones.md
+++ b/.claude/specs/v4-j-05-imagen-colecciones.md
@@ -1,0 +1,88 @@
+# J-05: Soporte de imagen en colecciones (hallazgo A)
+
+## Contexto
+
+Hallazgo A del QA de Sergio: los cursos aparecen en el carrusel del landing con el placeholder "PDT" porque el modelo `Coleccion` no tiene campo de imagen. El landing hardcodea `imagen: null` al armar los items del carrusel.
+
+## Que construir
+
+### 1. Campo imagenUrl en modelo Coleccion
+
+Archivo: `prisma/schema.prisma`, modelo `Coleccion` (~linea 607)
+
+Agregar:
+```prisma
+imagenUrl    String?   // URL de imagen de portada del curso
+```
+
+Migracion: `npx prisma migrate dev --name agregar_imagen_coleccion`
+
+### 2. Upload endpoint (patron novedades)
+
+Crear: `src/app/api/colecciones/[id]/upload/route.ts`
+
+Patron identico a `/api/contenido/novedades/upload/route.ts`:
+- POST con FormData (`file`)
+- Solo CONTENIDO o ADMIN
+- Validar MIME (jpeg, png, webp) y size (5MB)
+- Path en bucket: `colecciones/{coleccionId}/{timestamp}.{ext}`
+- Usar `uploadFile(buffer, path, contentType, 'imagenes')` de `@/compartido/lib/storage`
+- Retornar `{ url }`
+
+### 3. Aceptar imagenUrl en PUT /api/colecciones/[id]
+
+Archivo: `src/app/api/colecciones/[id]/route.ts`
+
+Agregar `imagenUrl: body.imagenUrl` al data del update (linea 42-49).
+
+### 4. Input de imagen en form de editar coleccion
+
+Archivo: `src/app/(contenido)/contenido/colecciones/[id]/page.tsx`
+
+Patron identico a `FormularioNovedad`:
+- Estado: `imagenUrl` (string | null), `uploading` (boolean)
+- `handleUpload(file)`: POST FormData a `/api/colecciones/${coleccionId}/upload`, guardar URL
+- Cargar `imagenUrl` desde data en useEffect (ya carga datos de la coleccion)
+- En el form, seccion "Imagen de portada" dentro del Card de Informacion Basica:
+  - Si hay imagen: preview + boton "Quitar imagen"
+  - Si no: input file + texto ayuda
+  - Mientras sube: "Subiendo imagen..."
+- Enviar `imagenUrl` en el body del PUT de handleSave
+
+### 5. Usar imagen real en carrusel del landing
+
+Archivo: `src/app/page.tsx` (~linea 46)
+
+- Agregar `imagenUrl: true` al select de la query de colecciones
+- Linea 65: cambiar `imagen: null` → `imagen: c.imagenUrl`
+- El CarruselNovedades ya maneja `imagen: null` como fallback al placeholder PDT
+
+## Datos
+
+- Schema: campo `imagenUrl String?` en modelo Coleccion (migracion)
+- Sin seed — colecciones existentes quedan con `imagenUrl: null` (placeholder)
+
+## Prescripciones tecnicas
+
+- Upload endpoint simple (como novedades), sin ConfiguracionUpload
+- No usar FileUpload component — usar input file nativo (como novedades)
+- No tocar la pagina de "nueva coleccion" — la imagen se sube en la edicion
+- No cambiar el CarruselNovedades — ya soporta imagen null como placeholder
+- `next.config.ts` ya tiene `*.supabase.co` en remotePatterns
+
+## Casos borde
+
+- Coleccion sin imagen → placeholder PDT en carrusel (sin cambios, ya funciona)
+- Sofia sube imagen de 6MB → error "Archivo muy grande. Maximo 5MB."
+- Sofia sube PDF → error "Tipo de archivo no permitido. Use JPEG, PNG o WebP."
+- Bucket "imagenes" no existe → error 503 descriptivo
+- Coleccion eliminada con imagen → imagen queda huerfana en storage (aceptable, no critico)
+
+## Criterio de aceptacion
+
+1. Campo `imagenUrl` existe en modelo Coleccion
+2. Sofia puede subir imagen en el form de edicion de coleccion
+3. La imagen aparece como preview en el form
+4. Sofia puede quitar la imagen (vuelve a null)
+5. Carrusel del landing muestra la imagen real si existe, placeholder si no
+6. Build sin errores

--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,18 @@
 # Daily Log
 
+## 2026-05-26
+
+### Gerardo Breard
+- **00:05** `2971791` — feat(j-05): soporte de imagen en colecciones (hallazgo A)
+  - `.claude/specs/v4-j-05-imagen-colecciones.md`
+  - `prisma/migrations/20260526000000_agregar_imagen_coleccion/migration.sql`
+  - `prisma/schema.prisma`
+  - `src/app/(contenido)/contenido/colecciones/[id]/page.tsx`
+  - `src/app/api/colecciones/[id]/route.ts`
+  - `src/app/api/colecciones/[id]/upload/route.ts`
+  - `src/app/page.tsx`
+
+
 ## 2026-05-25
 
 ### Gerardo Breard

--- a/prisma/migrations/20260526000000_agregar_imagen_coleccion/migration.sql
+++ b/prisma/migrations/20260526000000_agregar_imagen_coleccion/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "colecciones" ADD COLUMN "imagenUrl" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -612,6 +612,7 @@ model Coleccion {
   institucion  String?
   orden        Int      @default(0)
   activa       Boolean  @default(true)
+  imagenUrl    String?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 

--- a/src/app/(contenido)/contenido/colecciones/[id]/page.tsx
+++ b/src/app/(contenido)/contenido/colecciones/[id]/page.tsx
@@ -36,6 +36,8 @@ export default function AdminEditarColeccionPage() {
   const [duracion, setDuracion] = useState('')
   const [activa, setActiva] = useState(false)
   const [videos, setVideos] = useState<Video[]>([])
+  const [imagenUrl, setImagenUrl] = useState<string | null>(null)
+  const [uploading, setUploading] = useState(false)
   const [saving, setSaving] = useState(false)
   const [loading, setLoading] = useState(true)
   const [msg, setMsg] = useState<{ type: 'ok' | 'error'; text: string } | null>(null)
@@ -52,6 +54,7 @@ export default function AdminEditarColeccionPage() {
         setCategoria(data.categoria ?? '')
         setDuracion(data.duracion ?? '')
         setActiva(data.activa ?? false)
+        setImagenUrl(data.imagenUrl ?? null)
         setVideos(data.videos ?? [])
       })
       .catch(() => {})
@@ -66,7 +69,7 @@ export default function AdminEditarColeccionPage() {
       const res = await fetch(`/api/colecciones/${coleccionId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ titulo, descripcion, institucion, categoria, duracion, activa }),
+        body: JSON.stringify({ titulo, descripcion, institucion, categoria, duracion, activa, imagenUrl }),
       })
       if (res.ok) {
         setMsg({ type: 'ok', text: 'Colección guardada correctamente' })
@@ -78,6 +81,29 @@ export default function AdminEditarColeccionPage() {
       setMsg({ type: 'error', text: 'Error de conexión' })
     } finally {
       setSaving(false)
+    }
+  }
+
+  async function handleUpload(file: File) {
+    setUploading(true)
+    setMsg(null)
+    try {
+      const formData = new FormData()
+      formData.append('file', file)
+      const res = await fetch(`/api/colecciones/${coleccionId}/upload`, {
+        method: 'POST',
+        body: formData,
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Error subiendo imagen')
+      }
+      const { url } = await res.json()
+      setImagenUrl(url)
+    } catch (err) {
+      setMsg({ type: 'error', text: err instanceof Error ? err.message : 'Error subiendo imagen' })
+    } finally {
+      setUploading(false)
     }
   }
 
@@ -171,6 +197,40 @@ export default function AdminEditarColeccionPage() {
         </div>
       </Card>
 
+      {/* Imagen de portada */}
+      <Card className="mb-6">
+        <h2 className="font-serif font-bold text-brand-blue mb-3">Imagen de portada</h2>
+        {imagenUrl ? (
+          <div className="space-y-2">
+            <img src={imagenUrl} alt="" className="max-w-xs h-40 object-cover rounded-lg border border-gray-200" />
+            <button
+              type="button"
+              onClick={() => setImagenUrl(null)}
+              className="text-sm text-red-600 hover:text-red-800 font-overpass font-medium"
+            >
+              Quitar imagen
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <input
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              disabled={uploading}
+              onChange={async (e) => {
+                const file = e.target.files?.[0]
+                if (file) await handleUpload(file)
+              }}
+              className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-overpass file:font-semibold file:bg-pastel-blue file:text-brand-blue hover:file:bg-pastel-blue"
+            />
+            {uploading && (
+              <p className="text-sm text-brand-blue animate-pulse">Subiendo imagen...</p>
+            )}
+            <p className="text-xs text-gray-400">JPEG, PNG o WebP. Máximo 5MB. Aparece en el carrusel del landing.</p>
+          </div>
+        )}
+      </Card>
+
       {/* Videos */}
       <Card className="mb-6">
         <div className="flex items-center justify-between mb-3">
@@ -220,7 +280,7 @@ export default function AdminEditarColeccionPage() {
       </Card>
 
       <div className="flex gap-3">
-        <Button onClick={handleSave} disabled={saving} className="flex-1">
+        <Button onClick={handleSave} disabled={saving || uploading} className="flex-1">
           {saving ? 'Guardando...' : 'Guardar cambios'}
         </Button>
         <Button variant="secondary" onClick={() => router.push('/contenido/colecciones')}>

--- a/src/app/api/colecciones/[id]/route.ts
+++ b/src/app/api/colecciones/[id]/route.ts
@@ -46,6 +46,7 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
         institucion: body.institucion,
         orden: body.orden,
         activa: body.activa,
+        imagenUrl: body.imagenUrl,
       },
     })
     logAccionAdmin('COLECCION_EDITADA', session.user.id, {

--- a/src/app/api/colecciones/[id]/upload/route.ts
+++ b/src/app/api/colecciones/[id]/upload/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/compartido/lib/auth'
+import { uploadFile } from '@/compartido/lib/storage'
+
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp']
+const MAX_SIZE = 5 * 1024 * 1024 // 5MB
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+    }
+
+    const role = (session.user as { role?: string }).role
+    if (role !== 'CONTENIDO' && role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const { id } = await params
+    const formData = await req.formData()
+    const file = formData.get('file') as File | null
+
+    if (!file) {
+      return NextResponse.json({ error: 'No se proporcionó archivo' }, { status: 400 })
+    }
+
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      return NextResponse.json(
+        { error: 'Tipo de archivo no permitido. Use JPEG, PNG o WebP.' },
+        { status: 400 }
+      )
+    }
+
+    if (file.size > MAX_SIZE) {
+      return NextResponse.json(
+        { error: 'Archivo muy grande. Máximo 5MB.' },
+        { status: 400 }
+      )
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer())
+    const timestamp = Date.now()
+    const ext = file.name.split('.').pop() ?? 'jpg'
+    const path = `colecciones/${id}/${timestamp}.${ext}`
+
+    const url = await uploadFile(buffer, path, file.type, 'imagenes')
+
+    return NextResponse.json({ url })
+  } catch (error) {
+    console.error('[colecciones/upload]', error)
+    const message = error instanceof Error ? error.message : 'Error desconocido'
+    const isMissingBucket = /bucket not found/i.test(message)
+    return NextResponse.json(
+      { error: isMissingBucket ? 'Storage no configurado: bucket "imagenes" no existe' : message },
+      { status: isMissingBucket ? 503 : 500 }
+    )
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,7 +43,7 @@ export default async function Home() {
       where: { activa: true },
       orderBy: { createdAt: 'desc' },
       take: 6,
-      select: { id: true, titulo: true, duracion: true, videos: { select: { id: true } } },
+      select: { id: true, titulo: true, duracion: true, imagenUrl: true, videos: { select: { id: true } } },
     }),
   ]).catch(() => [0, 0, 0, 0, [], []] as const)
 
@@ -57,12 +57,12 @@ export default async function Home() {
       imagen: n.imagenUrl,
       href: `/novedades/${n.slug}`,
     })),
-    ...(colecciones as { id: string; titulo: string; duracion: string | null; videos: { id: string }[] }[]).map(c => ({
+    ...(colecciones as { id: string; titulo: string; duracion: string | null; imagenUrl: string | null; videos: { id: string }[] }[]).map(c => ({
       id: c.id,
       tipo: 'CURSO' as const,
       titulo: c.titulo,
       subtitulo: `${c.videos.length} videos${c.duracion ? ` · ${c.duracion}` : ''}`,
-      imagen: null,
+      imagen: c.imagenUrl,
       href: '/academia-publica',
     })),
   ]


### PR DESCRIPTION
## Summary

- Agrega campo `imagenUrl` al modelo Coleccion (migración incluida)
- Nuevo endpoint `POST /api/colecciones/[id]/upload` para subir imagen de portada (patrón novedades: JPEG/PNG/WebP, 5MB max, roles CONTENIDO/ADMIN)
- Input de imagen en el form de editar colección: upload, preview, quitar
- Carrusel del landing usa la imagen real cuando existe, placeholder PDT como fallback

Resuelve hallazgo A del QA de Sergio: cursos salían con placeholder "PDT" porque el modelo no tenía campo de imagen.

## Archivos (7)

- `prisma/schema.prisma` — campo `imagenUrl String?` en Coleccion
- `prisma/migrations/20260526000000_agregar_imagen_coleccion/` — ALTER TABLE
- `src/app/api/colecciones/[id]/upload/route.ts` — nuevo endpoint
- `src/app/api/colecciones/[id]/route.ts` — acepta `imagenUrl` en PUT
- `src/app/(contenido)/contenido/colecciones/[id]/page.tsx` — sección imagen
- `src/app/page.tsx` — carrusel usa `imagenUrl` real
- `.claude/specs/v4-j-05-imagen-colecciones.md` — spec

## Test plan

- [ ] Migración corre sin errores en deploy
- [ ] Sofía puede subir imagen en editar colección
- [ ] Preview muestra la imagen subida
- [ ] "Quitar imagen" limpia el campo
- [ ] Guardar persiste la imagenUrl
- [ ] Carrusel del landing muestra imagen real si existe
- [ ] Carrusel muestra placeholder PDT si no hay imagen
- [ ] Archivo > 5MB rechazado con error claro
- [ ] Archivo PDF rechazado con error claro

🤖 Generated with [Claude Code](https://claude.com/claude-code)