### PR TITLE
feat: U-06 clasificacion pedidos COMERCIAL/SUBCONTRATACION

### DIFF
--- a/.claude/specs/v4-u-06-clasificacion-pedidos.md
+++ b/.claude/specs/v4-u-06-clasificacion-pedidos.md
@@ -1,0 +1,228 @@
+# U-06: Clasificación automática de pedidos (COMERCIAL / SUBCONTRATACION)
+
+## Contexto
+
+Parte del bloque **U** (multi-rol "Airbnb": un mismo `User` puede operar como
+taller **y** como marca — ver `v4-u-01-analisis-multi-rol-airbnb.md` y
+`v4-u-02-schema-multi-rol.md`).
+
+**Necesidad de negocio:** el Estado / coordinación necesita distinguir dos tipos
+de demanda en la plataforma:
+
+- **COMERCIAL** — un pedido publicado por una marca "pura" (el dueño del pedido
+  *solo* tiene perfil de Marca). Es demanda real del mercado hacia los talleres.
+- **SUBCONTRATACION** — un pedido publicado por un `User` que *también* es taller
+  (tiene perfil de Taller además del de Marca). Es un taller que terceriza
+  trabajo, no demanda comercial nueva.
+
+La clasificación es **automática e invisible** para quien publica: se calcula en
+el servidor al crear el pedido y queda persistida. No hay UI de selección, ni se
+muestra a marcas ni a talleres. Solo el Estado/coordinación la ve en reportes
+agregados.
+
+Bajo el modelo **1-CUIT-1-User** la clasificación se decide mirando si el **dueño
+del pedido** (el `User` propietario de la `Marca`) tiene además un `Taller`:
+
+- el dueño tiene `Taller` → **SUBCONTRATACION**
+- el dueño solo tiene `Marca` → **COMERCIAL**
+
+> **Independencia de U-03/U-04:** la regla keya sobre la **existencia** de un
+> `Taller` para ese `userId`, no sobre `activeMode` ni sobre ningún modo activo.
+> Por eso U-06 no depende de U-03/U-04 y se puede implementar ya.
+
+## Que construir
+
+### 1. Schema — enum + campo en `Pedido`
+
+- **Archivo:** `prisma/schema.prisma`
+- **Enum nuevo** (junto a los otros enums de pedidos, p. ej. cerca de
+  `EstadoPedido` línea 29 / `VisibilidadPedido` línea 95):
+  ```prisma
+  enum TipoPedido {
+    COMERCIAL
+    SUBCONTRATACION
+  }
+  ```
+- **Campo nuevo** en `model Pedido` (línea 439). Aditivo, con default seguro:
+  ```prisma
+  tipo TipoPedido @default(COMERCIAL)
+  ```
+  Ubicarlo junto a `estado` / `visibilidad` (líneas 448-449) para mantener
+  agrupados los campos de clasificación.
+
+### 2. Migración aditiva
+
+- **No tocar a mano la DB.** Generar con Prisma:
+  ```bash
+  npx prisma migrate dev --name agregar_tipo_pedido
+  ```
+- Resultado esperado: crea el tipo enum `TipoPedido` y agrega la columna `tipo`
+  a `pedidos` con default `'COMERCIAL'`. Como tiene default, **los pedidos
+  existentes quedan COMERCIAL** sin pasos extra (ver Backfill).
+- Recordar: Prisma CLI lee `.env` (no `.env.local`) — ya configurado en el repo.
+
+### 3. Lógica de clasificación al crear el pedido
+
+- **Archivo:** `src/app/api/pedidos/route.ts`, handler `POST` (único punto de
+  creación en runtime; confirmado por discovery — el resto de `pedido.create`
+  está solo en `prisma/seed.ts`).
+- **Punto exacto:** entre la resolución de `resolvedMarcaId` (líneas 83-98) y el
+  `prisma.pedido.create` (línea 100).
+- **Cómo resolver el dueño (`ownerUserId`):** OJO — el clasificador es el dueño
+  de la **Marca**, *no* `session.user.id`. En el rol ADMIN un admin puede crear
+  el pedido en nombre de otra marca, así que hay que usar el `userId` de la marca
+  resuelta, no el del que dispara la request.
+  - Rama **MARCA** (líneas 84-90): la query de la marca hoy selecciona solo
+    `{ id: true }`. Agregar `userId`:
+    ```ts
+    const marca = await prisma.marca.findUnique({
+      where: { userId: session.user.id },
+      select: { id: true, userId: true },
+    })
+    ...
+    // ownerUserId = marca.userId  (== session.user.id, pero lo usamos explícito)
+    ```
+  - Rama **ADMIN** (líneas 91-95): **camino no usado actualmente.** El discovery
+    confirmó que ningún UI ni test postea `/api/pedidos` como ADMIN — la rama es
+    scaffolding simétrico (espejo del role-switch del `GET`), introducida en
+    `a710bde` sin spec que la pida; el diseño canaliza la manipulación admin de
+    pedidos por Prisma Studio (ver `semana2-schema-e2.md`). **No se testea.** Se
+    clasifica **defensivamente** igual, con una query para obtener el dueño:
+    ```ts
+    // Rama no usada en producción (admin no publica vía API). Clasificación
+    // defensiva. Limpieza de la rama pendiente en PR de housekeeping aparte.
+    const marcaTarget = await prisma.marca.findUnique({
+      where: { id: body.marcaId },
+      select: { id: true, userId: true },
+    })
+    if (!marcaTarget) return errorNotFound('marca')
+    // ownerUserId = marcaTarget.userId
+    ```
+- **Clasificación:**
+  ```ts
+  const ownerTaller = await prisma.taller.findFirst({
+    where: { userId: ownerUserId },
+    select: { id: true },
+  })
+  const tipo = ownerTaller ? 'SUBCONTRATACION' : 'COMERCIAL'
+  ```
+- **Persistir:** agregar `tipo` al objeto `data` del `prisma.pedido.create`
+  (línea 100):
+  ```ts
+  data: {
+    ...,
+    tipo,
+  }
+  ```
+- **No exponer en la respuesta de forma destacada:** el `create` ya devuelve el
+  objeto completo, lo cual es aceptable (el campo no es secreto, solo no se
+  muestra en UI de marca/taller). No agregar lógica de ocultamiento.
+
+### 4. Backfill de pedidos existentes
+
+- **Default cubre el caso base:** la migración deja todos los pedidos previos en
+  `COMERCIAL`. Para la mayoría del dataset actual (seed single-role) eso es
+  correcto.
+- **Recalculo opcional (recomendado, idempotente):** marcar como
+  `SUBCONTRATACION` los pedidos cuyo dueño de marca ya tiene taller. Script SQL
+  one-shot dentro de la misma migración o como `prisma db execute`:
+  ```sql
+  UPDATE pedidos p
+  SET tipo = 'SUBCONTRATACION'
+  FROM marcas m
+  JOIN talleres t ON t."userId" = m."userId"
+  WHERE p."marcaId" = m.id;
+  ```
+  Hoy no hay usuarios duales en el seed, así que este UPDATE no cambia filas,
+  pero deja la data consistente para cuando llegue el fixture dual (U-08) y para
+  prod si ya hubiera algún user dual.
+
+### 5. Visualización — DIFERIDA (fuera del alcance de U-06)
+
+**Decisión tomada (Gerardo):** U-06 entrega **solo el campo** — clasificación +
+backfill. **La vista de reporte queda diferida a Etapa 2/3**, donde la narrativa
+defina quién la consume (COORD / POLÍTICO). No se construye card en este spec.
+
+El campo queda **persistido y correcto**, listo para cuando se especifique la
+vista. Candidatas ya relevadas para ese spec futuro (no implementar ahora):
+
+- `src/app/(admin)/admin/reportes/page.tsx` — patrón `groupBy` + `StatCard`;
+  encajaría `prisma.pedido.groupBy({ by: ['tipo'], _count: true })`.
+- `src/app/(estado)/estado/sector/page.tsx` — patrón `BarChart` para rol ESTADO.
+
+## Datos
+
+- **Tabla afectada:** `pedidos` — columna nueva `tipo` (`TipoPedido`, default
+  `COMERCIAL`, NOT NULL por el default).
+- **Enum nuevo:** `TipoPedido { COMERCIAL, SUBCONTRATACION }`.
+- **Queries nuevas:**
+  - `prisma.taller.findFirst({ where: { userId: ownerUserId }, select: { id: true } })`
+    al crear (clasificación).
+  - rama ADMIN: `prisma.marca.findUnique` para obtener `userId` del dueño.
+  - opcional reporte: `prisma.pedido.groupBy({ by: ['tipo'], _count: true })`.
+- **Sin cambios** en `Cotizacion`, `OrdenManufactura`, ni en los flujos de
+  taller/marca existentes.
+
+## Prescripciones técnicas
+
+- **Schema es exclusivo de Gerardo** (regla CLAUDE.md): el cambio de
+  `schema.prisma` + la migración los hace Gerardo. Sergio implementa la lógica de
+  `route.ts` y, si se decide, el card de reporte.
+- **No** crear UI de selección de tipo. **No** aceptar `tipo` desde `body` (no
+  confiar en el cliente — la clasificación es autoritativa server-side).
+- Mantener el estilo de errores del archivo (`errorResponse` / `errorNotFound`
+  de `@/compartido/lib/api-errors`).
+- La query de clasificación va **antes** del `create`; no usar transacción (una
+  sola escritura).
+- Reusar el patrón `StatCard` / `groupBy` ya presente en `admin/reportes` si se
+  hace el card.
+
+## Casos borde
+
+| Caso | Comportamiento esperado |
+|------|-------------------------|
+| Marca pura crea pedido | `tipo = COMERCIAL` |
+| User dual (Marca + Taller) crea pedido como marca | `tipo = SUBCONTRATACION` |
+| ADMIN crea pedido en nombre de una marca dual | `tipo = SUBCONTRATACION` (keya sobre el dueño de la marca, no sobre el admin) |
+| ADMIN crea pedido en nombre de una marca pura | `tipo = COMERCIAL` |
+| `body.marcaId` inexistente (ADMIN) | `errorNotFound('marca')` antes de clasificar |
+| Pedidos preexistentes | `COMERCIAL` por default; `SUBCONTRATACION` si corre el backfill y el dueño tiene taller |
+| User crea marca, luego crea taller, luego publica pedido | `SUBCONTRATACION` (taller ya existe al momento de crear) |
+| User publica pedido y *después* se da de alta como taller | El pedido queda `COMERCIAL` (clasificación es en el momento de crear, no reactiva). Aceptable: no se reclasifica retroactivamente. |
+
+## Criterio de aceptación
+
+- [ ] `schema.prisma` tiene el enum `TipoPedido` y el campo `Pedido.tipo`
+      (`@default(COMERCIAL)`).
+- [ ] Migración `agregar_tipo_pedido` aplicada; `pedidos.tipo` existe en DB con
+      default `COMERCIAL`.
+- [ ] Al crear un pedido como marca pura → `tipo = COMERCIAL`.
+- [ ] Al crear un pedido cuyo dueño tiene taller → `tipo = SUBCONTRATACION`
+      (verificable cuando exista fixture dual; hasta entonces, test unitario de la
+      rama de clasificación con un user dual creado ad-hoc).
+- [ ] La clasificación **no** se puede forzar desde `body` (se ignora cualquier
+      `tipo` enviado por el cliente).
+- [ ] Backfill (si se corre) no rompe pedidos existentes.
+- [ ] Vista de reporte **diferida** — fuera del alcance de U-06 (Etapa 2/3).
+- [ ] `npm run build` + typecheck en verde (Vercel CI autoritativo).
+
+## Tests
+
+- **Unit/integración (Vitest):** la rama de clasificación — dado un `ownerUserId`
+  con taller → `SUBCONTRATACION`; sin taller → `COMERCIAL`. Mockeando
+  `prisma.taller.findFirst`.
+- **E2E (Playwright):**
+  - **Regresión (con seed single-role actual):** marca pura crea pedido → al
+    leerlo en DB / reporte, `tipo = COMERCIAL`. No rompe el flujo de creación
+    existente.
+  - **Caso dual (`test.fixme`, TODO U-08):** requiere `User` con Marca + Taller
+    (no existe en el seed). Crear pedido como ese user → `SUBCONTRATACION`.
+    Dejar trackeado como `fixme` igual que en `e2e/u-07-anti-incesto.spec.ts`.
+- **No forzar un fixture dual a medias** que rompa otros tests (misma disciplina
+  que U-07). El fixture dual llega en U-08.
+
+---
+
+Refs: `.claude/specs/v4-u-01-analisis-multi-rol-airbnb.md`,
+`.claude/specs/v4-u-02-schema-multi-rol.md`,
+`.claude/specs/v4-u-07-anti-incesto.md`

