### PR TITLE
fix: #305 ocultar boton Google sin credenciales

### DIFF
--- a/.claude/specs/handover/DECISIONS.md
+++ b/.claude/specs/handover/DECISIONS.md
@@ -452,6 +452,22 @@ Este documento registra las decisiones importantes tomadas durante el proyecto, 
   - Aplicado en `src/app/api/auth/registro/route.ts` y `src/app/api/admin/usuarios/route.ts` con comentario que marca el carácter temporal.
 - **Estado:** Temporal — reemplazar al implementar el flujo real de verificación (`/api/auth/send-verification` + magic link).
 
+### 25. Mitigación #305: ocultar el botón "Continuar con Google" sin credenciales OAuth
+
+- **Fecha:** 31-may-2026
+- **Categoría:** Técnica
+- **Contexto:** El botón "Continuar con Google" en `/login` estaba cableado a `signIn('google', { callbackUrl: '/' })`, pero el provider de Google solo se registra si existen `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` (`auth.ts`). Esas vars no están configuradas en ningún entorno, así que el botón fallaba silenciosamente al clickearlo (issue #305).
+- **Alternativas consideradas:**
+  - A) Configurar OAuth real ahora (alta en Google Cloud + vars en Vercel, 1-2h + trámite)
+  - B) Ocultar el botón temporalmente hasta tener las credenciales
+- **Decisión tomada:** B
+- **Razonamiento:** Sin credenciales, el botón ofrece una acción que siempre falla en silencio — peor UX que no mostrarlo. Ocultarlo es trivialmente reversible y no bloquea el piloto, que usa login por credenciales.
+- **Implicancias:**
+  - El login del piloto queda solo con email + contraseña (credenciales).
+  - Se ocultó el botón y el divisor "o continúa con" en `src/app/(auth)/login/page.tsx` con un comentario que marca el carácter temporal.
+  - El provider condicional de Google en `auth.ts` se deja intacto: cuando se configuren las vars, basta con reponer el botón.
+- **Estado:** Temporal — reactivar cuando se configure `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` (Google Cloud + vars en Vercel).
+
 ---
 
 ## Decisiones revisadas o anuladas

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,10 @@
 ## 2026-05-31
 
 ### Gerardo Breard
+- **21:02** `9249325` — fix(#305): ocultar boton Google sin credenciales OAuth
+  - `.claude/specs/handover/DECISIONS.md`
+  - `src/app/(auth)/login/page.tsx`
+
 - **20:24** `3aa2a1b` — fix(#307): setear emailVerified al crear cuenta (mitigacion temporal)
   - `.claude/specs/handover/DECISIONS.md`
   - `src/app/api/admin/usuarios/route.ts`

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -174,30 +174,10 @@ export default function LoginPage() {
         </Button>
       </form>
 
-      {/* Separador */}
-      <div className="relative my-6">
-        <div className="absolute inset-0 flex items-center">
-          <div className="w-full border-t border-gray-200" />
-        </div>
-        <div className="relative flex justify-center text-sm">
-          <span className="bg-white px-2 text-gray-500">O continua con</span>
-        </div>
-      </div>
-
-      {/* Google */}
-      <button
-        type="button"
-        onClick={() => signIn('google', { callbackUrl: '/' })}
-        className="w-full flex items-center justify-center gap-2 border border-gray-200 rounded-lg px-4 py-2.5 text-sm font-overpass font-medium text-gray-700 hover:bg-gray-50 transition-colors"
-      >
-        <svg className="w-4 h-4" viewBox="0 0 24 24">
-          <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/>
-          <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
-          <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
-          <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
-        </svg>
-        Continuar con Google
-      </button>
+      {/* Boton "Continuar con Google" oculto temporalmente (#305): el provider
+          de Google solo se registra si hay GOOGLE_CLIENT_ID/SECRET (auth.ts), y
+          esas vars no estan configuradas en ningun entorno, asi que signIn('google')
+          fallaba silenciosamente. Reactivar al configurar OAuth real. Ver DECISIONS.md #25. */}
 
       {/* Magic link */}
       <MagicLinkForm />


### PR DESCRIPTION
## Problema

El botón "Continuar con Google" en `/login` estaba cableado a `signIn('google', { callbackUrl: '/' })`, pero el provider de Google en `auth.ts` solo se registra si existen `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`. Esas vars no están configuradas en ningún entorno, así que al clickear el botón `signIn('google')` fallaba silenciosamente (issue #305).

## Fix (Opción B)

Mitigación temporal: se oculta el botón "Continuar con Google" y el divisor "o continúa con" en `src/app/(auth)/login/page.tsx`, reemplazándolos por un comentario que documenta el carácter temporal y referencia #305 / DECISIONS.md #25.

- El login del piloto queda solo con email + contraseña (credenciales).
- El provider condicional de Google en `auth.ts` se deja **intacto**: cuando se configuren las vars, basta con reponer el botón.
- El import de `signIn` se mantiene (lo usan el login por credenciales y el magic link).

## Carácter temporal

Reversible: reactivar cuando se configure `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` (Google Cloud + vars en Vercel).

Refs #305. Ver DECISIONS.md entrada #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
