### PR TITLE
chore: Fase 0 - CLAUDE.md con Resend (sin SendGrid)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ src/
 - GitHub: https://github.com/Grupo-De-Investigacion-y-Desarollo-GIDs/plataforma-textil
 - DB: Supabase (sa-east-1)
 - Vercel user: gbreard (gbreard@gmail.com)
-- Env vars en Vercel: DATABASE_URL, DIRECT_URL, NEXTAUTH_SECRET, NEXTAUTH_URL, SENDGRID_API_KEY, EMAIL_FROM, SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, CUIT_API_URL (pendiente)
+- Env vars en Vercel: DATABASE_URL, DIRECT_URL, NEXTAUTH_SECRET, NEXTAUTH_URL, RESEND_API_KEY, EMAIL_FROM, EMAIL_FROM_NAME (opcional), EMAIL_REPLY_TO (opcional), SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, CUIT_API_URL (pendiente)
+- Email: proveedor Resend (`src/compartido/lib/email.ts`). `EMAIL_FROM` usa el dominio propio `notificaciones@plataformatextil.com.ar`; sin `RESEND_API_KEY` el envio cae a modo dev (log por consola, no manda)
 
 ## Variables de entorno locales
 - `.env.local` — todas las variables (bajar con `vercel env pull .env.local`)

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-05-31
 
 ### Gerardo Breard
+- **22:15** `6c2216b` — chore(fase-0): actualizar CLAUDE.md - Resend en lugar de SendGrid
+  - `CLAUDE.md`
+
 - **21:02** `9249325` — fix(#305): ocultar boton Google sin credenciales OAuth
   - `.claude/specs/handover/DECISIONS.md`
   - `src/app/(auth)/login/page.tsx`


### PR DESCRIPTION
Cierra el item de codigo de Fase 0: CLAUDE.md decia `SENDGRID_API_KEY` pero el codigo migro a Resend hace tiempo (`src/compartido/lib/email.ts`).

## Cambio
- Linea 42: `SENDGRID_API_KEY` -> `RESEND_API_KEY` (+ `EMAIL_FROM_NAME`/`EMAIL_REPLY_TO` opcionales)
- Nota nueva documentando el provider Resend, el dominio propio del `EMAIL_FROM` y el modo dev sin API key

## Fuera de alcance (no es Fase 0)
Quedan referencias historicas a SendGrid en docs/specs/auditorias y en la pantalla admin `/admin/integraciones/email` (UI cosmetica). No se tocan aca.

## Pendiente para Gerardo (Vercel, no codigo)
- Confirmar `NEXTAUTH_URL` en los 3 entornos
- `EMAIL_FROM_NAME` opcional

🤖 Generated with [Claude Code](https://claude.com/claude-code)