--- a/DAILY.md
+++ b/DAILY.md
@@ -6,37 +6,16 @@
 - **18:42** `4243067` — test: arreglar asercion fragil en acceso-verificado
   - `src/__tests__/acceso-verificado.test.ts`
 
-- **18:41** `1fd8934` — test: arreglar asercion fragil en acceso-verificado
-  - `.claude/scheduled_tasks.lock`
-  - `.claude/specs/06-spec-mejoras-landing.md`
-  - `.claude/specs/07-spec-mejoras-landing-FINAL.md`
-  - `.claude/specs/k-01-rls-supabase.md`
-  - `.claude/specs/k-02-bucket-documentos-publico.md`
-  - `.claude/specs/logo-pdt.png.png`
-  - `.claude/specs/narrativa-V4-consolidado-niveles-1-a-4.md`
-  - `.claude/specs/proceso-textil.webp.webp`
-  - `.claude/specs/v4-x-04b-cms-novedades-v2.md`
-  - `.claude/specs/v4-x-04b-cms-novedades.md`
-  - `.claude/specs/v4-x-05-header-app-footer.md`
-  - `.claude/specs/v4-x-06-header-public-landing-v2.md`
-  - `.claude/specs/v4-x-06-header-public-landing.md`
-  - `.claude/specs/v4-x-07-paleta-dashboards.md`
-  - `.claude/specs/v4-x-07a-paleta-dashboards-critico.md`
-  - `"docs/Dise\303\261o/ChatGPT Image 25 may 2026, 09_07_37 p.m. (1).png"`
-  - `"docs/Dise\303\261o/ChatGPT Image 25 may 2026, 09_07_37 p.m. (2).png"`
-  - `"docs/Dise\303\261o/ChatGPT Image 25 may 2026, 09_07_38 p.m. (3).png"`
-  - `"docs/Dise\303\261o/ChatGPT Image 25 may 2026, 09_08_41 p.m..png"`
-  - `"docs/Dise\303\261o/ChatGPT Image 25 may 2026, 09_08_48 p.m..png"`
-  - `"docs/Dise\303\261o/PDT_logo_sin_fondo.png"`
-  - `"docs/Dise\303\261o/buzo.png"`
-  - `"docs/Dise\303\261o/camisa.png"`
-  - `"docs/Dise\303\261o/logo_PDT.png"`
-  - `"docs/Dise\303\261o/proceso_nuevo_sin_fondo.png"`
-  - `"docs/Dise\303\261o/remera.png"`
-  - `src/__tests__/acceso-verificado.test.ts`
-
 - **18:03** `43d0fd7` — ci: agregar workflow Vitest (modo informativo)
   - `.github/workflows/test.yml`
