### PR TITLE
feat: F2 tabs internos en Pedidos del taller

### DIFF
--- a/.claude/specs/v4-f2-tabs-pedidos.md
+++ b/.claude/specs/v4-f2-tabs-pedidos.md
@@ -1,0 +1,50 @@
+# v4-f2 — Tabs internos en Pedidos del taller
+
+## Contexto
+
+F2 del informe de navegación de Sergio. Actualmente `/taller/pedidos` (recibidos) y `/taller/pedidos/disponibles` son páginas independientes conectadas por un botón y breadcrumbs, sin relación visual que indique que pertenecen a la misma sección. Sergio pide que sean tabs dentro de una misma sección.
+
+Riesgo: BAJO. Autocontenido — solo toca el rol TALLER, no afecta componentes compartidos.
+
+## Qué construir
+
+1. **Layout con tabs** en `src/app/(taller)/taller/pedidos/layout.tsx`
+   - Dos tabs: "Recibidos" (→ `/taller/pedidos`) y "Disponibles" (→ `/taller/pedidos/disponibles`)
+   - Tab activo detectado por `usePathname()`
+   - Los tabs **NO** se muestran en la vista de detalle (`/taller/pedidos/[id]` ni `/taller/pedidos/disponibles/[id]`)
+   - Condición: si pathname matchea `/taller/pedidos/` seguido de algo que no sea exactamente `disponibles`, ocultar tabs
+
+2. **Limpiar redundancias**
+   - `page.tsx`: quitar el botón `<Link href="/taller/pedidos/disponibles">` con su badge
+   - `disponibles/page.tsx`: quitar `<Breadcrumbs>` (los tabs cumplen esa función)
+
+## Datos
+
+Sin cambios de schema ni queries.
+
+## Prescripciones técnicas
+
+- `layout.tsx` es `'use client'` por `usePathname()`
+- Usar tokens del design system: `font-overpass`, `text-brand-blue`, `border-brand-blue`
+- No crear componente reutilizable de tabs — implementar inline en el layout
+- Mantener `<main>` wrapping del layout padre (taller) intacto
+
+## Casos borde
+
+- `/taller/pedidos` → tabs visibles, "Recibidos" activo
+- `/taller/pedidos/disponibles` → tabs visibles, "Disponibles" activo
+- `/taller/pedidos/[uuid]` → tabs ocultos, detalle sin tabs
+- `/taller/pedidos/disponibles/[uuid]` → tabs ocultos, detalle sin tabs
+
+## Criterios de aceptación
+
+- [ ] Layout con 2 tabs funcionales, highlight correcto
+- [ ] Tabs ocultos en rutas de detalle
+- [ ] Botón "Pedidos disponibles" eliminado de page.tsx
+- [ ] Breadcrumbs eliminados de disponibles/page.tsx
+- [ ] Build exitoso, tsc sin errores
+- [ ] No hay redundancia visual entre tabs y encabezados
+
+## Tests
+
+- Navegación manual: verificar los 4 casos borde listados arriba

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-26
 
 ### Gerardo Breard
+- **10:58** `820acd4` — fix(e2e): usar exact:true para tab Disponibles (strict mode)
+  - `tests/e2e/ux-mejoras.spec.ts`
+
 - **10:49** `e8c9fa0` — fix(e2e): actualizar tests para tabs en pedidos taller
   - `tests/e2e/ux-mejoras.spec.ts`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-26
 
 ### Gerardo Breard
+- **10:49** `e8c9fa0` — fix(e2e): actualizar tests para tabs en pedidos taller
+  - `tests/e2e/ux-mejoras.spec.ts`
+
 - **10:26** `c3c39ce` — feat(f2): tabs internos en Pedidos del taller [Recibidos | Disponibles]
   - `.claude/specs/v4-f2-tabs-pedidos.md`
   - `src/app/(taller)/taller/pedidos/disponibles/page.tsx`

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,12 @@
 ## 2026-05-26
 
 ### Gerardo Breard
+- **10:26** `c3c39ce` — feat(f2): tabs internos en Pedidos del taller [Recibidos | Disponibles]
+  - `.claude/specs/v4-f2-tabs-pedidos.md`
+  - `src/app/(taller)/taller/pedidos/disponibles/page.tsx`
+  - `src/app/(taller)/taller/pedidos/layout.tsx`
+  - `src/app/(taller)/taller/pedidos/page.tsx`
+
 - **00:05** `2971791` — feat(j-05): soporte de imagen en colecciones (hallazgo A)
   - `.claude/specs/v4-j-05-imagen-colecciones.md`
   - `prisma/migrations/20260526000000_agregar_imagen_coleccion/migration.sql`

