### PR TITLE
chore: gitignore fuentes de diseno de marca

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,12 @@ node_modules/
 
 # Iteraciones throwaway de generacion de imagenes (no son assets finales)
 docs/Diseño/ChatGPT Image*.png
+
+# Fuentes de diseño de marca (no usadas por el código; las versiones
+# servidas viven en public/ y las prendas en Supabase Storage)
+docs/Diseño/PDT_logo_sin_fondo.png
+docs/Diseño/logo_PDT.png
+docs/Diseño/proceso_nuevo_sin_fondo.png
+docs/Diseño/buzo.png
+docs/Diseño/camisa.png
+docs/Diseño/remera.png

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-06-02
 
 ### Gerardo Breard
+- **18:00** `f2485b5` — chore: gitignore para fuentes de diseno de marca
+  - `.gitignore`
+
 - **17:18** `3a437c9` — chore: trackear specs vigentes del bloque X y K
   - `.claude/specs/07-spec-mejoras-landing-FINAL.md`
   - `.claude/specs/k-01-rls-supabase.md`


### PR DESCRIPTION
Ultimo frente del housekeeping. Los 6 PNG fuente no se usan en codigo (servidos desde public/ y Supabase). Working tree queda limpio.