### PR TITLE
feat: U-07 regla anti-incesto multi-rol

### DIFF
--- a/.claude/specs/v4-u-07-anti-incesto.md
+++ b/.claude/specs/v4-u-07-anti-incesto.md
@@ -1,0 +1,166 @@
+# U-07: Regla anti-incesto (bloque multi-rol)
+
+## Contexto
+
+Parte del bloque **U** (multi-rol "Airbnb": un mismo `User` puede operar como
+taller **y** como marca — ver `v4-u-01-analisis-multi-rol-airbnb.md` y
+`v4-u-02-schema-multi-rol.md`).
+
+**Regla de negocio (RN del U-01):** un `User` que tiene perfil de taller **y**
+de marca no puede cotizar pedidos que él mismo publicó como marca. Es decir, no
+puede "cotizarse a sí mismo".
+
+Bajo el modelo **1-CUIT-1-User** (un usuario = un CUIT = un par Taller/Marca),
+basta con comparar `userId` para detectar el caso: si el dueño del pedido
+(`pedido.marca.userId`) es el mismo usuario que está cotizando
+(`session.user.id`), es auto-cotización y debe bloquearse.
+
+> **Nota de alcance:** el discovery global preveía guard en `POST /api/cotizaciones`
+> + filtros de UI. Durante este discovery puntual apareció un **segundo punto de
+> entrada** no contemplado: la **auto-invitación** desde el flujo de marca
+> (`POST /api/pedidos/[id]/invitaciones`). Se incluye abajo. Ver "Casos borde".
+
+## Que construir
+
+### 1. Guard server-side en `POST /api/cotizaciones` (autoritativo)
+
+Es **el guard que importa** — la UI puede esquivarse, este no.
+
+- **Archivo:** `src/app/api/cotizaciones/route.ts`
+- **Ubicación exacta:** dentro del handler `POST`, justo **después** de obtener
+  el pedido y validar que existe (actual línea 110,
+  `if (!pedido) return errorNotFound('pedido')`) y **antes** de la validación de
+  `visibilidad === 'INVITACION'` (línea 115).
+- **Dato ya en scope:** `pedido.marca.userId` ya viene en el `select`
+  (línea 108). No hace falta modificar la query.
+- **Lógica:**
+  ```ts
+  if (pedido.marca.userId === session.user.id) {
+    return errorResponse({
+      code: 'AUTO_COTIZACION',
+      message: 'No podés cotizar un pedido que publicaste como marca.',
+      status: 403,
+    })
+  }
+  ```
+- Reusar el helper `errorResponse` ya importado (línea 8). Código nuevo
+  `AUTO_COTIZACION` (string libre, consistente con los existentes
+  `TALLER_NO_VERIFICADO`, `INVALID_INPUT`).
+
+### 2. Guard server-side en `POST /api/pedidos/[id]/invitaciones` (auto-invitación)
+
+Evita que una marca invite a su **propio** taller a cotizar (que crearía una
+invitación que después el guard #1 rechazaría igual, pero deja la UI inconsistente).
+
+- **Archivo:** `src/app/api/pedidos/[id]/invitaciones/route.ts`
+- **Ubicación:** la query `talleresConUser` (línea 39-42) ya incluye
+  `user: { select: { id: true, email: true } }`. Después de cargarla y antes de
+  `idsValidos`, filtrar/rechazar el taller cuyo `user.id === pedido.marca.userId`.
+- **Decisión de comportamiento (pendiente de Gerardo):** ante un taller propio
+  en la selección, ¿se **rechaza toda la operación** con error (consistente con
+  el patrón "no verificados" de línea 44-50) o se **filtra silenciosamente**?
+  Recomendación: rechazar con mensaje claro, igual que `noVerificados`, porque
+  es un error del usuario y conviene que lo vea.
+  ```ts
+  const propios = talleresConUser.filter(t => t.user.id === pedido.marca.userId)
+  if (propios.length > 0) {
+    return NextResponse.json(
+      { error: 'No podés invitarte a vos mismo a cotizar tu propio pedido.' },
+      { status: 400 }
+    )
+  }
+  ```
+
+### 3. Filtros de UI (no autoritativos — UX, evitan que el usuario llegue al error)
+
+**3a. Detalle de pedido — ocultar `CotizarForm`**
+- **Archivo:** `src/app/(taller)/taller/pedidos/disponibles/[id]/page.tsx`
+- La query del pedido (línea 17-20) hoy **no** trae `marca.userId`. Agregarlo al
+  `select` de `marca`.
+- En la cascada de render (línea 85-120), agregar una rama: si
+  `pedido.marca.userId === session.user.id`, mostrar un `Card` informativo
+  ("Este es un pedido que publicaste como marca — no podés cotizarlo") **en lugar**
+  del `CotizarForm`. Va **antes** de la rama `!taller.verificadoAfip`.
+
+**3b. Listado de disponibles — excluir pedidos propios**
+- **Archivo:** `src/app/(taller)/taller/pedidos/disponibles/page.tsx`
+- En el `where` (línea 21-28), agregar `NOT: { marca: { userId: session.user.id } }`.
+  Ojo: combinar con el `NOT` existente de `tipoPrenda` (usar `AND` o un array de
+  `NOT`). Aplica también al `count` (mismo `where`). El usuario logueado ya está
+  disponible vía `session.user.id` (línea 16-17).
+
+**3c. Invitador de marca — excluir taller propio de la búsqueda**
+- **Archivo:** `src/marca/componentes/invitar-a-cotizar.tsx` (consume
+  `/api/talleres?q=...`).
+- El guard #2 ya cubre el server. Para UX, el endpoint `/api/talleres` podría
+  excluir el taller del propio usuario de los resultados. **Marcar como opcional**
+  — requiere tocar `/api/talleres` (fuera del scope mínimo). Si se omite, el
+  usuario igual recibe el error claro del guard #2 al confirmar.
+
+## Datos
+
+- **Sin cambios de schema.** No se toca Prisma.
+- Campos ya existentes usados: `Pedido.marca.userId` (relación `Marca.userId`),
+  `Taller.user.id`, `session.user.id`.
+- Comparación por `userId` (no por CUIT): suficiente bajo 1-CUIT-1-User. Ver
+  casos borde.
+
+## Prescripciones tecnicas
+
+- **Patrón:** guards server-side en API routes (no server actions). Reusar los
+  helpers existentes: `errorResponse` en cotizaciones, `NextResponse.json(...,
+  { status })` en invitaciones (mantener el estilo de cada archivo).
+- **No** agregar dependencias.
+- **No** modificar queries salvo agregar `marca.userId` al `select` del detalle
+  (3a) — los demás datos ya están en scope.
+- Mensajes de error en español, tono de la plataforma (ver mensajes vecinos).
+- El guard #1 es **obligatorio**; #2 obligatorio; #3a y #3b recomendados (UX);
+  #3c opcional.
+
+## Casos borde
+
+1. **User con SOLO rol taller** (no tiene Marca) → ningún pedido tiene
+   `marca.userId === session.user.id` → la regla nunca dispara. Flujo normal.
+2. **User con ambos perfiles mirando un pedido de OTRA marca** →
+   `marca.userId !== session.user.id` → puede cotizar normal.
+3. **¿`userId` alcanza o conviene comparar `User.cuit`?** Bajo 1-CUIT-1-User,
+   `userId` alcanza y es lo correcto: un mismo User es la misma persona/CUIT.
+   Comparar CUIT solo importaría si dos `User` distintos compartieran CUIT, lo
+   que el modelo prohíbe. **Confirmado: comparar `userId`.**
+4. **Pedido por INVITACIÓN a sí mismo:** si por un bug previo existiera una
+   `PedidoInvitacion` del taller propio, el guard #1 igual bloquea la cotización
+   (corre después de validar existencia del pedido, antes de chequear invitación).
+   El guard #2 previene crear ese estado a futuro.
+5. **(Hallazgo nuevo del discovery)** **Auto-invitación:** sin el guard #2, una
+   marca podía invitar a su propio taller; se creaba la invitación y el pedido
+   aparecía en "disponibles" del taller, pero al cotizar saltaba el error. UX
+   inconsistente. Cubierto por guard #2.
+6. **ADMIN cotizando/invitando en nombre de otro:** el POST de cotizaciones exige
+   `role === 'TALLER'` (línea 79), así que ADMIN no cotiza. En invitaciones, ADMIN
+   omite el ownership (línea 27) pero el chequeo de "taller propio de la marca"
+   sigue siendo correcto (compara contra `pedido.marca.userId`, no contra el admin).
+
+## Criterio de aceptacion
+
+- [ ] `POST /api/cotizaciones` devuelve **403 `AUTO_COTIZACION`** cuando
+  `pedido.marca.userId === session.user.id`.
+- [ ] Un taller cotizando un pedido de **otra** marca sigue funcionando (201).
+- [ ] `POST /api/pedidos/[id]/invitaciones` devuelve **400** si se incluye el
+  taller propio del dueño del pedido.
+- [ ] Detalle de pedido propio: se muestra el aviso informativo, **no** el
+  `CotizarForm`.
+- [ ] Listado "Pedidos disponibles" **no** lista pedidos propios del usuario.
+- [ ] User con solo rol taller: sin cambios de comportamiento.
+- [ ] `npm run build` y e2e existentes verdes.
+
+## Tests
+
+- **Vitest / e2e (Playwright):**
+  - Cotizar pedido propio → 403 `AUTO_COTIZACION` (caso central).
+  - Cotizar pedido ajeno → 201 (regresión, no romper flujo normal).
+  - Invitar taller propio → 400.
+  - Listado disponibles de un user multi-rol no incluye su pedido.
+  - User solo-taller: cotiza normal (regresión).
+- Setup: requiere un fixture de `User` con Taller **y** Marca (modelo multi-rol).
+  Si el seed actual no lo tiene, el spec de implementación debe crear el fixture
+  (coordinar con `v4-u-02-schema-multi-rol`).

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,14 @@
 ## 2026-06-01
 
 ### Gerardo Breard
+- **14:34** `5ecc879` — feat(u-07): regla anti-incesto multi-rol
+  - `.claude/specs/v4-u-07-anti-incesto.md`
+  - `e2e/u-07-anti-incesto.spec.ts`
+  - `src/app/(taller)/taller/pedidos/disponibles/[id]/page.tsx`
+  - `src/app/(taller)/taller/pedidos/disponibles/page.tsx`
+  - `src/app/api/cotizaciones/route.ts`
+  - `src/app/api/pedidos/[id]/invitaciones/route.ts`
+
 - **10:55** `4a85e04` — fix(admin): UI de integraciones email decia 'SendGrid', es 'Resend'
   - `e2e/checklist-sec5-6.spec.ts`
   - `src/app/(admin)/admin/integraciones/email/page.tsx`

--- a/e2e/u-07-anti-incesto.spec.ts
+++ b/e2e/u-07-anti-incesto.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test'
+import { loginAs } from './helpers/auth'
+
+// U-07 — Regla anti-incesto (bloque multi-rol).
+// Un User con perfil de taller Y marca no puede cotizar/invitar a sus propios pedidos.
+// Ver .claude/specs/v4-u-07-anti-incesto.md
+
+// --- REGRESIÓN (con fixtures single-role actuales) ---
+// Garantiza que el guard 3a (ocultar CotizarForm en pedido propio) NO afecta el
+// flujo normal: un taller mirando el pedido de OTRA marca nunca ve el aviso
+// "publicaste como marca".
+test('taller viendo pedido ajeno NO ve el aviso anti-incesto', async ({ page }) => {
+  await loginAs(page, 'taller_oro')
+  await page.goto('/taller/pedidos/disponibles')
+
+  const primerPedido = page.locator('a[href^="/taller/pedidos/disponibles/"]').first()
+  await expect(primerPedido).toBeVisible()
+  await primerPedido.click()
+
+  await expect(page).toHaveURL(/\/taller\/pedidos\/disponibles\/.+/)
+  await expect(page.getByText('Este es un pedido que publicaste como marca')).toHaveCount(0)
+})
+
+// --- CASOS CENTRALES (requieren fixture multi-rol) ---
+// El seed actual es single-role: ningún User tiene Taller Y Marca a la vez.
+// Estos tests se completan en U-08, cuando exista el seed dual (v4-u-02-schema-multi-rol).
+// Se dejan como `fixme` para que queden trackeados y se activen al llegar el fixture.
+
+test.fixme('cotizar pedido propio devuelve 403 AUTO_COTIZACION', async () => {
+  // TODO(U-08): requiere User dual (taller+marca). POST /api/cotizaciones sobre
+  // un pedido cuya marca.userId === session.user.id → 403 code AUTO_COTIZACION.
+})
+
+test.fixme('invitar al taller propio devuelve 400', async () => {
+  // TODO(U-08): requiere User dual. POST /api/pedidos/[id]/invitaciones incluyendo
+  // el taller del propio dueño del pedido → 400 "No podés invitarte a vos mismo...".
+})
+
+test.fixme('listado de disponibles no incluye los pedidos propios del user dual', async () => {
+  // TODO(U-08): requiere User dual. /taller/pedidos/disponibles no debe listar
+  // pedidos cuya marca.userId === session.user.id.
+})

--- a/src/app/(taller)/taller/pedidos/disponibles/[id]/page.tsx
+++ b/src/app/(taller)/taller/pedidos/disponibles/[id]/page.tsx
@@ -16,7 +16,7 @@ export default async function PedidoDisponibleDetallePage({ params }: { params: 
 
   const pedido = await prisma.pedido.findFirst({
     where: { id, estado: 'PUBLICADO' },
-    include: { marca: { select: { nombre: true, tipo: true, ubicacion: true } } },
+    include: { marca: { select: { nombre: true, tipo: true, ubicacion: true, userId: true } } },
   })
   if (!pedido) notFound()
 
@@ -82,7 +82,18 @@ export default async function PedidoDisponibleDetallePage({ params }: { params: 
         </Card>
       )}
 
-      {taller && !taller.verificadoAfip ? (
+      {pedido.marca.userId === session.user.id ? (
+        <Card>
+          <div className="text-center py-6">
+            <p className="font-overpass font-semibold text-brand-blue mb-1">
+              Este es un pedido que publicaste como marca
+            </p>
+            <p className="text-sm text-gray-600">
+              No podés cotizarlo. Para gestionar las cotizaciones recibidas, andá a tu panel de marca.
+            </p>
+          </div>
+        </Card>
+      ) : taller && !taller.verificadoAfip ? (
         <Card>
           <div className="text-center py-6">
             <p className="font-overpass font-semibold text-amber-800 mb-2">

--- a/src/app/(taller)/taller/pedidos/disponibles/page.tsx
+++ b/src/app/(taller)/taller/pedidos/disponibles/page.tsx
@@ -20,7 +20,10 @@ async function ListaPedidosDisponibles({ page }: { page: number }) {
 
   const where = {
     estado: 'PUBLICADO' as const,
-    NOT: { tipoPrenda: { startsWith: 'E2E-Test' } },
+    NOT: [
+      { tipoPrenda: { startsWith: 'E2E-Test' } },
+      ...(session.user.id ? [{ marca: { userId: session.user.id } }] : []),
+    ],
     OR: [
       { visibilidad: 'PUBLICO' as const },
       ...(taller ? [{ invitaciones: { some: { tallerId: taller.id } } }] : []),

--- a/src/app/api/cotizaciones/route.ts
+++ b/src/app/api/cotizaciones/route.ts
@@ -108,6 +108,15 @@ export const POST = apiHandler(async (req: NextRequest) => {
     select: { id: true, estado: true, visibilidad: true, marca: { select: { userId: true, nombre: true } }, omId: true, tipoPrenda: true, cantidad: true, marcaId: true },
   })
   if (!pedido) return errorNotFound('pedido')
+
+  if (pedido.marca.userId === session.user.id) {
+    return errorResponse({
+      code: 'AUTO_COTIZACION',
+      message: 'No podés cotizar un pedido que publicaste como marca.',
+      status: 403,
+    })
+  }
+
   if (pedido.estado !== 'PUBLICADO') {
     return errorResponse({ code: 'INVALID_INPUT', message: 'El pedido no esta disponible para cotizar', status: 400 })
   }

--- a/src/app/api/pedidos/[id]/invitaciones/route.ts
+++ b/src/app/api/pedidos/[id]/invitaciones/route.ts
@@ -41,6 +41,14 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       include: { user: { select: { id: true, email: true } } },
     })
 
+    const propios = talleresConUser.filter(t => t.user.id === pedido.marca.userId)
+    if (propios.length > 0) {
+      return NextResponse.json(
+        { error: 'No podés invitarte a vos mismo a cotizar tu propio pedido.' },
+        { status: 400 }
+      )
+    }
+
     const noVerificados = talleresConUser.filter(t => !t.verificadoAfip)
     if (noVerificados.length > 0) {
       return NextResponse.json(


### PR DESCRIPTION
Guards server-side + filtros UI para que un User con perfil de taller **y** marca no pueda cotizar ni invitarse a sus propios pedidos.

## Cambios
- **Guard #1 (obligatorio)** — `POST /api/cotizaciones`: rechaza **403 `AUTO_COTIZACION`** si `pedido.marca.userId === session.user.id`.
- **Guard #2 (obligatorio)** — `POST /api/pedidos/[id]/invitaciones`: rechaza **400** si se incluye el taller propio del dueño del pedido (decisión cerrada: opción A, rechazo con mensaje claro).
- **UI 3a** — detalle de pedido: oculta `CotizarForm` y muestra aviso cuando el pedido es propio.
- **UI 3b** — listado disponibles: excluye pedidos propios del `where` (combinado con el `NOT` E2E existente de G-19, sin pisarlo).
- **UI 3c** — omitida (requería tocar `/api/talleres`; el guard #2 ya cubre el server).

Comparación por `userId` (suficiente bajo 1-CUIT-1-User). **Sin cambios de schema.**

## Tests
- Regresión activa: taller viendo pedido ajeno NO ve el aviso anti-incesto.
- Casos centrales (cotizar/invitar propio, listado dual) como `test.fixme` documentados — requieren fixture multi-rol (User con Taller+Marca), que el seed actual no tiene. Se activan en U-08 con el seed dual.

Refs spec `.claude/specs/v4-u-07-anti-incesto.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)