### PR TITLE
fix(admin): UI integraciones email Resend (no SendGrid)

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,14 @@
 # Daily Log
 
+## 2026-06-01
+
+### Gerardo Breard
+- **10:55** `4a85e04` — fix(admin): UI de integraciones email decia 'SendGrid', es 'Resend'
+  - `e2e/checklist-sec5-6.spec.ts`
+  - `src/app/(admin)/admin/integraciones/email/page.tsx`
+  - `src/app/(admin)/admin/integraciones/page.tsx`
+
+
 ## 2026-05-31
 
 ### Gerardo Breard

--- a/e2e/checklist-sec5-6.spec.ts
+++ b/e2e/checklist-sec5-6.spec.ts
@@ -292,7 +292,7 @@ test('6.7 /admin/integraciones/email banner amarillo', async ({ page }) => {
 test('6.8 Formulario email deshabilitado (opacity reducida)', async ({ page }) => {
   await loginAs(page, 'admin')
   await page.goto('/admin/integraciones/email')
-  await expect(page.getByText('Configuracion SendGrid')).toBeVisible({ timeout: 15000 })
+  await expect(page.getByText('Configuracion Resend')).toBeVisible({ timeout: 15000 })
   const opacityCards = page.locator('.opacity-50')
   const count = await opacityCards.count()
   expect(count, 'Debe haber al menos 1 card con opacity reducida').toBeGreaterThanOrEqual(1)

--- a/src/app/(admin)/admin/integraciones/email/page.tsx
+++ b/src/app/(admin)/admin/integraciones/email/page.tsx
@@ -15,7 +15,7 @@ export default function AdminIntegracionEmailPage() {
         { label: 'Email' },
       ]} />
 
-      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1 mt-4">Configuracion SendGrid</h1>
+      <h1 className="font-serif font-bold text-2xl text-ink-primary mb-1 mt-4">Configuracion Resend</h1>
       <p className="text-gray-500 text-sm mb-6">Envio de emails transaccionales y masivos</p>
 
       <div className="mb-6 p-4 bg-amber-50 border border-amber-200 rounded-xl flex items-center gap-3">
@@ -23,13 +23,13 @@ export default function AdminIntegracionEmailPage() {
         <div>
           <p className="text-sm font-medium text-amber-800">Configuracion en construccion</p>
           <p className="text-xs text-amber-600 mt-0.5">
-            Esta pantalla no guarda cambios todavia. SendGrid ya esta configurado via variables de entorno.
+            Esta pantalla no guarda cambios todavia. Resend ya esta configurado via variables de entorno.
           </p>
         </div>
       </div>
 
       <Card className="mb-6 opacity-50">
-        <h2 className="font-serif font-bold text-brand-blue mb-4">API de SendGrid</h2>
+        <h2 className="font-serif font-bold text-brand-blue mb-4">API de Resend</h2>
         <div className="space-y-4">
           <Input label="API Key" type="password" value="............" disabled onChange={() => {}} />
           <Input label="Email remitente" value="noreply@plataformatextil.ar" disabled onChange={() => {}} />

--- a/src/app/(admin)/admin/integraciones/page.tsx
+++ b/src/app/(admin)/admin/integraciones/page.tsx
@@ -25,7 +25,7 @@ const integraciones = [
   {
     href: '/admin/integraciones/email',
     icon: Mail,
-    nombre: 'SendGrid (Email)',
+    nombre: 'Resend (Email)',
     descripcion: 'Envío de emails transaccionales y masivos',
     estado: 'configurado',
     proximamente: false,


### PR DESCRIPTION
Reemplazo factual del nombre del proveedor en la UI de admin. Sin cambios de diseno/copy.

## Cambios (4 strings + 1 assert)
- `integraciones/email/page.tsx`: 'Configuracion SendGrid' -> 'Configuracion Resend'; 'API de SendGrid' -> 'API de Resend'; nota del banner 'SendGrid ya esta configurado...' -> 'Resend...'
- `integraciones/page.tsx`: tarjeta 'SendGrid (Email)' -> 'Resend (Email)'
- `e2e/checklist-sec5-6.spec.ts` (test 6.8): assert actualizado a 'Configuracion Resend'

## Notas
- La pantalla es mock estatico: no lee env vars (`SENDGRID_API_KEY` no se chequeaba), asi que no habia logica funcional que tocar.
- Fuera de alcance (no es reemplazo de proveedor): el campo mock 'Email remitente' muestra `noreply@plataformatextil.ar`, distinto del real `notificaciones@plataformatextil.com.ar`. Es copy/mock, queda para la narrativa de Sergio.

Refs #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)