### PR TITLE
feat: U-03 PR1 - sesion multi-rol + helper + middleware/layouts

### DIFF
--- a/.claude/specs/v4-u-03-auth-multirol.md
+++ b/.claude/specs/v4-u-03-auth-multirol.md
@@ -259,6 +259,89 @@ El discovery global estimó **8h**. Con la superficie medida (58 API files con g
 
 ---
 
+## PR2 — Plan de burn-down (API)
+
+> Resultado del discovery del burn-down (post-PR1). **No migra código** — es el plan a ejecutar cuando PR1 (#391) tenga OK de QA de Sergio.
+
+### Inventario
+
+| | Archivos |
+|--|--|
+| Gatean `role` inline (cualquier forma) | **52** |
+| − falso positivo (`body.role`, no sesión) | −1 (`auth/registro/route.ts`) |
+| − ya migrado al helper | −1 (`talleres/route.ts`) |
+| **A migrar (neto)** | **~50** |
+| Ya usan `requiereRolApi` (no tocar) | 8 |
+
+> El conteo "literal" (`session.user.role`) da solo 15, pero **subestima**: el patrón dominante es `const role = (session.user as { role?: string }).role` y después `if (role !== 'ADMIN')`. La comparación cae en una variable, no en `session.user.role` literal. El conteo bueno es **52** (coincide con el "~58" de la sección 2).
+
+### Patrones de gating
+
+| Patrón | ~Cantidad | Migración |
+|--|--|--|
+| **A — admin-only** (`role !== 'ADMIN'`) | ~41 refs | Mecánico |
+| **B — lista** (`['ADMIN','ESTADO'].includes(role)`) | 7 | Mecánico (cambia el array) |
+| **C — ownership-or-rol** | 2 (`observaciones/[id]`, `validaciones/[id]`) | Ojo individual |
+| **D — role dirige lógica** (no solo gatea) | 2 (`validaciones/[id]` ramifica en `role === 'ESTADO'`; `registro` usa `body.role` → **no migrar**) | Ojo individual |
+
+**~48 son reemplazo mecánico idéntico; ~2-4 necesitan ojo individual.**
+
+### Patrón de migración mecánico (A y B)
+
+```ts
+const sesion = await requiereRolApi(['ADMIN'])        // o ['ADMIN', 'ESTADO']
+if (sesion instanceof NextResponse) return sesion
+// sesion.userId / sesion.role disponibles
+```
+
+En **C/D**, el gate se migra igual, pero el `role` que se reusa abajo (branching/ownership) se obtiene con `modoActivo(session.user)` (= modo actuante, respeta el invariante `role == activeMode`).
+
+### ⚠️ Cambio de comportamiento
+
+Los admin-only que hoy devuelven **401** para un usuario logueado-pero-sin-rol pasarán a **403** con el helper (el **401** queda solo para sin-sesión). Es lo correcto, pero **hay que actualizar los tests que asserteen 401** en ese caso.
+
+### Riesgo `roles[]` derivado — SEGURO
+
+`requiereRolApi` lee la **sesión** (`auth()` → `tieneAlgunRol(session.user, …)`), donde `roles[]` ya viene normalizado por el callback `jwt`. **Nunca** toca la DB cruda. Grep confirmado: ningún endpoint selecciona `user.roles`/`activeMode` de Prisma para gatear.
+
+**Regla del burn-down: siempre el helper (lee la sesión), nunca leer `roles` de la DB** (leería el array vacío y rompería el gating).
+
+### Orden de migración (por carpeta, de menos a más riesgo)
+
+1. `admin/*` admin-only puro (config, stats, marcas, usuarios, usuarios/[id])
+2. `admin/*` lista ADMIN/ESTADO (notas-seguimiento, observaciones, reportes, onboarding, usuarios-buscar)
+3. Resto por área (colecciones, pedidos, cotizaciones, auditorías, certificados, procesos, tipos-documento, contenido, validaciones lista)
+4. **Último, con ojo:** `observaciones/[id]`, `validaciones/[id]` (ownership/branching)
+5. **Excluir:** `auth/registro/*` (es `body.role`, input, no sesión)
+
+### Estructura — 2 sub-PRs
+
+- **PR2a** — los ~48 mecánicos (A+B). Diff grande pero homogéneo.
+- **PR2b** — los ~4 ownership/branching + limpieza de los 46 casts `as { role }`.
+
+### Verificación de cobertura final
+
+```bash
+grep -rE "session\.user.*role|as \{[^}]*role" src/app/api
+```
+Debe dar **0** fuera del helper.
+
+### Tests
+
+Matriz rol×endpoint representativa (1 por patrón): ADMIN-only rechaza TALLER con 403; lista ADMIN/ESTADO acepta ambos y rechaza MARCA; ownership acepta owner sin rol; multi-rol `[TALLER, MARCA]` entra a endpoint MARCA. **Reusar el harness de `src/__tests__/roles-multirol.test.ts`.**
+
+### Estimación
+
+| Bloque | Estimación |
+|--|--|
+| ~48 mecánicos (PR2a) | 3–4 h |
+| ~4 ownership/branching + casts (PR2b) | 2–3 h |
+| Tests matriz | 1.5 h |
+| QA + ajuste de asserts 401→403 | 1 h |
+| **Total burn-down** | **~7–9 h** |
+
+---
+
 ## 11. Metadata
 
 ```

--- a/.claude/specs/v4-u-03-auth-multirol.md
+++ b/.claude/specs/v4-u-03-auth-multirol.md
@@ -1,0 +1,274 @@
+# SPEC V4 — U-03: Refactor de auth y sesiones para multi-rol
+
+> **Estado:** PENDIENTE de implementación
+> **Rama:** `feature/u-03-auth-multirol`
+> **Depende de:** U-02 (schema multi-rol, MERGEADO — `User.roles[]` + `User.activeMode` existen y están backfilleados)
+> **Habilita:** U-04 (toggle de modo en UI), U-08 (tests e2e multi-rol)
+> **Decisiones aplicadas:** D1 (Opción A: array `roles[]` + `activeMode`), D8 (helper uniforme `requiereRol`/`requiereRolApi`)
+
+---
+
+## 0. Pre-flight checks (BLOQUEANTE)
+
+Antes de tocar código, Sergio debe correr estos comandos y confirmar que los números coinciden con la "Superficie real" (sección 2). Si difieren mucho, parar y avisar a Gerardo — significa que la base cambió desde que se escribió el spec.
+
+```bash
+# Entorno
+git checkout feature/u-03-auth-multirol
+git rev-parse --short HEAD   # debe partir de develop f3375d5 o posterior
+
+# Confirmar que el schema YA tiene las columnas (no se tocan en U-03)
+grep -n "roles\s*UserRole\|activeMode" prisma/schema.prisma
+
+# Superficie de lectura de rol
+grep -rn "session\.user\.role\|user\.role\b" src/ --include="*.ts" --include="*.tsx" | wc -l   # ~34
+grep -rln "await auth()" src/app/api | wc -l        # ~63 archivos
+grep -rln "requiereRolApi" src/app/api | wc -l      # ~8 (adopción actual)
+grep -rln "requiereRol" src/app --include="*.tsx" | wc -l   # ~4 pages
+```
+
+### 0.1 Output bloqueante del pre-flight
+- [ ] Las columnas `roles` y `activeMode` existen en `prisma/schema.prisma` (U-02 mergeado)
+- [ ] Los conteos de superficie están dentro del ±15% de la sección 2
+- [ ] `npm run build` pasa en verde ANTES de empezar (línea base sana)
+- [ ] La suite e2e pasa en verde ANTES de empezar (línea base sana)
+
+---
+
+## 1. Contexto
+
+### El problema
+U-02 agregó `User.roles UserRole[]` y `User.activeMode UserRole?` al schema y los backfilleó (`roles = [role]`, `activeMode = role`). Pero **son columnas huérfanas**: hoy ningún gate las lee. TODO el control de acceso sigue gateando por el escalar `User.role`:
+
+- La sesión (JWT + callbacks) solo carga y expone `role`.
+- El middleware decide por `req.auth.user.role`.
+- Los 6 layouts redirigen por `session.user.role`.
+- ~58 de 83 API routes chequean `session.user.role` (mayoría inline, no por helper).
+
+Mientras el código gatee por `role`, un usuario con `roles = [TALLER, MARCA]` solo puede actuar como su `role` escalar. Multi-rol no funciona aunque el dato exista.
+
+### Objetivo de U-03
+Que **la sesión exponga `roles[]` + `activeMode`** y que **todos los gates migren a usarlos**, manteniendo `role` en sync para back-compat mientras dura la migración. No se construye UI de cambio de modo (eso es U-04).
+
+### Decisiones aplicadas
+| Dec | Qué | Implicancia en U-03 |
+|-----|-----|---------------------|
+| D1 | Opción A: `roles[]` + `activeMode` | La sesión carga ambos; el gate de "área permitida" usa `roles[]`, el de "modo actual" usa `activeMode` |
+| D8 | Helper uniforme `requiereRol`/`requiereRolApi` | El helper YA existe en `src/compartido/lib/permisos.ts` pero (a) lee solo `role` escalar y (b) está poco adoptado. U-03 lo extiende y lo adopta en toda la superficie |
+
+### Riesgo clave declarado
+**"Media migración"** — un endpoint olvidado que siga gateando por `role` con un valor stale = agujero de permisos. La estrategia (sección 3) lo neutraliza manteniendo `role` sincronizado con `activeMode`, de modo que ningún gate sin migrar se rompe ni se abre.
+
+---
+
+## 2. Superficie real (medida, no estimada)
+
+Medido sobre `feature/u-03-auth-multirol` (base develop `f3375d5`):
+
+| Superficie | Conteo | Detalle |
+|-----------|--------|---------|
+| Lecturas de `session.user.role` / `user.role` | **34** | Across `.ts` + `.tsx` |
+| API route files totales | **83** | `src/app/api/**/route.ts` |
+| API route files que mencionan `role` | **58** | Superficie de gating en API |
+| API routes con `await auth()` directo | **63** | Obtienen sesión sin helper |
+| API routes usando `requiereRolApi` (helper) | **8** | Adopción actual del helper |
+| Chequeos inline en API: `includes(...role...)` | **11** | |
+| Chequeos inline en API: `role ===` / `role !==` | **17** | |
+| Layouts con gate de rol | **6** | `(admin)`, `(contenido)`, `(estado)`, `(marca)`, `(public)`, `(taller)` |
+| Pages usando `requiereRol` (helper) | **4** | Las 4 de `(estado)` |
+| Type assertions `as { role }` / `user as` | **88** | Casts defensivos redundantes (la `d.ts` ya tipa `role`) |
+| Usos de `activeMode` en código | **0** | Columna huérfana |
+| Usos de `.roles` (array) en código | **1** | Columna huérfana |
+
+**Archivos núcleo del refactor (capa de sesión):**
+- `src/compartido/lib/auth.ts` — `authorize()` arma el objeto user (línea ~48: retorna `role`, falta `roles`/`activeMode`)
+- `src/compartido/lib/auth.config.ts` — callbacks `jwt` y `session` (cargan/exponen solo `role`)
+- `src/compartido/types/next-auth.d.ts` — tipos de `User`, `Session.user`, `JWT` (solo `role`)
+- `src/compartido/lib/permisos.ts` — helpers `requiereRol` (server comp) + `requiereRolApi` (API)
+- `src/middleware.ts` — gate por prefijo de ruta + redirect de home por rol
+
+---
+
+## 3. Qué construir — estrategia incremental (sin big-bang)
+
+El backfill de U-02 (`activeMode = role`, `roles = [role]`) es lo que permite migrar incremental: en todo momento `role`, `activeMode` y `roles[]` son **consistentes**, así que se puede cambiar la capa de sesión y migrar gates uno por uno sin ventana de inconsistencia.
+
+### Invariante de back-compat (la clave anti-agujero)
+> Mientras dure la migración, **`token.role` y `session.user.role` SIEMPRE reflejan `activeMode`** (que en U-03 == `role` de DB, porque no hay toggle todavía). Cualquier gate NO migrado que lea `session.user.role` sigue viendo el valor correcto. Ningún gate sin migrar se rompe ni se abre.
+
+### Paso 3a — La sesión expone `roles[]` + `activeMode` (capa de sesión)
+Cambio **aditivo**: se agregan campos, no se quita `role`.
+
+1. **`auth.ts` `authorize()`** — al retornar el user, agregar `roles: user.roles` y `activeMode: user.activeMode ?? user.role`. Mantener `role` (= `activeMode`) para back-compat.
+2. **`auth.config.ts` callback `jwt`** — al crear el token (`if (user)`), copiar `token.roles = user.roles` y `token.activeMode = user.activeMode ?? user.role`. Setear `token.role = token.activeMode` (sync invariante).
+3. **`auth.config.ts` callback `session`** — exponer `session.user.roles` y `session.user.activeMode`; mantener `session.user.role = token.activeMode`.
+4. **`next-auth.d.ts`** — agregar `roles?: UserRole[]` y `activeMode?: UserRole` a `User`, `Session.user` y `JWT`. Mantener `role`.
+
+> Importante: estos callbacks corren en Edge (middleware los usa vía `auth.config.ts`). No agregar imports de Prisma/Node acá. Los datos vienen del `user` que ya armó `authorize()` en `auth.ts`.
+
+### Paso 3b — Extender el helper de permisos
+En `src/compartido/lib/permisos.ts`, extender `requiereRol` y `requiereRolApi` para que la decisión de acceso use `roles[]` (membresía) en vez del escalar `role`, con `activeMode` como el "modo actuante":
+
+- Semántica de acceso a un área (`requiereRol(['ESTADO','ADMIN'])`):
+  pasa si **`roles[]` intersecta** con los roles permitidos. (Un usuario MARCA+TALLER puede entrar a `/taller` y `/marca`.)
+- ADMIN mantiene su bypass donde hoy lo tiene.
+- Fallback: si `roles[]` viene vacío/undefined (sesión vieja en tránsito), usar `[activeMode ?? role]`. Garantiza que sesiones emitidas antes del deploy no queden bloqueadas.
+- Agregar helpers de lectura reutilizables (sin redirect) para usar en componentes y branches:
+  - `tieneAlgunRol(session, roles[]): boolean`
+  - `modoActivo(session): UserRole` (= `activeMode ?? role`)
+
+> No se cambia la firma pública de `requiereRol`/`requiereRolApi` (siguen recibiendo `RolPermitido[]`). Solo cambia su lógica interna y se amplía `RolPermitido` si hace falta.
+
+### Paso 3c — Migrar los gates al helper (burn-down mecánico)
+Orden de migración (de menos a más riesgo, cada uno verificable por separado):
+
+1. **Middleware** (`src/middleware.ts`) — reemplazar `userRole === 'X'` por chequeo de membresía contra `roles[]`, y el `switch` de redirect de home por `activeMode`. Es el gate más amplio; migrarlo primero da cobertura base.
+2. **6 layouts** — reemplazar el bloque inline `if (session.user.role !== 'X') redirect('/unauthorized')` por `await requiereRol([...])`. `(public)` es lectura (no redirect), adaptarlo a `modoActivo()`.
+3. **API routes** — reemplazar los ~28 chequeos inline (`includes(session.user.role)`, `role ===/!==`) por `requiereRolApi([...])`. Ir directorio por directorio (`/api/admin`, `/api/taller`, ...) y dejar el grep en 0.
+4. **Lecturas restantes** (componentes server, branches de UI) — pasar de `session.user.role` a `modoActivo(session)` donde representen "el modo en que actúa el usuario".
+
+### Cómo se evita la "media migración" (agujero de permisos)
+1. **Invariante de sync** (3a): `role` siempre == `activeMode`. Un gate sin migrar nunca ve un valor stale ni se abre. Esto convierte la migración en *segura por construcción*, no por completitud.
+2. **Grep como burn-down con criterio de cierre**: el PR no se mergea hasta que
+   ```bash
+   grep -rn "session\.user\.role\|user\.role\b" src/app --include="*.ts" --include="*.tsx" | grep -v "permisos.ts"
+   ```
+   devuelva **0** fuera de `permisos.ts` (única excepción permitida: el propio helper y el sync en callbacks).
+3. **Lint rule (opcional, recomendado)**: regla `no-restricted-syntax` que prohíba `session.user.role` fuera de `permisos.ts` y los callbacks de auth. Hace imposible reintroducir el patrón viejo.
+4. **Tests de gating** (sección 7): un test parametrizado que recorre cada prefijo de ruta protegida con cada rol y verifica 200/403 esperado. Detecta el endpoint olvidado.
+
+---
+
+## 4. Qué entra en U-03 vs qué queda para U-04 / U-08
+
+| Item | U-03 | U-04 | U-08 |
+|------|:----:|:----:|:----:|
+| Sesión expone `roles[]` + `activeMode` | ✅ | | |
+| Helper `requiereRol`/`requiereRolApi` lee `roles[]`/`activeMode` | ✅ | | |
+| Migrar middleware + 6 layouts + ~58 API a helper | ✅ | | |
+| Back-compat `role` == `activeMode` en sync | ✅ | | |
+| Tests unit de los helpers + test de matriz de gating | ✅ | | |
+| **UI de toggle de modo** (botón "actuar como…") | | ✅ | |
+| **Endpoint PATCH** que persiste `activeMode` en DB + re-emite sesión | | ✅ | |
+| Redirect al dashboard del nuevo modo tras el toggle | | ✅ | |
+| **Matriz e2e completa** de usuarios multi-rol (login → switch → acceso) | | | ✅ |
+
+> U-03 deja `activeMode` igual a `role` siempre (no hay forma de cambiarlo todavía). El valor de U-03 es: la *infraestructura* de permisos lee los campos correctos, así que cuando U-04 agregue el toggle, NADA de gating hay que tocar.
+
+---
+
+## 5. Casos borde
+
+| # | Caso | Comportamiento esperado |
+|---|------|------------------------|
+| 1 | Usuario single-role (la mayoría) | `roles = [role]`, `activeMode = role`. Todo idéntico a hoy. |
+| 2 | Usuario sin `activeMode` (NULL inesperado) | Helper usa fallback `activeMode ?? role`. Nunca bloquea por NULL. |
+| 3 | Usuario con `roles = []` (vacío) | Fallback a `[activeMode ?? role]`. No queda sin acceso a su propia área. |
+| 4 | ADMIN | Mantiene bypass donde hoy lo tiene (middleware `/admin`, helpers). Verificar que no se pierde. |
+| 5 | CONTENIDO en `/admin/evaluaciones` | Caso especial actual del middleware: preservarlo explícitamente al migrar. |
+| 6 | Sesión vieja emitida antes del deploy (sin `roles`/`activeMode` en JWT) | Fallback: el helper usa `[role]` del token viejo. No se fuerza re-login. |
+| 7 | ESTADO accede a área TALLER | Solo pasa si `TALLER ∈ roles[]`. Si no, `/unauthorized` (igual que hoy). |
+| 8 | Multi-rol real (`roles=[TALLER,MARCA]`) accediendo a `/marca` mientras `activeMode=TALLER` | En U-03: **pasa** (membresía en `roles[]`). El "modo activo" recién se usa para defaults de navegación; el acceso es por membresía. (Refinar en U-04 si se decide gatear por modo.) |
+
+> **Decisión a confirmar con Gerardo (caso 8):** ¿el acceso a un área se gatea por *membresía en `roles[]`* (un multi-rol entra a todas sus áreas siempre) o por *`activeMode`* (solo entra al área del modo activo, debe togglear primero)? El spec asume **membresía** para U-03 (más simple, no rompe nada). Si se prefiere gating-por-modo, es trivial cambiarlo en el helper, pero requiere el toggle de U-04 para ser usable.
+
+---
+
+## 6. Prescripciones técnicas
+
+- **NO tocar `prisma/schema.prisma`** — las columnas ya existen (U-02). Si hace falta un cambio de schema, parar y avisar a Gerardo.
+- **NO correr migraciones** — U-03 es solo código de aplicación. (GUARD: Prisma CLI local roto / `.env` apunta a prod.)
+- Capa de sesión: editar **solo** `auth.ts`, `auth.config.ts`, `next-auth.d.ts`. Los callbacks de `auth.config.ts` corren en Edge → **sin imports de Prisma/Node**.
+- Helper: toda la lógica nueva de permisos vive en `src/compartido/lib/permisos.ts`. No duplicar lógica de rol en otros archivos.
+- Patrón de API: server route → `const guard = await requiereRolApi([...]); if (guard instanceof NextResponse) return guard;` y usar `guard.userId` / `guard.role`. (Patrón ya existente, solo ampliar adopción.)
+- Patrón de page/layout: `const session = await requiereRol([...])`.
+- Eliminar los casts redundantes `(session.user as { role?: string })` a medida que se migra cada archivo (la `d.ts` ya tipa los campos). No es obligatorio para los 88, pero sí en los archivos que se tocan.
+- Errores: mantener el formato de `requiereRolApi` (401 sin sesión, 403 `INSUFFICIENT_ROLE` con `rolesRequeridos`). No inventar formatos nuevos.
+
+---
+
+## 7. Plan de testing
+
+### Unit (Vitest)
+- `permisos.test.ts`:
+  - `requiereRolApi` retorna 401 sin sesión, 403 si `roles[]` no intersecta, OK si intersecta.
+  - Fallback: `roles=[]` → usa `[activeMode ?? role]`.
+  - ADMIN bypass donde corresponda.
+  - `modoActivo()` y `tieneAlgunRol()` con single-role, multi-rol, NULL.
+
+### Matriz de gating (el anti-"media-migración")
+- Test parametrizado: para cada prefijo protegido (`/admin`, `/taller`, `/marca`, `/estado`, `/contenido`) × cada rol, afirmar acceso/redirect esperado. Cubre middleware + layouts.
+- Para API: un test que recorre una lista de endpoints representativos por área y verifica 403 con rol ajeno, 200 con rol propio.
+
+### e2e (Playwright, corre en CI)
+- Login single-role de cada tipo → llega a su dashboard (no regresión).
+- Usuario seed multi-rol (si existe; si no, crear uno en el fixture) → puede cargar `/taller` y `/marca` con `roles=[TALLER,MARCA]`.
+- Sesión vieja simulada (token sin `roles`) → fallback no bloquea.
+
+> La matriz e2e *completa* de multi-rol (con toggle) es U-08. Acá solo el subconjunto que prueba que el gating por `roles[]` no rompió nada.
+
+---
+
+## 8. Criterios de aceptación
+
+- [ ] La sesión expone `session.user.roles` (array) y `session.user.activeMode`, tipados en `next-auth.d.ts`.
+- [ ] `session.user.role` sigue presente y == `activeMode` (back-compat).
+- [ ] `requiereRol`/`requiereRolApi` deciden por membresía en `roles[]` con fallback a `[activeMode ?? role]`.
+- [ ] Middleware migrado a `roles[]`/`activeMode` (incluido el caso CONTENIDO→evaluaciones y el redirect de home).
+- [ ] Los 6 layouts usan el helper (no chequeo inline de `role`).
+- [ ] `grep -rn "session\.user\.role\|user\.role\b" src/app` devuelve 0 fuera de `permisos.ts`.
+- [ ] Casts redundantes `as { role }` eliminados en todo archivo tocado.
+- [ ] `npm run build` verde.
+- [ ] Suite unit + e2e verde en CI.
+- [ ] Un usuario single-role se comporta exactamente igual que antes (sin regresión).
+- [ ] (Opcional) lint rule que prohíbe `session.user.role` fuera del helper.
+
+---
+
+## 9. Riesgos + rollback
+
+| Riesgo | Mitigación | Rollback |
+|--------|-----------|----------|
+| "Media migración" deja un agujero | Invariante `role`==`activeMode` (3a) hace que ningún gate sin migrar se abra; grep+lint+matriz cierran completitud | Revertir el PR; los gates sin migrar siguen funcionando por `role` |
+| Callback de Edge importa algo de Node y rompe el middleware | Regla estricta: los callbacks no importan Prisma/Node; los datos vienen de `authorize()` | Revertir `auth.config.ts` |
+| Sesiones vivas viejas (sin `roles` en JWT) quedan bloqueadas | Fallback a `[role]` del token viejo; `maxAge` 7d rota solo | Hotfix en el fallback del helper |
+| Cambio de semántica de acceso (caso 8) altera comportamiento esperado | Default = membresía (no rompe nada); decisión confirmada con Gerardo antes de implementar | Cambiar una condición en el helper |
+| Regresión silenciosa en un área | Matriz de gating parametrizada en CI | — |
+
+Rollback global: el PR es 100% código de aplicación (sin migración), así que `git revert` del merge restaura el estado anterior sin tocar datos.
+
+---
+
+## 10. Estimación realista
+
+El discovery global estimó **8h**. Con la superficie medida (58 API files con gating, 6 layouts, middleware, 34 lecturas, 88 casts):
+
+| Bloque | Estimación |
+|--------|-----------|
+| 3a — capa de sesión (auth.ts + config + d.ts) | 1.5 h |
+| 3b — extender helper + helpers de lectura + unit tests | 1.5 h |
+| 3c.1 — middleware | 1 h |
+| 3c.2 — 6 layouts | 1 h |
+| 3c.3 — ~58 API routes (burn-down dir por dir) | 4–5 h |
+| 3c.4 — lecturas restantes + limpieza de casts | 1.5 h |
+| Matriz de gating + e2e | 2 h |
+| Build, CI, fixes | 1 h |
+| **Total** | **~13–14 h (≈ 2 días)** |
+
+**Las 8h del discovery global subestiman.** El grueso es el burn-down de ~58 API routes, que es mecánico pero voluminoso y debe quedar en grep 0. Recomendación: dividir en 2 PRs si se quiere mergear incremental — PR1 = capa de sesión + helper + middleware + layouts (la parte que habilita multi-rol y es segura por el invariante), PR2 = burn-down de API + limpieza. Ambos preservan back-compat.
+
+---
+
+## 11. Metadata
+
+```
+Spec: U-03 — Refactor auth y sesiones multi-rol
+Bloque: U (multi-rol Airbnb)
+Depende de: U-02 (mergeado)
+Habilita: U-04, U-08
+Decisiones: D1, D8
+Archivos núcleo: auth.ts, auth.config.ts, next-auth.d.ts, permisos.ts, middleware.ts
+Schema: NO se toca (columnas ya existen)
+Migraciones: NINGUNA
+Estimación: ~13–14h (2 días)
+```

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-06-03
 
 ### Gerardo Breard
+- **21:58** `65c1263` — merge: develop en feature/u-03-auth-multirol (resuelve DAILY.md)
+
+
 - **15:16** `413a0e7` — feat(u-03): PR1 sesion multi-rol + helper por membresia + middleware/layouts
   - `.claude/specs/v4-u-03-auth-multirol.md`
   - `src/__tests__/roles-multirol.test.ts`

--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,25 @@
 # Daily Log
 
+## 2026-06-03
+
+### Gerardo Breard
+- **15:16** `413a0e7` — feat(u-03): PR1 sesion multi-rol + helper por membresia + middleware/layouts
+  - `.claude/specs/v4-u-03-auth-multirol.md`
+  - `src/__tests__/roles-multirol.test.ts`
+  - `src/app/(admin)/layout.tsx`
+  - `src/app/(contenido)/layout.tsx`
+  - `src/app/(estado)/layout.tsx`
+  - `src/app/(marca)/layout.tsx`
+  - `src/app/(public)/layout.tsx`
+  - `src/app/(taller)/layout.tsx`
+  - `src/compartido/lib/auth.config.ts`
+  - `src/compartido/lib/auth.ts`
+  - `src/compartido/lib/permisos.ts`
+  - `src/compartido/lib/roles.ts`
+  - `src/compartido/types/next-auth.d.ts`
+  - `src/middleware.ts`
+
+
 ## 2026-06-02
 
 ### Gerardo Breard

--- a/src/__tests__/roles-multirol.test.ts
+++ b/src/__tests__/roles-multirol.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import { modoActivo, rolesEfectivos, tieneAlgunRol } from '@/compartido/lib/roles'
+import authConfig from '@/compartido/lib/auth.config'
+
+// U-03 — gating por MEMBRESÍA en roles[] (decisión D1/A) + invariante role==activeMode.
+
+describe('roles.ts — membresía', () => {
+  it('single-role [TALLER] accede a área taller, no a marca', () => {
+    const u = { role: 'TALLER', roles: ['TALLER'], activeMode: 'TALLER' }
+    expect(tieneAlgunRol(u, ['TALLER'])).toBe(true)
+    expect(tieneAlgunRol(u, ['MARCA'])).toBe(false)
+  })
+
+  it('multi-rol [TALLER, MARCA] accede a ambas áreas', () => {
+    const u = { role: 'TALLER', roles: ['TALLER', 'MARCA'], activeMode: 'TALLER' }
+    expect(tieneAlgunRol(u, ['TALLER'])).toBe(true)
+    expect(tieneAlgunRol(u, ['MARCA'])).toBe(true)
+    expect(tieneAlgunRol(u, ['ESTADO'])).toBe(false)
+  })
+
+  it('ESTADO/ADMIN: un ADMIN entra a área estado (lista permitidos)', () => {
+    const admin = { role: 'ADMIN', roles: ['ADMIN'], activeMode: 'ADMIN' }
+    expect(tieneAlgunRol(admin, ['ESTADO', 'ADMIN'])).toBe(true)
+  })
+
+  it('fallback: roles[] vacío usa [activeMode]', () => {
+    const u = { role: 'MARCA', roles: [], activeMode: 'MARCA' }
+    expect(rolesEfectivos(u)).toEqual(['MARCA'])
+    expect(tieneAlgunRol(u, ['MARCA'])).toBe(true)
+    expect(tieneAlgunRol(u, ['TALLER'])).toBe(false)
+  })
+
+  it('fallback: roles[] ausente y activeMode null usa [role] (sesión vieja)', () => {
+    const u = { role: 'TALLER', roles: undefined, activeMode: null }
+    expect(rolesEfectivos(u)).toEqual(['TALLER'])
+    expect(tieneAlgunRol(u, ['TALLER'])).toBe(true)
+  })
+
+  it('sin ningún rol → sin membresía', () => {
+    const u = { role: null, roles: [], activeMode: null }
+    expect(rolesEfectivos(u)).toEqual([])
+    expect(tieneAlgunRol(u, ['ADMIN'])).toBe(false)
+  })
+})
+
+describe('roles.ts — modoActivo', () => {
+  it('usa activeMode cuando existe', () => {
+    expect(modoActivo({ role: 'TALLER', activeMode: 'MARCA' })).toBe('MARCA')
+  })
+  it('cae a role cuando activeMode es null', () => {
+    expect(modoActivo({ role: 'TALLER', activeMode: null })).toBe('TALLER')
+  })
+})
+
+describe('auth.config.ts — callbacks multi-rol (invariante role==activeMode)', () => {
+  const jwt = authConfig.callbacks!.jwt!
+  const session = authConfig.callbacks!.session!
+
+  // Helper para invocar el callback jwt con los args mínimos que usa.
+  const callJwt = (token: Record<string, unknown>, user: unknown) =>
+    jwt({ token, user } as never) as Promise<Record<string, unknown>>
+
+  it('jwt normaliza roles[] desde role cuando la DB trae roles=[]', async () => {
+    const token = await callJwt({}, {
+      id: 'u1', role: 'TALLER', roles: [], activeMode: null, registroCompleto: true,
+    })
+    expect(token.roles).toEqual(['TALLER'])
+    expect(token.activeMode).toBe('TALLER')
+    // Invariante de back-compat
+    expect(token.role).toBe('TALLER')
+    expect(token.role).toBe(token.activeMode)
+  })
+
+  it('jwt preserva roles[] reales de un multi-rol', async () => {
+    const token = await callJwt({}, {
+      id: 'u2', role: 'TALLER', roles: ['TALLER', 'MARCA'], activeMode: 'TALLER', registroCompleto: true,
+    })
+    expect(token.roles).toEqual(['TALLER', 'MARCA'])
+    expect(token.activeMode).toBe('TALLER')
+    expect(token.role).toBe(token.activeMode)
+  })
+
+  it('session expone roles[]+activeMode y mantiene role==activeMode', async () => {
+    const sess = await (session as never as (a: {
+      session: { user: Record<string, unknown> }
+      token: Record<string, unknown>
+    }) => Promise<{ user: Record<string, unknown> }>)({
+      session: { user: {} },
+      token: { id: 'u3', role: 'MARCA', roles: ['MARCA', 'TALLER'], activeMode: 'MARCA', registroCompleto: true },
+    })
+    expect(sess.user.roles).toEqual(['MARCA', 'TALLER'])
+    expect(sess.user.activeMode).toBe('MARCA')
+    expect(sess.user.role).toBe('MARCA')
+    expect(sess.user.role).toBe(sess.user.activeMode)
+  })
+
+  it('session de token viejo (sin roles/activeMode) cae a token.role', async () => {
+    const sess = await (session as never as (a: {
+      session: { user: Record<string, unknown> }
+      token: Record<string, unknown>
+    }) => Promise<{ user: Record<string, unknown> }>)({
+      session: { user: {} },
+      token: { id: 'u4', role: 'ESTADO', registroCompleto: true },
+    })
+    expect(sess.user.role).toBe('ESTADO')
+    expect(sess.user.roles).toEqual([])
+    expect(sess.user.activeMode).toBe(null)
+  })
+})

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link'
-import { auth } from '@/compartido/lib/auth'
-import { redirect } from 'next/navigation'
+import { requiereRol } from '@/compartido/lib/permisos'
 import {
   LayoutDashboard, BookOpen, Users, Building2, ShoppingCart, ClipboardCheck,
   Settings, Shield, BarChart3, FileText, Bell, Award,
@@ -32,13 +31,7 @@ const sidebarItems = [
 ]
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
-  const session = await auth()
-  if (!session?.user) {
-    redirect('/login')
-  }
-  if (session.user.role !== 'ADMIN') {
-    redirect('/unauthorized')
-  }
+  const session = await requiereRol(['ADMIN'])
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/src/app/(contenido)/layout.tsx
+++ b/src/app/(contenido)/layout.tsx
@@ -1,16 +1,10 @@
-import { auth } from '@/compartido/lib/auth'
-import { redirect } from 'next/navigation'
+import { requiereRol } from '@/compartido/lib/permisos'
 import Link from 'next/link'
 import { LogoutButton } from '@/compartido/componentes/ui/logout-button'
 import { ContenidoSidebar } from './contenido-sidebar'
 
 export default async function ContenidoLayout({ children }: { children: React.ReactNode }) {
-  const session = await auth()
-  if (!session?.user) redirect('/login')
-  const role = (session.user as { role?: string }).role
-  if (role !== 'CONTENIDO' && role !== 'ADMIN') {
-    redirect('/unauthorized')
-  }
+  await requiereRol(['CONTENIDO', 'ADMIN'])
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/src/app/(estado)/layout.tsx
+++ b/src/app/(estado)/layout.tsx
@@ -1,20 +1,12 @@
 import { Header, UserSidebar, SidebarProvider } from '@/compartido/componentes/layout'
 import { Footer } from '@/compartido/componentes/layout/footer'
-import { auth } from '@/compartido/lib/auth'
-import { redirect } from 'next/navigation'
+import { requiereRol, modoActivo } from '@/compartido/lib/permisos'
 
 export default async function EstadoLayout({ children }: { children: React.ReactNode }) {
-  const session = await auth()
+  const session = await requiereRol(['ESTADO', 'ADMIN'])
 
-  if (!session?.user) {
-    redirect('/login')
-  }
-  const role = session.user.role as string
-  if (role !== 'ESTADO' && role !== 'ADMIN') {
-    redirect('/unauthorized')
-  }
-
-  const userName = session.user.name || (role === 'ADMIN' ? 'Administrador' : 'Ente Estatal')
+  const modo = modoActivo(session.user)
+  const userName = session.user.name || (modo === 'ADMIN' ? 'Administrador' : 'Ente Estatal')
 
   const isMain = process.env.VERCEL_GIT_COMMIT_REF === 'main'
   const isLocal = !process.env.VERCEL_ENV

--- a/src/app/(marca)/layout.tsx
+++ b/src/app/(marca)/layout.tsx
@@ -1,18 +1,10 @@
 import { Header, UserSidebar, SidebarProvider } from '@/compartido/componentes/layout'
 import { Footer } from '@/compartido/componentes/layout/footer'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRol } from '@/compartido/lib/permisos'
 import { prisma } from '@/compartido/lib/prisma'
-import { redirect } from 'next/navigation'
 
 export default async function MarcaLayout({ children }: { children: React.ReactNode }) {
-  const session = await auth()
-
-  if (!session?.user) {
-    redirect('/login')
-  }
-  if (session.user.role !== 'MARCA') {
-    redirect('/unauthorized')
-  }
+  const session = await requiereRol(['MARCA'])
 
   const marca = await prisma.marca.findFirst({
     where: { userId: session.user.id },

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,4 +1,5 @@
 import { auth } from '@/compartido/lib/auth'
+import { modoActivo } from '@/compartido/lib/roles'
 import { Header, UserSidebar, SidebarProvider } from '@/compartido/componentes/layout'
 import { HeaderPublic } from '@/compartido/componentes/layout/header-public'
 import { Footer } from '@/compartido/componentes/layout/footer'
@@ -6,14 +7,13 @@ import { getShowPilotPill } from '@/compartido/lib/env'
 
 export default async function PublicLayout({ children }: { children: React.ReactNode }) {
   const session = await auth()
-  const role = (session?.user as { role?: string } | undefined)?.role || ''
 
   const showPilotPill = getShowPilotPill()
 
   // Logged in: Header global with tabs + sidebar visible en desktop
   if (session?.user) {
     const userName = session.user.name || 'Usuario'
-    const userRole = (role as 'TALLER' | 'MARCA' | 'ESTADO') || 'TALLER'
+    const userRole = (modoActivo(session.user) as 'TALLER' | 'MARCA' | 'ESTADO') || 'TALLER'
 
     return (
       <SidebarProvider>

--- a/src/app/(taller)/layout.tsx
+++ b/src/app/(taller)/layout.tsx
@@ -1,18 +1,10 @@
 import { Header, UserSidebar, SidebarProvider } from '@/compartido/componentes/layout'
 import { Footer } from '@/compartido/componentes/layout/footer'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRol } from '@/compartido/lib/permisos'
 import { prisma } from '@/compartido/lib/prisma'
-import { redirect } from 'next/navigation'
 
 export default async function TallerLayout({ children }: { children: React.ReactNode }) {
-  const session = await auth()
-
-  if (!session?.user) {
-    redirect('/login')
-  }
-  if (session.user.role !== 'TALLER') {
-    redirect('/unauthorized')
-  }
+  const session = await requiereRol(['TALLER'])
 
   const taller = await prisma.taller.findFirst({
     where: { userId: session.user.id },

--- a/src/compartido/lib/auth.config.ts
+++ b/src/compartido/lib/auth.config.ts
@@ -1,4 +1,5 @@
 import type { NextAuthConfig } from 'next-auth'
+import type { UserRole } from '@prisma/client'
 import Credentials from 'next-auth/providers/credentials'
 
 // Configuracion ligera sin Prisma/bcrypt para uso en middleware (Edge)
@@ -57,16 +58,41 @@ export default {
   callbacks: {
     async jwt({ token, user }) {
       if (user) {
-        token.role = (user as { role?: string }).role
-        token.id = user.id
-        token.registroCompleto = (user as { registroCompleto?: boolean }).registroCompleto ?? true
+        const u = user as {
+          id: string
+          role?: string | null
+          roles?: UserRole[] | null
+          activeMode?: UserRole | null
+          registroCompleto?: boolean
+        }
+        token.id = u.id
+        // Normalización en el borde de sesión (U-03): roles[] efectivos y
+        // activeMode siempre derivados, aunque la DB tenga roles=[] o
+        // activeMode=null (usuarios creados post-U02).
+        const activeMode = (u.activeMode ?? u.role ?? null) as UserRole | null
+        token.activeMode = activeMode
+        token.roles =
+          u.roles && u.roles.length > 0
+            ? u.roles
+            : activeMode
+              ? [activeMode]
+              : []
+        // INVARIANTE de back-compat: role == activeMode. Cualquier gate sin
+        // migrar que lea token.role / session.user.role ve el valor correcto.
+        token.role = activeMode ?? undefined
+        token.registroCompleto =
+          (user as { registroCompleto?: boolean }).registroCompleto ?? true
       }
       return token
     },
     async session({ session, token }) {
       if (session.user) {
         session.user.id = token.id as string
-        session.user.role = token.role as string
+        session.user.roles = (token.roles as UserRole[]) ?? []
+        session.user.activeMode = (token.activeMode as UserRole | null) ?? null
+        // INVARIANTE: role == activeMode (fallback a token.role para sesiones
+        // viejas emitidas antes del deploy de U-03).
+        session.user.role = (token.activeMode ?? token.role) as string
         ;(session.user as { registroCompleto: boolean }).registroCompleto =
           (token.registroCompleto as boolean) ?? true
       }

--- a/src/compartido/lib/auth.ts
+++ b/src/compartido/lib/auth.ts
@@ -51,6 +51,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           email: user.email,
           name: user.name,
           role: user.role,
+          roles: user.roles,
+          activeMode: user.activeMode,
           registroCompleto: user.registroCompleto,
         }
       },

--- a/src/compartido/lib/permisos.ts
+++ b/src/compartido/lib/permisos.ts
@@ -1,21 +1,22 @@
 import { auth } from './auth'
 import { redirect } from 'next/navigation'
 import { NextResponse } from 'next/server'
+import { tieneAlgunRol, modoActivo, type Rol } from './roles'
 
-type RolPermitido = 'ADMIN' | 'ESTADO' | 'CONTENIDO' | 'MARCA' | 'TALLER'
+type RolPermitido = Rol
 
 /**
  * Para uso en Server Components.
- * Verifica que el usuario tiene uno de los roles permitidos.
- * Redirige a /login si no hay sesion, a /unauthorized si el rol no coincide.
+ * Verifica que el usuario tiene MEMBRESÍA en alguno de los roles permitidos
+ * (decisión D1/A: gating por roles[], no por el escalar role).
+ * Redirige a /login si no hay sesion, a /unauthorized si no tiene el rol.
  */
 export async function requiereRol(rolesPermitidos: RolPermitido[]) {
   const session = await auth()
   if (!session?.user) {
     redirect('/login')
   }
-  const role = (session.user as { role?: string }).role as string
-  if (!rolesPermitidos.includes(role as RolPermitido)) {
+  if (!tieneAlgunRol(session.user, rolesPermitidos)) {
     redirect('/unauthorized')
   }
   return session
@@ -33,8 +34,7 @@ export async function requiereRolApi(
   if (!session?.user) {
     return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
   }
-  const role = (session.user as { role?: string }).role as string
-  if (!rolesPermitidos.includes(role as RolPermitido)) {
+  if (!tieneAlgunRol(session.user, rolesPermitidos)) {
     return NextResponse.json(
       {
         error: `Requiere rol: ${rolesPermitidos.join(' o ')}`,
@@ -44,5 +44,12 @@ export async function requiereRolApi(
       { status: 403 }
     )
   }
-  return { userId: session.user.id!, role }
+  // role == activeMode (invariante de back-compat). Los consumidores que ya
+  // usaban .role siguen viendo el modo actuante.
+  return { userId: session.user.id!, role: (modoActivo(session.user) ?? '') as string }
 }
+
+// Re-export de las primitivas para componentes y branches de UI que necesitan
+// leer el modo/membresía sin redirigir.
+export { modoActivo, tieneAlgunRol, rolesEfectivos } from './roles'
+export type { Rol } from './roles'

--- a/src/compartido/lib/roles.ts
+++ b/src/compartido/lib/roles.ts
@@ -1,0 +1,40 @@
+// Primitivas puras de roles para multi-rol (U-03).
+// SIN imports de Prisma/auth/next — Edge-safe a propósito: las usan tanto
+// permisos.ts (server) como middleware.ts (Edge), sin duplicar la lógica.
+
+export type Rol = 'TALLER' | 'MARCA' | 'ESTADO' | 'ADMIN' | 'CONTENIDO'
+
+/** Fuente mínima de roles: lo que trae la sesión/token. */
+export interface FuenteRoles {
+  role?: string | null
+  roles?: string[] | null
+  activeMode?: string | null
+}
+
+/**
+ * Modo en que el usuario está actuando.
+ * Fallback: activeMode ?? role. Garantiza un valor aunque activeMode sea null
+ * (usuarios creados post-U02 o sesiones viejas no tienen activeMode poblado).
+ */
+export function modoActivo(u: FuenteRoles): Rol | undefined {
+  return (u.activeMode ?? u.role ?? undefined) as Rol | undefined
+}
+
+/**
+ * Roles efectivos para decisiones de acceso (membresía, decisión D1/A).
+ * Si roles[] está vacío o ausente (usuarios post-U02, sesiones viejas),
+ * cae a [activeMode ?? role]. Nunca devuelve vacío si hay role/activeMode.
+ */
+export function rolesEfectivos(u: FuenteRoles): Rol[] {
+  if (u.roles && u.roles.length > 0) return u.roles as Rol[]
+  const modo = modoActivo(u)
+  return modo ? [modo] : []
+}
+
+/**
+ * Membresía: true si alguno de los roles efectivos del usuario está en la
+ * lista de roles permitidos. Es la decisión central de acceso en U-03.
+ */
+export function tieneAlgunRol(u: FuenteRoles, permitidos: Rol[]): boolean {
+  return rolesEfectivos(u).some((r) => permitidos.includes(r))
+}

--- a/src/compartido/types/next-auth.d.ts
+++ b/src/compartido/types/next-auth.d.ts
@@ -1,14 +1,20 @@
 import { DefaultSession } from 'next-auth'
+import type { UserRole } from '@prisma/client'
 
 declare module 'next-auth' {
   interface User {
     role?: string
+    roles?: UserRole[]
+    activeMode?: UserRole | null
     registroCompleto?: boolean
   }
   interface Session {
     user: {
       id: string
+      // role == activeMode (invariante de back-compat U-03).
       role: string
+      roles: UserRole[]
+      activeMode: UserRole | null
       registroCompleto: boolean
     } & DefaultSession['user']
   }
@@ -18,6 +24,8 @@ declare module 'next-auth/jwt' {
   interface JWT {
     id?: string
     role?: string
+    roles?: UserRole[]
+    activeMode?: UserRole | null
     registroCompleto?: boolean
   }
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,13 +1,15 @@
 import NextAuth from 'next-auth'
 import { NextResponse } from 'next/server'
 import authConfig from '@/compartido/lib/auth.config'
+import { tieneAlgunRol, modoActivo, type FuenteRoles } from '@/compartido/lib/roles'
 
 const { auth } = NextAuth(authConfig)
 
 export default auth((req) => {
   const { nextUrl } = req
   const isLoggedIn = !!req.auth
-  const userRole = req.auth?.user?.role as string | undefined
+  // U-03: gating por MEMBRESÍA en roles[] (decisión D1/A), no por el escalar.
+  const sessionUser = req.auth?.user as FuenteRoles | undefined
 
   // Rutas públicas que no requieren autenticación
   const publicRoutes = [
@@ -80,40 +82,44 @@ export default auth((req) => {
   // ESTADO ya no accede a /admin/* (tiene sus propias rutas /estado/*)
   // Colecciones se gestiona desde /contenido/colecciones (J-03)
   if (pathname.startsWith('/admin')) {
-    if (userRole === 'ADMIN') return NextResponse.next()
-    if (userRole === 'CONTENIDO' && pathname.startsWith('/admin/evaluaciones')) {
+    if (sessionUser && tieneAlgunRol(sessionUser, ['ADMIN'])) return NextResponse.next()
+    if (
+      sessionUser &&
+      tieneAlgunRol(sessionUser, ['CONTENIDO']) &&
+      pathname.startsWith('/admin/evaluaciones')
+    ) {
       return NextResponse.next()
     }
     return NextResponse.redirect(new URL('/unauthorized', nextUrl))
   }
 
-  // Rutas de TALLER - solo para rol TALLER
+  // Rutas de TALLER - membresía TALLER
   if (pathname.startsWith('/taller')) {
-    if (userRole !== 'TALLER') {
+    if (!sessionUser || !tieneAlgunRol(sessionUser, ['TALLER'])) {
       return NextResponse.redirect(new URL('/unauthorized', nextUrl))
     }
     return NextResponse.next()
   }
 
-  // Rutas de MARCA - solo para rol MARCA
+  // Rutas de MARCA - membresía MARCA
   if (pathname.startsWith('/marca')) {
-    if (userRole !== 'MARCA') {
+    if (!sessionUser || !tieneAlgunRol(sessionUser, ['MARCA'])) {
       return NextResponse.redirect(new URL('/unauthorized', nextUrl))
     }
     return NextResponse.next()
   }
 
-  // Rutas de ESTADO - para rol ESTADO y ADMIN
+  // Rutas de ESTADO - membresía ESTADO o ADMIN
   if (pathname.startsWith('/estado')) {
-    if (userRole !== 'ESTADO' && userRole !== 'ADMIN') {
+    if (!sessionUser || !tieneAlgunRol(sessionUser, ['ESTADO', 'ADMIN'])) {
       return NextResponse.redirect(new URL('/unauthorized', nextUrl))
     }
     return NextResponse.next()
   }
 
-  // Rutas de CONTENIDO - para rol CONTENIDO y ADMIN
+  // Rutas de CONTENIDO - membresía CONTENIDO o ADMIN
   if (pathname.startsWith('/contenido')) {
-    if (userRole !== 'CONTENIDO' && userRole !== 'ADMIN') {
+    if (!sessionUser || !tieneAlgunRol(sessionUser, ['CONTENIDO', 'ADMIN'])) {
       return NextResponse.redirect(new URL('/unauthorized', nextUrl))
     }
     return NextResponse.next()
@@ -124,9 +130,9 @@ export default auth((req) => {
     return NextResponse.next()
   }
 
-  // Redirigir a dashboard según rol si accede a raíz estando logueado
+  // Redirigir a dashboard según el modo activo si accede a raíz estando logueado
   if (pathname === '/' && isLoggedIn) {
-    switch (userRole) {
+    switch (sessionUser ? modoActivo(sessionUser) : undefined) {
       case 'TALLER':
         return NextResponse.redirect(new URL('/taller', nextUrl))
       case 'MARCA':


### PR DESCRIPTION
## U-03 PR1 — Capa de sesión multi-rol + helper por membresía + middleware/layouts

Primera de dos PRs del refactor de auth multi-rol (spec `.claude/specs/v4-u-03-auth-multirol.md`). Decisión cerrada: **gating por MEMBRESÍA en `roles[]`** (opción A).

### Qué hace
- **Sesión expone `roles[]` + `activeMode`** (`auth.ts` authorize, `auth.config.ts` callbacks, `next-auth.d.ts`).
- **Invariante de back-compat:** `session.user.role == activeMode` siempre. Las ~58 API que aún leen `role` siguen viendo el valor correcto → no se rompen ni se abren.
- **Helper `permisos.ts`** (`requiereRol`/`requiereRolApi`) ahora decide por membresía en `roles[]`, con fallback `[activeMode ?? role]`. Firma pública intacta (los 8 usos actuales siguen OK).
- **Primitivas puras en `roles.ts`** (Edge-safe, sin Prisma): `rolesEfectivos`, `tieneAlgunRol`, `modoActivo`. Compartidas por middleware (Edge) y permisos (server) sin duplicar lógica.
- **Migrados:** `middleware.ts` + los 6 layouts (`admin`, `contenido`, `estado`, `marca`, `public`, `taller`).

### Qué NO hace (scope PR2 / U-04)
- **PR2:** burn-down de las ~58 API routes que aún leen `role` inline.
- **U-04:** UI de toggle de modo + endpoint que persiste `activeMode`.

### Normalización clave
Ni el seed ni `registro` setean `roles[]`/`activeMode` (quedan en `[]`/null por defecto del schema). El callback `jwt` **normaliza en el borde de sesión**: deriva `roles` no-vacío y `activeMode` desde `role`. Así un usuario single-role se comporta **idéntico** a hoy, sin tocar datos.

### Tests
- `src/__tests__/roles-multirol.test.ts`: membresía single/multi-rol, fallback `roles=[]`, `modoActivo`, e invariante `role==activeMode` en los callbacks `jwt`/`session`.

### Verificación
- Build/typecheck/unit local **no corribles** (node_modules WSL roto, limitación documentada). CI (`npm ci` fresco) es el gate: unit (`test.yml`, informativo) + e2e contra preview (`e2e.yml`).
- Self-review estático: 0 `session.user.role` en archivos migrados; 0 imports muertos; lógica de gating preservada (incl. caso CONTENIDO→evaluaciones).

Refs spec v4-u-03, bloque multi-rol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)