+
+- **17:21** `cdf735b` — feat(u-06): clasificacion automatica de pedidos COMERCIAL/SUBCONTRATACION
+  - `.claude/specs/v4-u-06-clasificacion-pedidos.md`
+  - `e2e/u-06-clasificacion-pedidos.spec.ts`
+  - `prisma/migrations/20260601120000_agregar_tipo_pedido/migration.sql`
+  - `prisma/schema.prisma`
+  - `src/__tests__/u-06-clasificacion-pedidos.test.ts`
+  - `src/app/api/pedidos/route.ts`
 
 - **14:34** `5ecc879` — feat(u-07): regla anti-incesto multi-rol
   - `.claude/specs/v4-u-07-anti-incesto.md`

--- a/e2e/u-06-clasificacion-pedidos.spec.ts
+++ b/e2e/u-06-clasificacion-pedidos.spec.ts
@@ -1,0 +1,22 @@
+import { test } from '@playwright/test'
+
+// U-06 — Clasificacion automatica de pedidos (COMERCIAL / SUBCONTRATACION).
+// La cobertura REAL de la logica esta a nivel unidad en
+// src/__tests__/u-06-clasificacion-pedidos.test.ts (ambas ramas, via mock de
+// prisma). Aca solo quedan los e2e de extremo a extremo, hoy bloqueados.
+// Ver .claude/specs/v4-u-06-clasificacion-pedidos.md
+
+// El campo Pedido.tipo es invisible en UI (la vista de reporte esta diferida a
+// Etapa 2/3) y el caso SUBCONTRATACION necesita un User dual (Marca + Taller) que
+// el seed single-role actual no tiene. Por eso estos e2e quedan `fixme` hasta
+// U-08 (seed dual) + la vista de reporte que exponga el tipo.
+
+test.fixme('e2e: marca pura crea pedido -> tipo COMERCIAL visible en reporte', async () => {
+  // TODO(U-08): requiere vista de reporte (diferida) para poder leer el tipo
+  // desde la UI tras crear el pedido.
+})
+
+test.fixme('e2e: user dual crea pedido -> tipo SUBCONTRATACION visible en reporte', async () => {
+  // TODO(U-08): requiere (1) User dual en el seed y (2) vista de reporte que
+  // exponga el tipo. La logica ya esta cubierta por el test unitario.
+})

