### PR TITLE
fix: #307 mitigar bloqueo de onboarding por emailVerified

### DIFF
--- a/.claude/specs/handover/DECISIONS.md
+++ b/.claude/specs/handover/DECISIONS.md
@@ -435,6 +435,23 @@ Este documento registra las decisiones importantes tomadas durante el proyecto, 
 - **Referencia:** `.claude/specs/U-01_multi-rol-airbnb_v2-tipos-corregidos.md`
 - **Estado:** Vigente
 
+### 24. Mitigación #307: setear `emailVerified` al crear la cuenta
+
+- **Fecha:** 31-may-2026
+- **Categoría:** Técnica
+- **Contexto:** El issue #307 (rol MARCA) reportó que no se podían completar los pasos del onboarding. El checklist (`onboarding.ts:86` y `:135`) gatea el paso "Verificar email" con `!!user.emailVerified`, pero el campo `emailVerified` (`DateTime?`, sin `@default`) nunca se seteaba al registrar: ni `auth/registro` ni `admin/usuarios` lo escribían, y no existe flujo de verificación de email. Resultado: el paso quedaba en `false` para todos los usuarios y bloqueaba el onboarding.
+- **Alternativas consideradas:**
+  - A) Implementar el flujo real de verificación ahora (endpoint `/api/auth/send-verification` + magic link, 2-4h)
+  - B) Sacar el paso "Verificar email" del checklist
+  - C) Setear `emailVerified: new Date()` al crear la cuenta (mitigación temporal)
+- **Decisión tomada:** C
+- **Razonamiento:** No bloquea el piloto, no requiere cambios de UX ni migración de schema, y se revierte trivialmente (borrar una línea por endpoint) cuando se implemente el flujo real. La opción B perdería el paso del checklist; la A no entra en el tiempo del piloto.
+- **Implicancias:**
+  - Usuarios nuevos del piloto quedan con `emailVerified` sin haber verificado realmente el correo.
+  - Riesgo: una cuenta con email mal escrito queda sin medio de recuperación verificado. Bajo para un piloto chico.
+  - Aplicado en `src/app/api/auth/registro/route.ts` y `src/app/api/admin/usuarios/route.ts` con comentario que marca el carácter temporal.
+- **Estado:** Temporal — reemplazar al implementar el flujo real de verificación (`/api/auth/send-verification` + magic link).
+
 ---
 
 ## Decisiones revisadas o anuladas

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,11 @@
 ## 2026-05-31
 
 ### Gerardo Breard
+- **20:24** `3aa2a1b` — fix(#307): setear emailVerified al crear cuenta (mitigacion temporal)
+  - `.claude/specs/handover/DECISIONS.md`
+  - `src/app/api/admin/usuarios/route.ts`
+  - `src/app/api/auth/registro/route.ts`
+
 - **14:44** `808b88d` — chore: registrar D1 del bloque U en DECISIONS (faltante de d48a37e)
   - `.claude/specs/handover/DECISIONS.md`
 

--- a/src/app/api/admin/usuarios/route.ts
+++ b/src/app/api/admin/usuarios/route.ts
@@ -62,7 +62,9 @@ export async function POST(req: NextRequest) {
 
     const hashedPassword = await bcrypt.hash(body.password, 10)
     const user = await prisma.user.create({
-      data: { email: body.email, password: hashedPassword, name: body.name, role: body.role, phone: body.phone },
+      // MITIGACION #307 (temporal): emailVerified al crear para no bloquear el
+      // onboarding (mismo motivo que en auth/registro). Revertir con flujo real.
+      data: { email: body.email, password: hashedPassword, name: body.name, role: body.role, phone: body.phone, emailVerified: new Date() },
       select: { id: true, email: true, name: true, role: true, active: true },
     })
     logAccionAdmin('ADMIN_USUARIO_CREADO', session.user.id, {

--- a/src/app/api/auth/registro/route.ts
+++ b/src/app/api/auth/registro/route.ts
@@ -89,6 +89,12 @@ export const POST = apiHandler(async (req: NextRequest) => {
         name: data.name || data.nombre || null,
         phone: data.phone || null,
         role: data.role,
+        // MITIGACION #307 (temporal): marcar emailVerified al crear la cuenta para
+        // no bloquear el onboarding. El paso "Verificar email" del checklist
+        // (onboarding.ts) gatea con !!user.emailVerified y, sin flujo de verificacion
+        // implementado, quedaba en false para siempre. Revertir cuando exista el
+        // flujo real (endpoint /api/auth/send-verification + magic link).
+        emailVerified: new Date(),
         ...(data.role === 'TALLER' && data.tallerData
           ? {
               taller: {


### PR DESCRIPTION
## Problema
El paso "Verificar email" del checklist de onboarding nunca se podia completar. Quedaba en `false` de forma permanente y bloqueaba el avance del onboarding (issue #307, observado en rol MARCA).

## Causa
El check del paso gatea con `!!user.emailVerified` (`onboarding.ts:86` y `:135`), pero:
- El campo `emailVerified` nunca se seteaba al registrar usuarios: ni `auth/registro` ni `admin/usuarios` lo escribian.
- En el schema, `emailVerified` es `DateTime?` y no tiene `@default`.
- No existe ningun flujo de verificacion de email que lo setee posteriormente.

Resultado: el campo siempre quedaba `null` y el paso jamas se completaba.

## Fix
Mitigacion temporal: setear `emailVerified: new Date()` al crear el usuario en ambos endpoints (`src/app/api/auth/registro/route.ts` y `src/app/api/admin/usuarios/route.ts`).

## Caracter temporal
Esto es una mitigacion, no la solucion definitiva. La solucion real (endpoint `/api/auth/send-verification` con magic link real de verificacion) queda como spec aparte.

Refs #307. Ver DECISIONS.md entrada #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)