--- a/src/app/(taller)/taller/pedidos/disponibles/page.tsx
+++ b/src/app/(taller)/taller/pedidos/disponibles/page.tsx
@@ -7,7 +7,6 @@ import { redirect } from 'next/navigation'
 import Link from 'next/link'
 import { Badge } from '@/compartido/componentes/ui/badge'
 import { EmptyState } from '@/compartido/componentes/ui/empty-state'
-import { Breadcrumbs } from '@/compartido/componentes/ui/breadcrumbs'
 import { SkeletonTable } from '@/compartido/componentes/ui/skeleton'
 import { Package, MapPin, Calendar, ShieldCheck } from 'lucide-react'
 
@@ -179,11 +178,7 @@ export default async function PedidosDisponiblesPage({ searchParams }: { searchP
   return (
     <div className="space-y-6">
       <div>
-        <Breadcrumbs items={[
-          { label: 'Taller', href: '/taller' },
-          { label: 'Pedidos disponibles' },
-        ]} />
-        <h1 className="font-serif font-bold text-3xl text-ink-primary mt-2">Pedidos disponibles</h1>
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">Pedidos disponibles</h1>
         <p className="text-gray-500 mt-1">Pedidos publicados por marcas que buscan talleres</p>
       </div>
 

--- a/src/app/(taller)/taller/pedidos/layout.tsx
+++ b/src/app/(taller)/taller/pedidos/layout.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+const tabs = [
+  { label: 'Recibidos', href: '/taller/pedidos' },
+  { label: 'Disponibles', href: '/taller/pedidos/disponibles' },
+]
+
+/** Tabs visibles solo en las páginas índice, no en detalle [id] */
+function showTabs(pathname: string) {
+  return pathname === '/taller/pedidos' || pathname === '/taller/pedidos/disponibles'
+}
+
+export default function PedidosLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+
+  return (
+    <>
+      {showTabs(pathname) && (
+        <nav className="flex gap-1 border-b border-gray-200 mb-6">
+          {tabs.map(tab => {
+            const isActive =
+              tab.href === '/taller/pedidos'
+                ? pathname === '/taller/pedidos'
+                : pathname.startsWith(tab.href)
+
+            return (
+              <Link
+                key={tab.href}
+                href={tab.href}
+                className={`px-4 py-2.5 text-sm font-overpass font-semibold border-b-2 transition-colors -mb-px ${
+                  isActive
+                    ? 'border-brand-blue text-brand-blue'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                }`}
+              >
+                {tab.label}
+              </Link>
+            )
+          })}
+        </nav>
+      )}
+      {children}
+    </>
+  )
+}

--- a/src/app/(taller)/taller/pedidos/page.tsx
+++ b/src/app/(taller)/taller/pedidos/page.tsx
@@ -9,7 +9,6 @@ import { Badge } from '@/compartido/componentes/ui/badge'
 import { EmptyState } from '@/compartido/componentes/ui/empty-state'
 import { SkeletonTable } from '@/compartido/componentes/ui/skeleton'
 import Link from 'next/link'
-import { Package } from 'lucide-react'
 
 const statusLabel: Record<string, string> = {
   PENDIENTE: 'Pendiente',
@@ -36,17 +35,7 @@ async function ListaOrdenes() {
 
   if (!taller) redirect('/login')
 
-  const [disponiblesCount, ordenes] = await Promise.all([
-    prisma.pedido.count({
-      where: {
-        estado: 'PUBLICADO',
-        OR: [
-          { visibilidad: 'PUBLICO' },
-          { invitaciones: { some: { tallerId: taller.id } } },
-        ],
-      },
-    }),
-    prisma.ordenManufactura.findMany({
+  const ordenes = await prisma.ordenManufactura.findMany({
       where: { tallerId: taller.id },
       include: {
         pedido: {
@@ -59,8 +48,7 @@ async function ListaOrdenes() {
         },
       },
       orderBy: { createdAt: 'desc' },
-    }),
-  ])
+    })
 
   const total = ordenes.length
   const enEjecucion = ordenes.filter(o => o.estado === 'EN_EJECUCION').length
@@ -69,21 +57,9 @@ async function ListaOrdenes() {
 
   return (
     <>
-      <div className="flex items-start justify-between">
-        <div>
-          <h1 className="font-serif font-bold text-3xl text-ink-primary">Pedidos Recibidos</h1>
-          <p className="text-gray-600 mt-2">Ordenes de manufactura asignadas a {taller.nombre}</p>
-        </div>
-        <Link
-          href="/taller/pedidos/disponibles"
-          className="inline-flex items-center gap-2 bg-brand-blue text-white px-4 py-2.5 rounded-lg text-sm font-overpass font-semibold hover:bg-brand-blue-hover transition-colors"
-        >
-          <Package className="w-4 h-4" />
-          Pedidos disponibles
-          {disponiblesCount > 0 && (
-            <span className="bg-white text-brand-blue text-xs font-bold px-1.5 py-0.5 rounded-full">{disponiblesCount}</span>
-          )}
-        </Link>
+      <div>
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">Pedidos recibidos</h1>
+        <p className="text-gray-600 mt-2">Ordenes de manufactura asignadas a {taller.nombre}</p>
       </div>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">

--- a/tests/e2e/ux-mejoras.spec.ts
+++ b/tests/e2e/ux-mejoras.spec.ts
@@ -42,7 +42,7 @@ test.describe('UX Mejoras', () => {
     expect(body).not.toContain('Application error')
 
     // Verificar que la pagina tiene tabs de navegacion (Recibidos | Disponibles)
-    const tabDisponibles = page.getByRole('link', { name: 'Disponibles' })
+    const tabDisponibles = page.getByRole('link', { name: 'Disponibles', exact: true })
     await expect(tabDisponibles).toBeVisible({ timeout: 30000 })
   })
 

--- a/tests/e2e/ux-mejoras.spec.ts
+++ b/tests/e2e/ux-mejoras.spec.ts
@@ -41,9 +41,9 @@ test.describe('UX Mejoras', () => {
     const body = await page.textContent('body')
     expect(body).not.toContain('Application error')
 
-    // Verificar que la pagina tiene breadcrumbs (nav con aria-label)
-    const breadcrumb = page.locator('main nav[aria-label="Breadcrumb"]')
-    await expect(breadcrumb).toBeVisible({ timeout: 30000 })
+    // Verificar que la pagina tiene tabs de navegacion (Recibidos | Disponibles)
+    const tabDisponibles = page.getByRole('link', { name: 'Disponibles' })
+    await expect(tabDisponibles).toBeVisible({ timeout: 30000 })
   })
 
   test('Pagina de ordenes del taller carga con Suspense', async ({ page }) => {
@@ -53,7 +53,7 @@ test.describe('UX Mejoras', () => {
     await page.goto('/taller/pedidos')
     await page.waitForLoadState('domcontentloaded')
 
-    const heading = page.getByRole('heading', { name: 'Pedidos Recibidos' })
+    const heading = page.getByRole('heading', { name: 'Pedidos recibidos' })
     await expect(heading).toBeVisible({ timeout: 30000 })
   })
 


### PR DESCRIPTION
## Summary
- Agrega `layout.tsx` en `/taller/pedidos/` con tabs [Recibidos | Disponibles]
- Tabs se ocultan automáticamente en las vistas de detalle (`[id]`)
- Elimina botón "Pedidos disponibles" (ahora es un tab) y breadcrumbs redundantes en disponibles

Resuelve **F2** del informe de navegación de Sergio. Cambio autocontenido — solo afecta rol TALLER, no toca componentes compartidos.

## Archivos tocados
- `src/app/(taller)/taller/pedidos/layout.tsx` — **NUEVO** (tabs con pathname detection)
- `src/app/(taller)/taller/pedidos/page.tsx` — quitar botón y query de disponiblesCount
- `src/app/(taller)/taller/pedidos/disponibles/page.tsx` — quitar Breadcrumbs

## Test plan
- [ ] `/taller/pedidos` → tabs visibles, "Recibidos" activo
- [ ] `/taller/pedidos/disponibles` → tabs visibles, "Disponibles" activo
- [ ] `/taller/pedidos/[uuid]` → tabs ocultos, detalle sin tabs
- [ ] `/taller/pedidos/disponibles/[uuid]` → tabs ocultos, detalle sin tabs
- [ ] EmptyState en Recibidos sigue mostrando link a Disponibles

🤖 Generated with [Claude Code](https://claude.com/claude-code)