--- a/prisma/migrations/20260601120000_agregar_tipo_pedido/migration.sql
+++ b/prisma/migrations/20260601120000_agregar_tipo_pedido/migration.sql
@@ -1,0 +1,14 @@
+-- CreateEnum
+CREATE TYPE "TipoPedido" AS ENUM ('COMERCIAL', 'SUBCONTRATACION');
+
+-- AlterTable
+ALTER TABLE "pedidos" ADD COLUMN     "tipo" "TipoPedido" NOT NULL DEFAULT 'COMERCIAL';
+
+-- Backfill U-06: reclasificar como SUBCONTRATACION los pedidos cuyo dueno de
+-- marca tambien tiene taller. Idempotente. Hoy cambia 0 filas (no hay usuarios
+-- duales aun); deja la data consistente para cuando exista el fixture dual.
+UPDATE "pedidos" p
+SET "tipo" = 'SUBCONTRATACION'
+FROM "marcas" m
+JOIN "talleres" t ON t."userId" = m."userId"
+WHERE p."marcaId" = m."id";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,11 @@ enum EstadoPedido {
   CANCELADO
 }
 
+enum TipoPedido {
+  COMERCIAL
+  SUBCONTRATACION
+}
+
 enum EstadoOrdenManufactura {
   PENDIENTE
   EN_EJECUCION
@@ -447,6 +452,7 @@ model Pedido {
   fechaObjetivo DateTime?
   estado        EstadoPedido      @default(BORRADOR)
   visibilidad   VisibilidadPedido @default(PUBLICO)
+  tipo          TipoPedido        @default(COMERCIAL)
   progresoTotal Float             @default(0)
   montoTotal    Float             @default(0)
   descripcion   String?           @db.Text

--- a/src/__tests__/u-06-clasificacion-pedidos.test.ts
+++ b/src/__tests__/u-06-clasificacion-pedidos.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// U-06 — Clasificacion automatica de pedidos (COMERCIAL / SUBCONTRATACION).
+// El campo Pedido.tipo es invisible en UI, asi que el caso real se cubre a nivel
+// unidad mockeando prisma: taller.findFirst -> null = COMERCIAL; -> {id} =
+// SUBCONTRATACION. No hace falta fixture dual real para ejercitar ambas ramas.
+// Ver .claude/specs/v4-u-06-clasificacion-pedidos.md
+
+const mockAuth = vi.fn()
+vi.mock('@/compartido/lib/auth', () => ({ auth: () => mockAuth() }))
+
+const mockPrisma = {
+  marca: { findUnique: vi.fn() },
+  taller: { findFirst: vi.fn() },
+  pedido: { create: vi.fn() },
+}
+vi.mock('@/compartido/lib/prisma', () => ({ prisma: mockPrisma }))
+vi.mock('@/compartido/lib/log', () => ({ logActividad: vi.fn() }))
+vi.mock('@/compartido/lib/ratelimit', () => ({ rateLimit: vi.fn().mockResolvedValue(null) }))
+
+function makeRequest(url: string, body: unknown) {
+  return new NextRequest(new URL(url, 'http://localhost'), {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  mockPrisma.pedido.create.mockResolvedValue({ id: 'p1', omId: 'OM-2026-XXXX' })
+})
+
+describe('POST /api/pedidos — clasificacion automatica (U-06)', () => {
+  it('marca SIN taller publica -> tipo COMERCIAL', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'mu1', role: 'MARCA' } })
+    mockPrisma.marca.findUnique.mockResolvedValue({ id: 'mi1', userId: 'mu1' })
+    mockPrisma.taller.findFirst.mockResolvedValue(null) // dueño no tiene taller
+
+    const { POST } = await import('@/app/api/pedidos/route')
+    const res = await POST(makeRequest('http://localhost/api/pedidos', {
+      tipoPrenda: 'Remera', cantidad: 100,
+    }))
+
+    expect(res.status).toBe(201)
+    const createArgs = mockPrisma.pedido.create.mock.calls[0][0]
+    expect(createArgs.data.tipo).toBe('COMERCIAL')
+    // se clasifico mirando el userId del dueño de la marca
+    expect(mockPrisma.taller.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: 'mu1' } })
+    )
+  })
+
+  it('marca CON taller (usuario dual) publica -> tipo SUBCONTRATACION', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'mu1', role: 'MARCA' } })
+    mockPrisma.marca.findUnique.mockResolvedValue({ id: 'mi1', userId: 'mu1' })
+    mockPrisma.taller.findFirst.mockResolvedValue({ id: 't1' }) // dueño tambien es taller
+
+    const { POST } = await import('@/app/api/pedidos/route')
+    const res = await POST(makeRequest('http://localhost/api/pedidos', {
+      tipoPrenda: 'Buzo', cantidad: 50,
+    }))
+
+    expect(res.status).toBe(201)
+    const createArgs = mockPrisma.pedido.create.mock.calls[0][0]
+    expect(createArgs.data.tipo).toBe('SUBCONTRATACION')
+  })
+
+  it('ignora un `tipo` enviado por el cliente (clasificacion autoritativa)', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'mu1', role: 'MARCA' } })
+    mockPrisma.marca.findUnique.mockResolvedValue({ id: 'mi1', userId: 'mu1' })
+    mockPrisma.taller.findFirst.mockResolvedValue(null)
+
+    const { POST } = await import('@/app/api/pedidos/route')
+    const res = await POST(makeRequest('http://localhost/api/pedidos', {
+      tipoPrenda: 'Remera', cantidad: 100, tipo: 'SUBCONTRATACION', // intento de spoof
+    }))
+
+    expect(res.status).toBe(201)
+    const createArgs = mockPrisma.pedido.create.mock.calls[0][0]
+    // el server clasifica por el dueño, no por el body -> COMERCIAL
+    expect(createArgs.data.tipo).toBe('COMERCIAL')
+  })
+})

