### PR TITLE
chore: eliminar rama ADMIN muerta en POST /api/pedidos

### DIFF
--- a/.claude/specs/handover/DECISIONS.md
+++ b/.claude/specs/handover/DECISIONS.md
@@ -292,6 +292,24 @@ Este documento registra las decisiones importantes tomadas durante el proyecto, 
 - **Implicancias:** Integración via SDK, RPC en Supabase para búsqueda vectorial
 - **Estado:** Vigente
 
+### 26. Eliminar la rama ADMIN muerta en `POST /api/pedidos`
+
+- **Fecha:** 2026-06
+- **Categoría:** Técnica (seguridad / limpieza)
+- **Contexto:** El handler `POST /api/pedidos` tenía una rama `role === 'ADMIN'` que permitía, vía API, publicar un pedido en nombre de cualquier marca tomando `body.marcaId` — **sin ninguna validación de permiso**. Era una puerta de escritura sin control.
+- **Origen del código:** `git blame`/`git log -S` → commit `a710bde` (17 feb 2026, "filtros directorio, pedidos marca…"). Nació por **simetría con el handler GET** (que sí distingue ADMIN para filtrar por `marcaId`), no por un requerimiento de producto.
+- **Evidencia de código muerto:** sin UI que la invoque, sin tests, sin cliente. El único `POST` real a `/api/pedidos` es el form de la marca, que resuelve `marcaId` desde la sesión y ni siquiera manda `body.marcaId`. El diseño (`semana2-schema-e2.md`, `publicacion-pedidos-ui.md`) canaliza la acción admin sobre pedidos por **Prisma Studio**, no por endpoint.
+- **Alternativas consideradas:**
+  - A) Dejarla y agregarle validación de permiso (construir una función que el producto no pide)
+  - B) Eliminarla — solo rol MARCA crea pedidos vía API; el resto recibe 403
+- **Decisión tomada:** B
+- **Razonamiento:** era una superficie de escritura sin validación (riesgo de seguridad latente) para una función que el diseño no contempla. Mantenerla obliga a custodiarla; eliminarla cierra la puerta. Si en el futuro se necesita que admin cree pedidos vía API, se agrega con validación de permiso explícita y su propio test.
+- **Implicancias:**
+  - `POST /api/pedidos`: solo `role === 'MARCA'` crea; cualquier otro rol → `errorForbidden()` (403).
+  - La clasificación automática U-06 (COMERCIAL/SUBCONTRATACION) vive después del bloque de resolución de marca, sobre `ownerUserId`, así que la rama MARCA (camino real) la conserva intacta. La clasificación "defensiva" que U-06 había puesto dentro de la rama ADMIN se va con la rama (correcto: era para un camino muerto).
+  - Se simplificó `estado: role === 'ADMIN' ? body.estado : 'BORRADOR'` → `estado: 'BORRADOR'` (ADMIN ya no llega a crear).
+- **Estado:** Vigente
+
 ---
 
 ## Decisiones Institucionales

--- a/src/app/api/pedidos/route.ts
+++ b/src/app/api/pedidos/route.ts
@@ -90,21 +90,9 @@ export const POST = apiHandler(async (req: NextRequest) => {
     if (!marca) return errorNotFound('marca')
     resolvedMarcaId = marca.id
     ownerUserId = marca.userId
-  } else if (role === 'ADMIN') {
-    // Rama no usada en produccion (admin no publica via API; manipula por Prisma
-    // Studio). Clasificacion defensiva. Limpieza de la rama pendiente en PR de
-    // housekeeping aparte. Ver spec v4-u-06.
-    if (!body.marcaId) {
-      return errorResponse({ code: 'INVALID_INPUT', message: 'marcaId requerido', status: 400 })
-    }
-    const marcaTarget = await prisma.marca.findUnique({
-      where: { id: body.marcaId },
-      select: { id: true, userId: true },
-    })
-    if (!marcaTarget) return errorNotFound('marca')
-    resolvedMarcaId = marcaTarget.id
-    ownerUserId = marcaTarget.userId
   } else {
+    // Solo rol MARCA crea pedidos via API. La accion admin sobre pedidos se
+    // canaliza por Prisma Studio, no por endpoint (ver DECISIONS.md).
     return errorForbidden()
   }
 
@@ -125,7 +113,7 @@ export const POST = apiHandler(async (req: NextRequest) => {
       tipoPrenda: body.tipoPrenda,
       cantidad: Math.round(cantidad),
       fechaObjetivo: body.fechaObjetivo ? new Date(body.fechaObjetivo) : undefined,
-      estado: role === 'ADMIN' ? body.estado : 'BORRADOR',
+      estado: 'BORRADOR',
       montoTotal: Number.isFinite(montoTotal) && montoTotal >= 0 ? montoTotal : 0,
       descripcion: typeof body.descripcion === 'string' ? body.descripcion.trim() || null : undefined,
       imagenes: Array.isArray(body.imagenes) ? body.imagenes.filter((u: unknown) => typeof u === 'string') : undefined,


### PR DESCRIPTION
Codigo muerto (git blame a710bde, nacio por simetria con el handler GET). Sin UI, sin tests, sin cliente. Solo rol MARCA crea pedidos via API; cualquier otro rol recibe 403. La clasificacion U-06 de la rama MARCA queda intacta. Documentado en `.claude/specs/handover/DECISIONS.md` (decision #26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)