### PR TITLE
chore: gitignore imagenes throwaway/mal ubicadas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,10 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+
+# Imagenes mal ubicadas en specs (un spec nunca es una imagen)
+.claude/specs/*.png
+.claude/specs/*.webp
+
+# Iteraciones throwaway de generacion de imagenes (no son assets finales)
+docs/Diseño/ChatGPT Image*.png

--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,12 @@
 # Daily Log
 
+## 2026-06-02
+
+### Gerardo Breard
+- **16:53** `c5dfe4e` — chore: gitignore para imagenes throwaway y mal ubicadas
+  - `.gitignore`
+
+
 ## 2026-06-01
 
 ### Gerardo Breard


### PR DESCRIPTION
Corta el ruido del git add -A. Solo imagenes basura; specs y assets de marca NO se tocan aca.