--- a/src/app/api/pedidos/route.ts
+++ b/src/app/api/pedidos/route.ts
@@ -81,26 +81,47 @@ export const POST = apiHandler(async (req: NextRequest) => {
   }
 
   let resolvedMarcaId = ''
+  let ownerUserId = ''
   if (role === 'MARCA') {
     const marca = await prisma.marca.findUnique({
       where: { userId: session.user.id },
-      select: { id: true },
+      select: { id: true, userId: true },
     })
     if (!marca) return errorNotFound('marca')
     resolvedMarcaId = marca.id
+    ownerUserId = marca.userId
   } else if (role === 'ADMIN') {
+    // Rama no usada en produccion (admin no publica via API; manipula por Prisma
+    // Studio). Clasificacion defensiva. Limpieza de la rama pendiente en PR de
+    // housekeeping aparte. Ver spec v4-u-06.
     if (!body.marcaId) {
       return errorResponse({ code: 'INVALID_INPUT', message: 'marcaId requerido', status: 400 })
     }
-    resolvedMarcaId = body.marcaId
+    const marcaTarget = await prisma.marca.findUnique({
+      where: { id: body.marcaId },
+      select: { id: true, userId: true },
+    })
+    if (!marcaTarget) return errorNotFound('marca')
+    resolvedMarcaId = marcaTarget.id
+    ownerUserId = marcaTarget.userId
   } else {
     return errorForbidden()
   }
+
+  // U-06: clasificacion automatica del pedido (bloque multi-rol). Si el dueno del
+  // pedido tambien tiene un Taller -> SUBCONTRATACION; si solo tiene Marca ->
+  // COMERCIAL. Invisible al cliente y autoritativa: no se acepta `tipo` del body.
+  const ownerTaller = await prisma.taller.findFirst({
+    where: { userId: ownerUserId },
+    select: { id: true },
+  })
+  const tipo = ownerTaller ? 'SUBCONTRATACION' : 'COMERCIAL'
 
   const pedido = await prisma.pedido.create({
     data: {
       omId: body.omId || generateOmId(),
       marcaId: resolvedMarcaId,
+      tipo,
       tipoPrenda: body.tipoPrenda,
       cantidad: Math.round(cantidad),
       fechaObjetivo: body.fechaObjetivo ? new Date(body.fechaObjetivo) : undefined,


### PR DESCRIPTION
## U-06 — Clasificación automática de pedidos (bloque multi-rol)

Agrega el campo `Pedido.tipo` (enum `TipoPedido { COMERCIAL, SUBCONTRATACION }`), clasificado **automática e invisiblemente** al crear el pedido en `POST /api/pedidos`:

- el dueño del pedido también tiene **Taller** → `SUBCONTRATACION`
- el dueño solo tiene **Marca** → `COMERCIAL`

Server-side y autoritativo: no se acepta `tipo` desde el body.

### Alcance
**Solo el campo** (clasificación + backfill). La **vista de reporte queda diferida** a Etapa 2/3, donde la narrativa defina quién la consume (COORD/POLÍTICO).

### Decisiones
- **Migración aditiva** `agregar_tipo_pedido`: enum + columna con `@default(COMERCIAL)` (cubre pedidos existentes). Incluye **backfill idempotente** que reclasifica como SUBCONTRATACION los pedidos de dueños con taller — **0 filas hoy** (no hay usuarios duales aún).
- **Rama ADMIN** del endpoint: clasifica **defensivamente** pero es un camino no usado vía API (admin manipula por Prisma Studio). Su limpieza queda para un **PR de housekeeping aparte**, no se mezcla acá.

### Tests
- **Unit (Vitest, activos):** ambas ramas vía mock de prisma — `COMERCIAL` (dueño sin taller), `SUBCONTRATACION` (dueño dual) y `tipo` del body ignorado.
- **e2e (test.fixme, TODO U-08):** los de extremo a extremo necesitan seed dual + la vista de reporte (diferida) para poder leer el tipo desde la UI.

Refs: `.claude/specs/v4-u-06-clasificacion-pedidos.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)