### PR TITLE
chore: rate-limit pedidos sin excepcion ADMIN/ESTADO

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,12 @@
 # Daily Log
 
+## 2026-06-03
+
+### Gerardo Breard
+- **18:18** `62f49f8` — chore: rate-limit en POST /api/pedidos aplica a todos los roles
+  - `src/app/api/pedidos/route.ts`
+
+
 ## 2026-06-02
 
 ### Gerardo Breard

--- a/src/app/api/pedidos/route.ts
+++ b/src/app/api/pedidos/route.ts
@@ -59,10 +59,8 @@ export const POST = apiHandler(async (req: NextRequest) => {
   if (!session?.user) return errorAuthRequired()
   const role = (session.user as { role?: string }).role
 
-  if (role !== 'ADMIN' && role !== 'ESTADO') {
-    const blocked = await rateLimit(req, 'pedidos', session.user.id!)
-    if (blocked) return blocked
-  }
+  const blocked = await rateLimit(req, 'pedidos', session.user.id!)
+  if (blocked) return blocked
 
   const body = await req.json()
   const cantidad = Number(body.cantidad)


### PR DESCRIPTION
Limpia codigo muerto que quedo tras eliminar la rama ADMIN (#385).

## Que cambia
`POST /api/pedidos` aplicaba rate-limit con una excepcion para ADMIN/ESTADO (`if (role !== 'ADMIN' && role !== 'ESTADO')`). Esa excepcion protegia el caso "admin crea pedido", que **ya no existe** tras eliminar la rama ADMIN muerta. Quedaba como codigo muerto sugiriendo una capacidad inexistente.

Ahora el rate-limit aplica **parejo a todo rol autenticado** (defense-in-depth).

## Por que es seguro
- ADMIN/ESTADO igual reciben **403** en el gate de rol (solo MARCA crea pedidos via API); el cambio solo hace que cuenten contra el limitador **antes** de ese 403.
- Ningun flujo legitimo se ve afectado: MARCA/TALLER **ya** pasaban por el limitador.

Diff: 2 lineas. Sin cambios de schema ni de comportamiento observable para flujos legitimos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)