### PR TITLE
feat: U-03 PR2a - burn-down mecanico (40 endpoints al helper)

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,50 @@
 ## 2026-06-03
 
 ### Gerardo Breard
+- **22:45** `f051a9e` — feat(u-03): PR2a burn-down mecanico - 40 endpoints al helper
+  - `src/__tests__/admin-logs-api.test.ts`
+  - `src/__tests__/permisos.test.ts`
+  - `src/app/api/admin/config/route.ts`
+  - `src/app/api/admin/configuracion-upload/[id]/route.ts`
+  - `src/app/api/admin/configuracion-upload/route.ts`
+  - `src/app/api/admin/logs/route.ts`
+  - `src/app/api/admin/mensajes-individuales/route.ts`
+  - `src/app/api/admin/notas-seguimiento/route.ts`
+  - `src/app/api/admin/notas/route.ts`
+  - `src/app/api/admin/notificaciones/route.ts`
+  - `src/app/api/admin/observaciones/route.ts`
+  - `src/app/api/admin/rag/[id]/route.ts`
+  - `src/app/api/admin/rag/route.ts`
+  - `src/app/api/admin/reporte-mensual/route.ts`
+  - `src/app/api/admin/reporte-piloto/route.ts`
+  - `src/app/api/admin/stats/route.ts`
+  - `src/app/api/admin/usuarios-buscar/route.ts`
+  - `src/app/api/admin/usuarios/[id]/route.ts`
+  - `src/app/api/admin/usuarios/route.ts`
+  - `src/app/api/admin/whatsapp/route.ts`
+  - `src/app/api/auditorias/[id]/route.ts`
+  - `src/app/api/auditorias/route.ts`
+  - `src/app/api/certificados/route.ts`
+  - `src/app/api/colecciones/[id]/evaluacion/route.ts`
+  - `src/app/api/colecciones/[id]/progreso/route.ts`
+  - `src/app/api/colecciones/[id]/route.ts`
+  - `src/app/api/colecciones/[id]/upload/route.ts`
+  - `src/app/api/colecciones/[id]/videos/route.ts`
+  - `src/app/api/colecciones/route.ts`
+  - `src/app/api/contenido/novedades/[id]/route.ts`
+  - `src/app/api/contenido/novedades/route.ts`
+  - `src/app/api/contenido/novedades/upload/route.ts`
+  - `src/app/api/cotizaciones/route.ts`
+  - `src/app/api/denuncias/route.ts`
+  - `src/app/api/estado/exportar/route.ts`
+  - `src/app/api/exportar/route.ts`
+  - `src/app/api/marcas/route.ts`
+  - `src/app/api/ordenes/[id]/route.ts`
+  - `src/app/api/pedidos/route.ts`
+  - `src/app/api/procesos/route.ts`
+  - `src/app/api/tipos-documento/route.ts`
+  - `src/app/api/validaciones/route.ts`
+
 - **21:58** `65c1263` — merge: develop en feature/u-03-auth-multirol (resuelve DAILY.md)
 
 

--- a/src/__tests__/admin-logs-api.test.ts
+++ b/src/__tests__/admin-logs-api.test.ts
@@ -79,10 +79,11 @@ describe('GET /api/admin/logs', () => {
     expect(res.status).toBe(401)
   })
 
-  it('retorna 401 si el rol no es ADMIN', async () => {
+  it('retorna 403 si el rol no es ADMIN ni ESTADO', async () => {
+    // U-03 PR2a: el gate pasa por requiereRolApi → logueado-sin-rol da 403 (no 401)
     mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'TALLER' } })
     const res = await GET(makeRequest())
-    expect(res.status).toBe(401)
+    expect(res.status).toBe(403)
   })
 
   it('retorna logs paginados con metadata', async () => {

--- a/src/__tests__/permisos.test.ts
+++ b/src/__tests__/permisos.test.ts
@@ -97,3 +97,33 @@ describe('requiereRolApi (API Routes)', () => {
     expect(body.rolesRequeridos).toEqual(['ESTADO', 'ADMIN'])
   })
 })
+
+// U-03 PR2a: tras el burn-down, los ~40 endpoints migrados gatean por este helper.
+// El gate decide por MEMBRESÍA en roles[] (no por el escalar role/activeMode).
+describe('requiereRolApi — membresía multi-rol (premisa del burn-down)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('multi-rol [TALLER, MARCA] con activeMode TALLER pasa un gate de MARCA por membresía', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'multi-1', role: 'TALLER', roles: ['TALLER', 'MARCA'], activeMode: 'TALLER' },
+    })
+    const result = await requiereRolApi(['MARCA'])
+    // role devuelto = modo activo (invariante), no el rol por el que entró
+    expect(result).toEqual({ userId: 'multi-1', role: 'TALLER' })
+  })
+
+  it('single-rol [TALLER] NO pasa un gate de MARCA (403)', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 't-1', role: 'TALLER', roles: ['TALLER'], activeMode: 'TALLER' },
+    })
+    const result = await requiereRolApi(['MARCA'])
+    expect(result).toBeInstanceOf(NextResponse)
+    expect((result as NextResponse).status).toBe(403)
+  })
+
+  it('fallback: sesión vieja sin roles[] usa el escalar role para el gate', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'old-1', role: 'ADMIN' } })
+    const result = await requiereRolApi(['ADMIN'])
+    expect(result).toEqual({ userId: 'old-1', role: 'ADMIN' })
+  })
+})

--- a/src/app/api/admin/config/route.ts
+++ b/src/app/api/admin/config/route.ts
@@ -1,13 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 
 export async function GET(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user || (session.user as { role?: string }).role !== 'ADMIN') {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const grupo = req.nextUrl.searchParams.get('grupo')
     const config = await prisma.configuracionSistema.findMany({
@@ -22,10 +20,8 @@ export async function GET(req: NextRequest) {
 
 export async function PUT(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user || (session.user as { role?: string }).role !== 'ADMIN') {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const body = await req.json()
     const config = await prisma.configuracionSistema.upsert({

--- a/src/app/api/admin/configuracion-upload/[id]/route.ts
+++ b/src/app/api/admin/configuracion-upload/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { prisma } from '@/compartido/lib/prisma'
 import { logAccionAdmin } from '@/compartido/lib/log'
 
@@ -7,11 +7,8 @@ const TIPOS_VALIDOS = ['pdf', 'jpeg', 'png', 'webp', 'xlsx', 'docx', 'mp4', 'mov
 
 export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN') return NextResponse.json({ error: 'Solo ADMIN' }, { status: 403 })
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { id } = await params
     const body = await req.json()
@@ -46,11 +43,11 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
         ...(tiposPermitidos !== undefined && { tiposPermitidos }),
         ...(tamanoMaximoMB !== undefined && { tamanoMaximoMB }),
         ...(activo !== undefined && { activo }),
-        actualizadoPor: session.user.id,
+        actualizadoPor: sesion.userId,
       },
     })
 
-    logAccionAdmin('CONFIGURACION_UPLOAD_ACTUALIZADA', session.user.id!, {
+    logAccionAdmin('CONFIGURACION_UPLOAD_ACTUALIZADA', sesion.userId, {
       entidad: 'configuracion',
       entidadId: id,
       cambios: {

--- a/src/app/api/admin/configuracion-upload/route.ts
+++ b/src/app/api/admin/configuracion-upload/route.ts
@@ -1,14 +1,11 @@
 import { NextResponse } from 'next/server'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { prisma } from '@/compartido/lib/prisma'
 
 export async function GET() {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN') return NextResponse.json({ error: 'Solo ADMIN' }, { status: 403 })
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const configs = await prisma.configuracionUpload.findMany({
       orderBy: { createdAt: 'asc' },

--- a/src/app/api/admin/logs/route.ts
+++ b/src/app/api/admin/logs/route.ts
@@ -1,16 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { toCsv } from '@/compartido/lib/csv'
 import { logAccionAdmin } from '@/compartido/lib/log'
 
 export async function GET(req: NextRequest) {
   try {
-    const session = await auth()
-    const role = (session?.user as { role?: string })?.role
-    if (!session?.user || (role !== 'ADMIN' && role !== 'ESTADO')) {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
+    const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { searchParams } = req.nextUrl
     const exportCsv = searchParams.get('export') === 'csv'
@@ -71,7 +68,7 @@ export async function GET(req: NextRequest) {
       const hastaStr = hasta || new Date().toISOString().split('T')[0]
 
       try {
-        logAccionAdmin('DATOS_EXPORTADOS', session.user.id!, {
+        logAccionAdmin('DATOS_EXPORTADOS', sesion.userId, {
           entidad: 'exportacion',
           entidadId: `logs_${desdeStr}_${hastaStr}`,
           metadata: { registros: logs.length, filtros: { userId, accion, entidad, desde, hasta } },

--- a/src/app/api/admin/mensajes-individuales/route.ts
+++ b/src/app/api/admin/mensajes-individuales/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { apiHandler, errorAuthRequired, errorForbidden, errorInvalidInput, errorNotFound, errorRateLimited } from '@/compartido/lib/api-errors'
-import { auth } from '@/compartido/lib/auth'
+import { apiHandler, errorInvalidInput, errorNotFound, errorRateLimited } from '@/compartido/lib/api-errors'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { z } from 'zod'
 import { prisma } from '@/compartido/lib/prisma'
 import { logAccionAdmin } from '@/compartido/lib/log'
@@ -15,17 +15,13 @@ const SchemaCrearMensaje = z.object({
 })
 
 export const POST = apiHandler(async (req) => {
-  const session = await auth()
-
-  if (!session?.user) return errorAuthRequired()
-  if (!['ADMIN', 'ESTADO'].includes((session.user as { role?: string }).role ?? '')) {
-    return errorForbidden('ADMIN o ESTADO')
-  }
+  const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+  if (sesion instanceof NextResponse) return sesion
 
   // Rate limit inline: 50 mensajes/hora por admin
   const unaHoraAtras = new Date(Date.now() - 60 * 60 * 1000)
   const enviados = await prisma.notificacion.count({
-    where: { createdById: session.user.id, tipo: 'mensaje_individual', createdAt: { gte: unaHoraAtras } },
+    where: { createdById: sesion.userId, tipo: 'mensaje_individual', createdAt: { gte: unaHoraAtras } },
   })
   if (enviados >= 50) return errorRateLimited(3600)
 
@@ -52,7 +48,7 @@ export const POST = apiHandler(async (req) => {
       titulo,
       mensaje,
       link: link || null,
-      createdById: session.user.id,
+      createdById: sesion.userId,
     },
   })
 
@@ -70,7 +66,7 @@ export const POST = apiHandler(async (req) => {
     })
   }
 
-  logAccionAdmin('MENSAJE_INDIVIDUAL_ENVIADO', session.user.id, {
+  logAccionAdmin('MENSAJE_INDIVIDUAL_ENVIADO', sesion.userId, {
     entidad: 'usuario',
     entidadId: destinatarioId,
     metadata: {

--- a/src/app/api/admin/notas-seguimiento/route.ts
+++ b/src/app/api/admin/notas-seguimiento/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { apiHandler, errorAuthRequired, errorForbidden, errorInvalidInput, errorResponse } from '@/compartido/lib/api-errors'
-import { auth } from '@/compartido/lib/auth'
+import { apiHandler, errorInvalidInput, errorResponse } from '@/compartido/lib/api-errors'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { prisma } from '@/compartido/lib/prisma'
 import { z } from 'zod'
 
@@ -10,11 +10,8 @@ const SchemaCrearNota = z.object({
 })
 
 export const GET = apiHandler(async (req: NextRequest) => {
-  const session = await auth()
-  if (!session?.user) return errorAuthRequired()
-  if (!['ADMIN', 'ESTADO'].includes(session.user.role)) {
-    return errorForbidden('ADMIN o ESTADO')
-  }
+  const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+  if (sesion instanceof NextResponse) return sesion
 
   const userId = req.nextUrl.searchParams.get('userId')
   if (!userId) return errorResponse({ code: 'INVALID_INPUT', message: 'userId requerido', status: 400 })
@@ -29,11 +26,8 @@ export const GET = apiHandler(async (req: NextRequest) => {
 })
 
 export const POST = apiHandler(async (req: NextRequest) => {
-  const session = await auth()
-  if (!session?.user) return errorAuthRequired()
-  if (!['ADMIN', 'ESTADO'].includes(session.user.role)) {
-    return errorForbidden('ADMIN o ESTADO')
-  }
+  const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+  if (sesion instanceof NextResponse) return sesion
 
   const body = await req.json()
   const parsed = SchemaCrearNota.safeParse(body)
@@ -42,7 +36,7 @@ export const POST = apiHandler(async (req: NextRequest) => {
   const nota = await prisma.notaSeguimiento.create({
     data: {
       userId: parsed.data.userId,
-      autorId: session.user.id,
+      autorId: sesion.userId,
       contenido: parsed.data.contenido,
     },
     include: { autor: { select: { name: true, role: true } } },

--- a/src/app/api/admin/notas/route.ts
+++ b/src/app/api/admin/notas/route.ts
@@ -1,14 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { logAccionAdmin } from '@/compartido/lib/log'
 
 export async function GET(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN') return NextResponse.json({ error: 'Solo ADMIN' }, { status: 403 })
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { searchParams } = req.nextUrl
     const tallerId = searchParams.get('tallerId')
@@ -37,10 +35,8 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN') return NextResponse.json({ error: 'Solo ADMIN' }, { status: 403 })
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { texto, tallerId, marcaId } = await req.json()
 
@@ -54,13 +50,13 @@ export async function POST(req: NextRequest) {
     const nota = await prisma.notaInterna.create({
       data: {
         texto: texto.trim(),
-        adminId: session.user.id,
+        adminId: sesion.userId,
         ...(tallerId ? { tallerId } : {}),
         ...(marcaId ? { marcaId } : {}),
       },
       include: { admin: { select: { name: true } } },
     })
-    logAccionAdmin('NOTA_INTERNA_CREADA', session.user.id, {
+    logAccionAdmin('NOTA_INTERNA_CREADA', sesion.userId, {
       entidad: 'nota',
       entidadId: nota.id,
       metadata: { tallerId: tallerId || null, marcaId: marcaId || null },

--- a/src/app/api/admin/notificaciones/route.ts
+++ b/src/app/api/admin/notificaciones/route.ts
@@ -2,17 +2,15 @@ import { NextRequest, NextResponse } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { logActividad } from '@/compartido/lib/log'
 import { sendEmail, buildComunicacionAdminEmail } from '@/compartido/lib/email'
 import { generarMensajeWhatsapp } from '@/compartido/lib/whatsapp'
 
 export async function POST(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN') return NextResponse.json({ error: 'Acceso denegado' }, { status: 403 })
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const body = await req.json()
     const { titulo, mensaje, tipo, canal, segmento, link } = body
@@ -63,7 +61,7 @@ export async function POST(req: NextRequest) {
         mensaje,
         canal: canal || 'PLATAFORMA',
         link: link || null,
-        createdById: session.user!.id!,
+        createdById: sesion.userId,
         batchId,
       })),
     })
@@ -103,7 +101,7 @@ export async function POST(req: NextRequest) {
       }).catch(err => console.error('[F-02] Error WhatsApp mensaje_admin:', err))
     }
 
-    await logActividad(session.user!.id!, 'NOTIFICACION_MASIVA', {
+    await logActividad(sesion.userId, 'NOTIFICACION_MASIVA', {
       titulo,
       segmento,
       canal,

--- a/src/app/api/admin/observaciones/route.ts
+++ b/src/app/api/admin/observaciones/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
-import { auth } from '@/compartido/lib/auth'
 import { prisma } from '@/compartido/lib/prisma'
-import { apiHandler, errorAuthRequired, errorForbidden, errorInvalidInput } from '@/compartido/lib/api-errors'
+import { apiHandler, errorInvalidInput } from '@/compartido/lib/api-errors'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { logAccionAdmin } from '@/compartido/lib/log'
 
 const crearSchema = z.object({
@@ -22,9 +22,8 @@ const crearSchema = z.object({
 })
 
 export const GET = apiHandler(async (req: NextRequest) => {
-  const session = await auth()
-  if (!session?.user?.id) return errorAuthRequired()
-  if (!['ADMIN', 'ESTADO'].includes(session.user.role)) return errorForbidden('ADMIN o ESTADO')
+  const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+  if (sesion instanceof NextResponse) return sesion
 
   const url = req.nextUrl.searchParams
   const tipo = url.get('tipo') || undefined
@@ -74,9 +73,8 @@ export const GET = apiHandler(async (req: NextRequest) => {
 })
 
 export const POST = apiHandler(async (req: NextRequest) => {
-  const session = await auth()
-  if (!session?.user?.id) return errorAuthRequired()
-  if (!['ADMIN', 'ESTADO'].includes(session.user.role)) return errorForbidden('ADMIN o ESTADO')
+  const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+  if (sesion instanceof NextResponse) return sesion
 
   const body = await req.json()
   const parsed = crearSchema.safeParse(body)
@@ -85,7 +83,7 @@ export const POST = apiHandler(async (req: NextRequest) => {
   const observacion = await prisma.observacionCampo.create({
     data: {
       ...parsed.data,
-      autorId: session.user.id,
+      autorId: sesion.userId,
     },
     include: {
       autor: { select: { id: true, name: true } },
@@ -93,7 +91,7 @@ export const POST = apiHandler(async (req: NextRequest) => {
     },
   })
 
-  logAccionAdmin('OBSERVACION_CAMPO_CREADA', session.user.id, {
+  logAccionAdmin('OBSERVACION_CAMPO_CREADA', sesion.userId, {
     entidad: 'nota',
     entidadId: observacion.id,
     metadata: { tipo: observacion.tipo, titulo: observacion.titulo },

--- a/src/app/api/admin/rag/[id]/route.ts
+++ b/src/app/api/admin/rag/[id]/route.ts
@@ -1,16 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { logAccionAdmin } from '@/compartido/lib/log'
 
 export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'CONTENIDO') {
-      return NextResponse.json({ error: 'Sin permisos' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['ADMIN', 'CONTENIDO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { id } = await params
 
@@ -19,7 +15,7 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
       where: { id },
       data: { activo: false },
     })
-    logAccionAdmin('RAG_DOCUMENTO_DESACTIVADO', session.user.id, {
+    logAccionAdmin('RAG_DOCUMENTO_DESACTIVADO', sesion.userId, {
       entidad: 'rag',
       entidadId: id,
     })

--- a/src/app/api/admin/rag/route.ts
+++ b/src/app/api/admin/rag/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { logAccionAdmin } from '@/compartido/lib/log'
 import { generarEmbedding } from '@/compartido/lib/rag'
 import { z } from 'zod'
@@ -14,12 +14,8 @@ const crearDocSchema = z.object({
 
 export async function GET() {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'CONTENIDO') {
-      return NextResponse.json({ error: 'Sin permisos' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['ADMIN', 'CONTENIDO'])
+    if (sesion instanceof NextResponse) return sesion
 
     // Retornar documentos sin el campo embedding (demasiado grande)
     const documentos = await prisma.documentoRAG.findMany({
@@ -36,12 +32,8 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'CONTENIDO') {
-      return NextResponse.json({ error: 'Sin permisos' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['ADMIN', 'CONTENIDO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const body = await req.json()
     const parsed = crearDocSchema.safeParse(body)
@@ -71,7 +63,7 @@ export async function POST(req: NextRequest) {
       )
     `
 
-    logAccionAdmin('RAG_DOCUMENTO_CREADO', session.user.id, {
+    logAccionAdmin('RAG_DOCUMENTO_CREADO', sesion.userId, {
       entidad: 'rag',
       entidadId: id,
       metadata: { titulo: data.titulo, categoria: data.categoria },

--- a/src/app/api/admin/reporte-mensual/route.ts
+++ b/src/app/api/admin/reporte-mensual/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { auth } from '@/compartido/lib/auth'
 import { prisma } from '@/compartido/lib/prisma'
-import { apiHandler, errorAuthRequired, errorForbidden } from '@/compartido/lib/api-errors'
+import { apiHandler } from '@/compartido/lib/api-errors'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { generarXlsx, type HojaExportable } from '@/compartido/lib/exportes'
 import { calcularEtapa, ETAPA_LABELS, type EtapaOnboarding } from '@/compartido/lib/onboarding'
 import { exportarMotivosCSV } from '@/compartido/lib/demanda-insatisfecha'
@@ -12,9 +12,8 @@ function fechaStr(d: Date | null | undefined): string {
 }
 
 export const GET = apiHandler(async (req: NextRequest) => {
-  const session = await auth()
-  if (!session?.user?.id) return errorAuthRequired()
-  if (!['ADMIN', 'ESTADO'].includes(session.user.role)) return errorForbidden('ADMIN o ESTADO')
+  const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+  if (sesion instanceof NextResponse) return sesion
 
   const mesParam = req.nextUrl.searchParams.get('mes')
   const ahora = new Date()
@@ -157,7 +156,7 @@ export const GET = apiHandler(async (req: NextRequest) => {
     subtitulo: `Periodo: ${mesLabel}`,
   })
 
-  logAccionAdmin('REPORTE_MENSUAL_GENERADO', session.user.id, {
+  logAccionAdmin('REPORTE_MENSUAL_GENERADO', sesion.userId, {
     entidad: 'exportacion',
     entidadId: mesParam ?? 'current',
     metadata: { mes: mesLabel },

--- a/src/app/api/admin/reporte-piloto/route.ts
+++ b/src/app/api/admin/reporte-piloto/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { auth } from '@/compartido/lib/auth'
 import { prisma } from '@/compartido/lib/prisma'
-import { apiHandler, errorAuthRequired, errorForbidden } from '@/compartido/lib/api-errors'
+import { apiHandler } from '@/compartido/lib/api-errors'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { generarXlsx, type HojaExportable } from '@/compartido/lib/exportes'
 import { calcularEtapa, ETAPA_LABELS, type EtapaOnboarding } from '@/compartido/lib/onboarding'
 import { calcularStatsAgregadas, exportarMotivosCSV, generarRecomendaciones } from '@/compartido/lib/demanda-insatisfecha'
@@ -12,9 +12,8 @@ function fechaStr(d: Date | null | undefined): string {
 }
 
 export const GET = apiHandler(async (req: NextRequest) => {
-  const session = await auth()
-  if (!session?.user?.id) return errorAuthRequired()
-  if (!['ADMIN', 'ESTADO'].includes(session.user.role)) return errorForbidden('ADMIN o ESTADO')
+  const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+  if (sesion instanceof NextResponse) return sesion
 
   const url = req.nextUrl.searchParams
   const desdeParam = url.get('desde')
@@ -226,7 +225,7 @@ export const GET = apiHandler(async (req: NextRequest) => {
     subtitulo: `Periodo: ${fechaStr(desde)} - ${fechaStr(hasta)}`,
   })
 
-  logAccionAdmin('REPORTE_PILOTO_GENERADO', session.user.id, {
+  logAccionAdmin('REPORTE_PILOTO_GENERADO', sesion.userId, {
     entidad: 'exportacion',
     entidadId: 'piloto',
     metadata: { desde: fechaStr(desde), hasta: fechaStr(hasta) },

--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -1,13 +1,11 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 
 export async function GET() {
   try {
-    const session = await auth()
-    if (!session?.user || (session.user as { role?: string }).role !== 'ADMIN') {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const [talleres, marcas, pedidos, auditorias, usuarios, denuncias, certificados] = await Promise.all([
       prisma.taller.count(),

--- a/src/app/api/admin/usuarios-buscar/route.ts
+++ b/src/app/api/admin/usuarios-buscar/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { auth } from '@/compartido/lib/auth'
 import { prisma } from '@/compartido/lib/prisma'
-import { apiHandler, errorAuthRequired, errorForbidden } from '@/compartido/lib/api-errors'
+import { apiHandler } from '@/compartido/lib/api-errors'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 
 export const GET = apiHandler(async (req: NextRequest) => {
-  const session = await auth()
-  if (!session?.user?.id) return errorAuthRequired()
-  if (!['ADMIN', 'ESTADO'].includes(session.user.role)) return errorForbidden('ADMIN o ESTADO')
+  const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+  if (sesion instanceof NextResponse) return sesion
 
   const url = req.nextUrl.searchParams
   const q = url.get('q') || ''

--- a/src/app/api/admin/usuarios/[id]/route.ts
+++ b/src/app/api/admin/usuarios/[id]/route.ts
@@ -1,14 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { logAccionAdmin } from '@/compartido/lib/log'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth()
-    if (!session?.user || (session.user as { role?: string }).role !== 'ADMIN') {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { id } = await params
     const user = await prisma.user.findUnique({
@@ -24,10 +22,8 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 
 export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth()
-    if (!session?.user || (session.user as { role?: string }).role !== 'ADMIN') {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { id } = await params
     const body = await req.json()
@@ -36,7 +32,7 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
       data: { name: body.name, role: body.role, active: body.active, phone: body.phone },
       select: { id: true, email: true, name: true, role: true, active: true },
     })
-    logAccionAdmin('ADMIN_USUARIO_EDITADO', session.user.id, {
+    logAccionAdmin('ADMIN_USUARIO_EDITADO', sesion.userId, {
       entidad: 'usuario',
       entidadId: id,
       cambios: { name: body.name, role: body.role, active: body.active, phone: body.phone },
@@ -49,14 +45,12 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
 
 export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth()
-    if (!session?.user || (session.user as { role?: string }).role !== 'ADMIN') {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { id } = await params
     await prisma.user.update({ where: { id }, data: { active: false } })
-    logAccionAdmin('ADMIN_USUARIO_DESACTIVADO', session.user.id, {
+    logAccionAdmin('ADMIN_USUARIO_DESACTIVADO', sesion.userId, {
       entidad: 'usuario',
       entidadId: id,
     })

--- a/src/app/api/admin/usuarios/route.ts
+++ b/src/app/api/admin/usuarios/route.ts
@@ -1,15 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { logAccionAdmin } from '@/compartido/lib/log'
 import bcrypt from 'bcryptjs'
 
 export async function GET(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user || (session.user as { role?: string }).role !== 'ADMIN') {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { searchParams } = req.nextUrl
 
@@ -51,10 +49,8 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user || (session.user as { role?: string }).role !== 'ADMIN') {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const body = await req.json()
     const exists = await prisma.user.findUnique({ where: { email: body.email } })
@@ -67,7 +63,7 @@ export async function POST(req: NextRequest) {
       data: { email: body.email, password: hashedPassword, name: body.name, role: body.role, phone: body.phone, emailVerified: new Date() },
       select: { id: true, email: true, name: true, role: true, active: true },
     })
-    logAccionAdmin('ADMIN_USUARIO_CREADO', session.user.id, {
+    logAccionAdmin('ADMIN_USUARIO_CREADO', sesion.userId, {
       entidad: 'usuario',
       entidadId: user.id,
       metadata: { role: body.role, email: body.email },

--- a/src/app/api/admin/whatsapp/route.ts
+++ b/src/app/api/admin/whatsapp/route.ts
@@ -1,21 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import {
   apiHandler,
-  errorAuthRequired,
-  errorForbidden,
   errorNotFound,
   errorResponse,
 } from '@/compartido/lib/api-errors'
 
 // GET: devuelve mensajes WhatsApp pendientes (estado=GENERADO)
 export const GET = apiHandler(async () => {
-  const session = await auth()
-  if (!session?.user) return errorAuthRequired()
-
-  const role = (session.user as { role?: string }).role
-  if (role !== 'ADMIN' && role !== 'ESTADO') return errorForbidden('ADMIN o ESTADO')
+  const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+  if (sesion instanceof NextResponse) return sesion
 
   const mensajes = await prisma.mensajeWhatsapp.findMany({
     where: { estado: 'GENERADO' },
@@ -37,11 +32,8 @@ export const GET = apiHandler(async () => {
 
 // PUT: marca un mensaje como ENVIADO
 export const PUT = apiHandler(async (req: NextRequest) => {
-  const session = await auth()
-  if (!session?.user) return errorAuthRequired()
-
-  const role = (session.user as { role?: string }).role
-  if (role !== 'ADMIN' && role !== 'ESTADO') return errorForbidden('ADMIN o ESTADO')
+  const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+  if (sesion instanceof NextResponse) return sesion
 
   const body = await req.json()
   const { id } = body as { id?: string }
@@ -66,7 +58,7 @@ export const PUT = apiHandler(async (req: NextRequest) => {
     data: {
       estado: 'ENVIADO',
       enviadoAt: new Date(),
-      enviadoPor: session.user.id,
+      enviadoPor: sesion.userId,
     },
   })
 

--- a/src/app/api/auditorias/[id]/route.ts
+++ b/src/app/api/auditorias/[id]/route.ts
@@ -1,15 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'ESTADO') {
-      return NextResponse.json({ error: 'Acceso denegado' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { id } = await params
     const auditoria = await prisma.auditoria.findUnique({
@@ -26,12 +22,8 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 
 export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'ESTADO') {
-      return NextResponse.json({ error: 'Acceso denegado' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { id } = await params
     const body = await req.json()

--- a/src/app/api/auditorias/route.ts
+++ b/src/app/api/auditorias/route.ts
@@ -1,15 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 
 export async function GET(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'ESTADO') {
-      return NextResponse.json({ error: 'Acceso denegado' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { searchParams } = req.nextUrl
     const page = parseInt(searchParams.get('page') || '1')
@@ -40,12 +36,8 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'ESTADO') {
-      return NextResponse.json({ error: 'Acceso denegado' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const body = await req.json()
     const auditoria = await prisma.auditoria.create({

--- a/src/app/api/certificados/route.ts
+++ b/src/app/api/certificados/route.ts
@@ -1,17 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { aplicarNivel } from '@/compartido/lib/nivel'
 import { logAccionAdmin } from '@/compartido/lib/log'
 
 export async function GET(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'ESTADO') {
-      return NextResponse.json({ error: 'Solo ADMIN o ESTADO' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { searchParams } = req.nextUrl
     const page = parseInt(searchParams.get('page') || '1')
@@ -44,10 +40,8 @@ export async function GET(req: NextRequest) {
 // PATCH /api/certificados — revocar certificado por id (admin)
 export async function PATCH(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN') return NextResponse.json({ error: 'Solo ADMIN' }, { status: 403 })
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { id, motivo } = await req.json()
     if (!id) return NextResponse.json({ error: 'Falta id' }, { status: 400 })
@@ -58,9 +52,9 @@ export async function PATCH(req: NextRequest) {
       include: { taller: { select: { id: true } } },
     })
 
-    await aplicarNivel(cert.taller.id, session.user.id)
+    await aplicarNivel(cert.taller.id, sesion.userId)
 
-    logAccionAdmin('CERTIFICADO_REVOCADO', session.user.id, {
+    logAccionAdmin('CERTIFICADO_REVOCADO', sesion.userId, {
       entidad: 'certificado',
       entidadId: id,
       motivo: motivo || 'Sin motivo',
@@ -76,12 +70,8 @@ export async function PATCH(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN') {
-      return NextResponse.json({ error: 'Solo ADMIN puede emitir certificados' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const body = await req.json()
     const certificado = await prisma.certificado.create({
@@ -94,9 +84,9 @@ export async function POST(req: NextRequest) {
     })
 
     // Recalculate taller level after new certificate
-    await aplicarNivel(body.tallerId, session.user.id)
+    await aplicarNivel(body.tallerId, sesion.userId)
 
-    logAccionAdmin('CERTIFICADO_EMITIDO', session.user.id, {
+    logAccionAdmin('CERTIFICADO_EMITIDO', sesion.userId, {
       entidad: 'certificado',
       entidadId: certificado.id,
       metadata: { tallerId: body.tallerId, codigo: body.codigo },

--- a/src/app/api/colecciones/[id]/evaluacion/route.ts
+++ b/src/app/api/colecciones/[id]/evaluacion/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { sendEmail, buildCertificadoEmail } from '@/compartido/lib/email'
 import { generateQrBuffer } from '@/compartido/lib/qr'
 import { uploadFile } from '@/compartido/lib/storage'
@@ -9,10 +9,8 @@ import { aplicarNivel } from '@/compartido/lib/nivel'
 // GET /api/colecciones/[id]/evaluacion — devuelve evaluacion existente (admin)
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'CONTENIDO') return NextResponse.json({ error: 'Solo ADMIN o CONTENIDO' }, { status: 403 })
+    const sesion = await requiereRolApi(['ADMIN', 'CONTENIDO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { id: coleccionId } = await params
     const evaluacion = await prisma.evaluacion.findUnique({ where: { coleccionId } })
@@ -27,10 +25,8 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 // Body: { preguntas: Pregunta[], puntajeMinimo: number }
 export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'CONTENIDO') return NextResponse.json({ error: 'Solo ADMIN o CONTENIDO' }, { status: 403 })
+    const sesion = await requiereRolApi(['ADMIN', 'CONTENIDO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { id: coleccionId } = await params
     const { preguntas, puntajeMinimo } = await req.json()
@@ -51,13 +47,11 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
 // Body: { respuestas: number[] }  (índice de opción elegida por pregunta)
 export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'TALLER') return NextResponse.json({ error: 'Solo talleres pueden rendir evaluaciones' }, { status: 403 })
+    const sesion = await requiereRolApi(['TALLER'])
+    if (sesion instanceof NextResponse) return sesion
 
     const taller = await prisma.taller.findFirst({
-      where: { userId: session.user.id },
+      where: { userId: sesion.userId },
       select: { id: true, nombre: true, user: { select: { email: true } } },
     })
     if (!taller) return NextResponse.json({ error: 'Taller no encontrado' }, { status: 404 })
@@ -144,7 +138,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       })
       // Recalcular nivel del taller (certificados suman puntaje)
       try {
-        await aplicarNivel(taller.id, session.user.id)
+        await aplicarNivel(taller.id, sesion.userId)
       } catch (err) {
         console.error('[academia] Error recalculando nivel tras certificado:', err)
       }

--- a/src/app/api/colecciones/[id]/progreso/route.ts
+++ b/src/app/api/colecciones/[id]/progreso/route.ts
@@ -1,18 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 
 // POST /api/colecciones/[id]/progreso
 // Body: { videosVistos: number, totalVideos: number }
 export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'TALLER') return NextResponse.json({ error: 'Solo talleres pueden registrar progreso' }, { status: 403 })
+    const sesion = await requiereRolApi(['TALLER'])
+    if (sesion instanceof NextResponse) return sesion
 
     const taller = await prisma.taller.findFirst({
-      where: { userId: session.user.id },
+      where: { userId: sesion.userId },
       select: { id: true },
     })
     if (!taller) return NextResponse.json({ error: 'Taller no encontrado' }, { status: 404 })

--- a/src/app/api/colecciones/[id]/route.ts
+++ b/src/app/api/colecciones/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { logAccionAdmin } from '@/compartido/lib/log'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -27,12 +27,8 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 
 export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'CONTENIDO') {
-      return NextResponse.json({ error: 'Solo ADMIN o CONTENIDO puede modificar colecciones' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['ADMIN', 'CONTENIDO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { id } = await params
     const body = await req.json()
@@ -49,7 +45,7 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
         imagenUrl: body.imagenUrl,
       },
     })
-    logAccionAdmin('COLECCION_EDITADA', session.user.id, {
+    logAccionAdmin('COLECCION_EDITADA', sesion.userId, {
       entidad: 'coleccion',
       entidadId: id,
       cambios: { titulo: body.titulo, activa: body.activa },
@@ -64,16 +60,12 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
 
 export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'CONTENIDO') {
-      return NextResponse.json({ error: 'Solo ADMIN o CONTENIDO puede eliminar colecciones' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['ADMIN', 'CONTENIDO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { id } = await params
     await prisma.coleccion.delete({ where: { id } })
-    logAccionAdmin('COLECCION_ELIMINADA', session.user.id, {
+    logAccionAdmin('COLECCION_ELIMINADA', sesion.userId, {
       entidad: 'coleccion',
       entidadId: id,
     })

--- a/src/app/api/colecciones/[id]/upload/route.ts
+++ b/src/app/api/colecciones/[id]/upload/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { uploadFile } from '@/compartido/lib/storage'
 
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp']
@@ -10,15 +10,8 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const session = await auth()
-    if (!session?.user) {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
-
-    const role = (session.user as { role?: string }).role
-    if (role !== 'CONTENIDO' && role !== 'ADMIN') {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['CONTENIDO', 'ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { id } = await params
     const formData = await req.formData()

--- a/src/app/api/colecciones/[id]/videos/route.ts
+++ b/src/app/api/colecciones/[id]/videos/route.ts
@@ -1,14 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 
 // POST /api/colecciones/[id]/videos — agregar video a colección
 export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'CONTENIDO') return NextResponse.json({ error: 'Solo ADMIN o CONTENIDO puede agregar videos' }, { status: 403 })
+    const sesion = await requiereRolApi(['ADMIN', 'CONTENIDO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { id: coleccionId } = await params
     const body = await req.json()
@@ -43,10 +41,8 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
 // DELETE /api/colecciones/[id]/videos?videoId=xxx
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'CONTENIDO') return NextResponse.json({ error: 'Solo ADMIN o CONTENIDO puede eliminar videos' }, { status: 403 })
+    const sesion = await requiereRolApi(['ADMIN', 'CONTENIDO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { id: coleccionId } = await params
     const videoId = req.nextUrl.searchParams.get('videoId')

--- a/src/app/api/colecciones/route.ts
+++ b/src/app/api/colecciones/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 
 export async function GET(req: NextRequest) {
   try {
@@ -33,10 +33,8 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'CONTENIDO') return NextResponse.json({ error: 'Solo ADMIN o CONTENIDO puede crear colecciones' }, { status: 403 })
+    const sesion = await requiereRolApi(['ADMIN', 'CONTENIDO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const body = await req.json()
     if (!body.titulo?.trim()) return NextResponse.json({ error: 'El título es obligatorio' }, { status: 400 })

--- a/src/app/api/contenido/novedades/[id]/route.ts
+++ b/src/app/api/contenido/novedades/[id]/route.ts
@@ -1,21 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { prisma } from '@/compartido/lib/prisma'
 import { generarSlugUnico } from '@/compartido/lib/slugify'
 
-function checkAuth(session: { user?: { role?: string } } | null) {
-  if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-  const role = (session.user as { role?: string }).role
-  if (role !== 'CONTENIDO' && role !== 'ADMIN') {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
-  return null
-}
-
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await auth()
-  const authError = checkAuth(session)
-  if (authError) return authError
+  const sesion = await requiereRolApi(['CONTENIDO', 'ADMIN'])
+  if (sesion instanceof NextResponse) return sesion
 
   const { id } = await params
   const body = await req.json()
@@ -45,9 +35,8 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
 }
 
 export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await auth()
-  const authError = checkAuth(session)
-  if (authError) return authError
+  const sesion = await requiereRolApi(['CONTENIDO', 'ADMIN'])
+  if (sesion instanceof NextResponse) return sesion
 
   const { id } = await params
 

--- a/src/app/api/contenido/novedades/route.ts
+++ b/src/app/api/contenido/novedades/route.ts
@@ -1,21 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { prisma } from '@/compartido/lib/prisma'
 import { generarSlugUnico } from '@/compartido/lib/slugify'
 
-function checkAuth(session: { user?: { role?: string } } | null) {
-  if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-  const role = (session.user as { role?: string }).role
-  if (role !== 'CONTENIDO' && role !== 'ADMIN') {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
-  return null
-}
-
 export async function GET() {
-  const session = await auth()
-  const authError = checkAuth(session)
-  if (authError) return authError
+  const sesion = await requiereRolApi(['CONTENIDO', 'ADMIN'])
+  if (sesion instanceof NextResponse) return sesion
 
   const novedades = await prisma.novedad.findMany({
     orderBy: { createdAt: 'desc' },
@@ -25,9 +15,8 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  const session = await auth()
-  const authError = checkAuth(session)
-  if (authError) return authError
+  const sesion = await requiereRolApi(['CONTENIDO', 'ADMIN'])
+  if (sesion instanceof NextResponse) return sesion
 
   const body = await req.json()
 

--- a/src/app/api/contenido/novedades/upload/route.ts
+++ b/src/app/api/contenido/novedades/upload/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { uploadFile } from '@/compartido/lib/storage'
 
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp']
@@ -7,15 +7,8 @@ const MAX_SIZE = 5 * 1024 * 1024 // 5MB
 
 export async function POST(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
-
-    const role = (session.user as { role?: string }).role
-    if (role !== 'CONTENIDO' && role !== 'ADMIN') {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['CONTENIDO', 'ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const formData = await req.formData()
     const file = formData.get('file') as File | null

--- a/src/app/api/cotizaciones/route.ts
+++ b/src/app/api/cotizaciones/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { notificarCotizacion } from '@/compartido/lib/notificaciones'
 import { logActividad } from '@/compartido/lib/log'
 import { rateLimit } from '@/compartido/lib/ratelimit'
-import { apiHandler, errorAuthRequired, errorForbidden, errorNotFound, errorConflict, errorResponse } from '@/compartido/lib/api-errors'
+import { apiHandler, errorForbidden, errorNotFound, errorConflict, errorResponse } from '@/compartido/lib/api-errors'
 import { z } from 'zod'
 
 const cotizacionSchema = z.object({
@@ -17,10 +17,10 @@ const cotizacionSchema = z.object({
 })
 
 export const GET = apiHandler(async (req: NextRequest) => {
-  const session = await auth()
-  if (!session?.user) return errorAuthRequired()
-  const role = (session.user as { role?: string }).role
-  const userId = session.user.id!
+  const sesion = await requiereRolApi(['TALLER', 'MARCA', 'ADMIN'])
+  if (sesion instanceof NextResponse) return sesion
+  const role = sesion.role
+  const userId = sesion.userId
 
   await prisma.cotizacion.updateMany({
     where: {
@@ -45,13 +45,12 @@ export const GET = apiHandler(async (req: NextRequest) => {
       pedido: { marca: { userId } },
       ...(pedidoId ? { pedidoId } : {}),
     }
-  } else if (role === 'ADMIN') {
+  } else {
+    // role === 'ADMIN' (garantizado por el gate de requiereRolApi)
     where = {
       ...(pedidoId ? { pedidoId } : {}),
       ...(tallerId ? { tallerId } : {}),
     }
-  } else {
-    return errorForbidden()
   }
 
   const cotizaciones = await prisma.cotizacion.findMany({
@@ -67,19 +66,15 @@ export const GET = apiHandler(async (req: NextRequest) => {
 })
 
 export const POST = apiHandler(async (req: NextRequest) => {
-  const session = await auth()
-  if (!session?.user) return errorAuthRequired()
-  const role = (session.user as { role?: string }).role
+  // Solo rol TALLER puede cotizar.
+  const sesion = await requiereRolApi(['TALLER'])
+  if (sesion instanceof NextResponse) return sesion
 
-  if (role !== 'ADMIN' && role !== 'ESTADO') {
-    const blocked = await rateLimit(req, 'cotizaciones', session.user.id!)
-    if (blocked) return blocked
-  }
-
-  if (role !== 'TALLER') return errorForbidden('TALLER')
+  const blocked = await rateLimit(req, 'cotizaciones', sesion.userId)
+  if (blocked) return blocked
 
   const taller = await prisma.taller.findUnique({
-    where: { userId: session.user.id! },
+    where: { userId: sesion.userId },
     select: { id: true, nombre: true, verificadoAfip: true },
   })
   if (!taller) return errorNotFound('taller')
@@ -109,7 +104,7 @@ export const POST = apiHandler(async (req: NextRequest) => {
   })
   if (!pedido) return errorNotFound('pedido')
 
-  if (pedido.marca.userId === session.user.id) {
+  if (pedido.marca.userId === sesion.userId) {
     return errorResponse({
       code: 'AUTO_COTIZACION',
       message: 'No podés cotizar un pedido que publicaste como marca.',
@@ -148,7 +143,7 @@ export const POST = apiHandler(async (req: NextRequest) => {
       },
     })
 
-    logActividad('COTIZACION_RECIBIDA', session.user.id, {
+    logActividad('COTIZACION_RECIBIDA', sesion.userId, {
       pedidoId: data.pedidoId,
       cotizacionId: cotizacion.id,
       tallerId: taller.id,

--- a/src/app/api/denuncias/route.ts
+++ b/src/app/api/denuncias/route.ts
@@ -1,17 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { getFeatureFlag } from '@/compartido/lib/features'
 import { rateLimit, getClientIp } from '@/compartido/lib/ratelimit'
 
 export async function GET(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'ESTADO') {
-      return NextResponse.json({ error: 'Acceso denegado' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { searchParams } = req.nextUrl
     const page = parseInt(searchParams.get('page') || '1')

--- a/src/app/api/estado/exportar/route.ts
+++ b/src/app/api/estado/exportar/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { logAccionAdmin } from '@/compartido/lib/log'
 import { rateLimit, getClientIp } from '@/compartido/lib/ratelimit'
 import { generarXlsx, toCsv } from '@/compartido/lib/exportes'
@@ -8,14 +8,8 @@ import { obtenerDataExporte, esTipoValido } from './data'
 export const maxDuration = 120
 
 export async function GET(req: NextRequest) {
-  const session = await auth()
-  if (!session?.user) {
-    return NextResponse.json({ error: { code: 'AUTH_REQUIRED', message: 'No autorizado' } }, { status: 401 })
-  }
-  const role = (session.user as { role?: string }).role
-  if (role !== 'ESTADO' && role !== 'ADMIN') {
-    return NextResponse.json({ error: { code: 'FORBIDDEN', message: 'Solo ESTADO o ADMIN' } }, { status: 403 })
-  }
+  const sesion = await requiereRolApi(['ESTADO', 'ADMIN'])
+  if (sesion instanceof NextResponse) return sesion
 
   const rateLimitResponse = await rateLimit(req, 'exportar', getClientIp(req))
   if (rateLimitResponse) return rateLimitResponse
@@ -44,7 +38,7 @@ export async function GET(req: NextRequest) {
     const data = await obtenerDataExporte(tipo, { desde, hasta, provincia, nivel })
     const fecha = new Date().toISOString().split('T')[0]
 
-    logAccionAdmin('EXPORTE_GENERADO', session.user.id, {
+    logAccionAdmin('EXPORTE_GENERADO', sesion.userId, {
       entidad: 'exportacion',
       entidadId: tipo,
       metadata: { tipo, formato, filtros: { desde, hasta, provincia, nivel }, cantidadRegistros: data.filas.length },

--- a/src/app/api/exportar/route.ts
+++ b/src/app/api/exportar/route.ts
@@ -1,17 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { logAccionAdmin } from '@/compartido/lib/log'
 import { toCsv } from '@/compartido/lib/csv'
 
 export async function GET(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'ESTADO') {
-      return NextResponse.json({ error: 'Solo ADMIN o ESTADO' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const tipo = req.nextUrl.searchParams.get('tipo') || 'talleres'
     const desde = req.nextUrl.searchParams.get('desde')
@@ -162,7 +158,7 @@ export async function GET(req: NextRequest) {
       filename = 'denuncias.csv'
     }
 
-    logAccionAdmin('DATOS_EXPORTADOS', session.user.id, {
+    logAccionAdmin('DATOS_EXPORTADOS', sesion.userId, {
       entidad: 'exportacion',
       entidadId: tipo,
       metadata: { formato: 'csv' },

--- a/src/app/api/marcas/route.ts
+++ b/src/app/api/marcas/route.ts
@@ -1,13 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 
 export async function GET(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user || (session.user as { role?: string }).role !== 'ADMIN') {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { searchParams } = req.nextUrl
     const page = Math.max(parseInt(searchParams.get('page') || '1', 10), 1)

--- a/src/app/api/ordenes/[id]/route.ts
+++ b/src/app/api/ordenes/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { logActividad } from '@/compartido/lib/log'
 import { EstadoPedido } from '@prisma/client'
 
@@ -11,13 +11,9 @@ const TRANSICIONES_VALIDAS: Record<string, string[]> = {
 
 export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'TALLER') {
-      return NextResponse.json({ error: 'Solo talleres o ADMIN pueden modificar órdenes' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['ADMIN', 'TALLER'])
+    if (sesion instanceof NextResponse) return sesion
+    const role = sesion.role
 
     const { id } = await params
 
@@ -29,7 +25,7 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
     if (!orden) return NextResponse.json({ error: 'Orden no encontrada' }, { status: 404 })
 
     // Solo el taller asignado o ADMIN puede modificar
-    if (role !== 'ADMIN' && orden.taller.userId !== session.user.id) {
+    if (role !== 'ADMIN' && orden.taller.userId !== sesion.userId) {
       return NextResponse.json({ error: 'Sin acceso a esta orden' }, { status: 403 })
     }
 
@@ -65,16 +61,16 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
 
     // Logs de actividad
     if (estado === 'EN_EJECUCION' && orden.estado === 'PENDIENTE') {
-      logActividad('ORDEN_ACEPTADA', session.user.id, { ordenId: id, pedidoId: orden.pedidoId })
+      logActividad('ORDEN_ACEPTADA', sesion.userId, { ordenId: id, pedidoId: orden.pedidoId })
     }
     if (estado === 'CANCELADO' && orden.estado === 'PENDIENTE') {
-      logActividad('ORDEN_RECHAZADA', session.user.id, { ordenId: id, pedidoId: orden.pedidoId })
+      logActividad('ORDEN_RECHAZADA', sesion.userId, { ordenId: id, pedidoId: orden.pedidoId })
     }
     if (data.estado === 'COMPLETADO') {
-      logActividad('ORDEN_COMPLETADA', session.user.id, { ordenId: id, pedidoId: orden.pedidoId })
+      logActividad('ORDEN_COMPLETADA', sesion.userId, { ordenId: id, pedidoId: orden.pedidoId })
     }
     if (progreso !== undefined && !estado) {
-      logActividad('PROGRESO_ACTUALIZADO', session.user.id, {
+      logActividad('PROGRESO_ACTUALIZADO', sesion.userId, {
         ordenId: id,
         pedidoId: orden.pedidoId,
         progreso: Number(data.progreso),

--- a/src/app/api/pedidos/route.ts
+++ b/src/app/api/pedidos/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { logActividad } from '@/compartido/lib/log'
 import { rateLimit } from '@/compartido/lib/ratelimit'
-import { apiHandler, errorAuthRequired, errorForbidden, errorNotFound, errorResponse } from '@/compartido/lib/api-errors'
+import { apiHandler, errorNotFound, errorResponse } from '@/compartido/lib/api-errors'
 
 function generateOmId() {
   const year = new Date().getFullYear()
@@ -12,10 +12,10 @@ function generateOmId() {
 }
 
 export const GET = apiHandler(async (req: NextRequest) => {
-  const session = await auth()
-  if (!session?.user) return errorAuthRequired()
+  const sesion = await requiereRolApi(['ADMIN', 'MARCA'])
+  if (sesion instanceof NextResponse) return sesion
 
-  const role = (session.user as { role?: string }).role
+  const role = sesion.role
   const { searchParams } = req.nextUrl
   const page = parseInt(searchParams.get('page') || '1')
   const limit = parseInt(searchParams.get('limit') || '10')
@@ -26,15 +26,14 @@ export const GET = apiHandler(async (req: NextRequest) => {
   if (estado) where.estado = estado
   if (role === 'ADMIN') {
     if (marcaId) where.marcaId = marcaId
-  } else if (role === 'MARCA') {
+  } else {
+    // role === 'MARCA' (garantizado por el gate de requiereRolApi)
     const marca = await prisma.marca.findUnique({
-      where: { userId: session.user.id },
+      where: { userId: sesion.userId },
       select: { id: true },
     })
     if (!marca) return errorNotFound('marca')
     where.marcaId = marca.id
-  } else {
-    return errorForbidden()
   }
 
   const [pedidos, total] = await Promise.all([
@@ -55,11 +54,12 @@ export const GET = apiHandler(async (req: NextRequest) => {
 })
 
 export const POST = apiHandler(async (req: NextRequest) => {
-  const session = await auth()
-  if (!session?.user) return errorAuthRequired()
-  const role = (session.user as { role?: string }).role
+  // Solo rol MARCA crea pedidos via API. La accion admin sobre pedidos se
+  // canaliza por Prisma Studio, no por endpoint (ver DECISIONS.md).
+  const sesion = await requiereRolApi(['MARCA'])
+  if (sesion instanceof NextResponse) return sesion
 
-  const blocked = await rateLimit(req, 'pedidos', session.user.id!)
+  const blocked = await rateLimit(req, 'pedidos', sesion.userId)
   if (blocked) return blocked
 
   const body = await req.json()
@@ -78,21 +78,13 @@ export const POST = apiHandler(async (req: NextRequest) => {
     }
   }
 
-  let resolvedMarcaId = ''
-  let ownerUserId = ''
-  if (role === 'MARCA') {
-    const marca = await prisma.marca.findUnique({
-      where: { userId: session.user.id },
-      select: { id: true, userId: true },
-    })
-    if (!marca) return errorNotFound('marca')
-    resolvedMarcaId = marca.id
-    ownerUserId = marca.userId
-  } else {
-    // Solo rol MARCA crea pedidos via API. La accion admin sobre pedidos se
-    // canaliza por Prisma Studio, no por endpoint (ver DECISIONS.md).
-    return errorForbidden()
-  }
+  const marca = await prisma.marca.findUnique({
+    where: { userId: sesion.userId },
+    select: { id: true, userId: true },
+  })
+  if (!marca) return errorNotFound('marca')
+  const resolvedMarcaId = marca.id
+  const ownerUserId = marca.userId
 
   // U-06: clasificacion automatica del pedido (bloque multi-rol). Si el dueno del
   // pedido tambien tiene un Taller -> SUBCONTRATACION; si solo tiene Marca ->
@@ -119,7 +111,7 @@ export const POST = apiHandler(async (req: NextRequest) => {
     },
   })
 
-  logActividad('CRUD_PEDIDO_CREADO', session.user.id, { pedidoId: pedido.id, omId: pedido.omId, marcaId: resolvedMarcaId })
+  logActividad('CRUD_PEDIDO_CREADO', sesion.userId, { pedidoId: pedido.id, omId: pedido.omId, marcaId: resolvedMarcaId })
 
   return NextResponse.json(pedido, { status: 201 })
 })

--- a/src/app/api/procesos/route.ts
+++ b/src/app/api/procesos/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
 import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 
 export async function GET() {
   try {
@@ -20,10 +21,8 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN') return NextResponse.json({ error: 'Solo admin' }, { status: 403 })
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const body = await req.json()
     if (!body.nombre?.trim()) {
@@ -50,10 +49,8 @@ export async function POST(req: NextRequest) {
 
 export async function PUT(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN') return NextResponse.json({ error: 'Solo admin' }, { status: 403 })
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const body = await req.json()
     if (!body.id) return NextResponse.json({ error: 'ID requerido' }, { status: 400 })

--- a/src/app/api/tipos-documento/route.ts
+++ b/src/app/api/tipos-documento/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
 import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 import { invalidarCacheNivel } from '@/compartido/lib/nivel'
 
 export async function GET() {
@@ -20,10 +21,8 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ESTADO') return NextResponse.json({ error: 'Requiere rol: ESTADO', code: 'INSUFFICIENT_ROLE', rolesRequeridos: ['ESTADO'] }, { status: 403 })
+    const sesion = await requiereRolApi(['ESTADO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const body = await req.json()
     if (!body.nombre?.trim()) return NextResponse.json({ error: 'Nombre requerido' }, { status: 400 })
@@ -57,10 +56,8 @@ export async function POST(req: NextRequest) {
 
 export async function PUT(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ESTADO') return NextResponse.json({ error: 'Requiere rol: ESTADO', code: 'INSUFFICIENT_ROLE', rolesRequeridos: ['ESTADO'] }, { status: 403 })
+    const sesion = await requiereRolApi(['ESTADO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const body = await req.json()
     if (!body.id) return NextResponse.json({ error: 'ID requerido' }, { status: 400 })

--- a/src/app/api/validaciones/route.ts
+++ b/src/app/api/validaciones/route.ts
@@ -1,15 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { auth } from '@/compartido/lib/auth'
+import { requiereRolApi } from '@/compartido/lib/permisos'
 
 export async function GET(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN' && role !== 'ESTADO') {
-      return NextResponse.json({ error: 'Acceso denegado' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['ADMIN', 'ESTADO'])
+    if (sesion instanceof NextResponse) return sesion
 
     const { searchParams } = req.nextUrl
     const tallerId = searchParams.get('tallerId')
@@ -38,12 +34,8 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user) return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    const role = (session.user as { role?: string }).role
-    if (role !== 'ADMIN') {
-      return NextResponse.json({ error: 'Solo ADMIN puede crear validaciones' }, { status: 403 })
-    }
+    const sesion = await requiereRolApi(['ADMIN'])
+    if (sesion instanceof NextResponse) return sesion
 
     const body = await req.json()
 


### PR DESCRIPTION
## Qué hace

Burn-down de los endpoints con gating **mecánico** de rol (patrones A admin-only y B lista) al helper `requiereRolApi`. **40 archivos** migrados. Mismo conjunto de roles permitidos que antes; cambia el mecanismo: ahora deciden por **membresía en `roles[]`** (decisión D1/A de U-03) en vez de leer el escalar `role` inline.

Depende de **#391 (PR1)** ya mergeado en develop.

## Cobertura

`grep -rE "session\.user.*role|as \{[^}]*role" src/app/api` → el role-inline restante está **solo** en los archivos diferidos a PR2b y en los que no gatean por rol.

## Diferidos a PR2b (ownership / branching)

El gate de rol no es separable del control de acceso por id (un MARCA solo ve SU pedido, un TALLER su orden, etc.). Forzarlos a un role gate rompería el control de acceso:

- `pedidos/[id]`, `pedidos/[id]/ordenes`, `pedidos/[id]/invitaciones`
- `cotizaciones/[id]`
- `marcas/[id]`, `talleres/[id]`
- `validaciones/[id]`, `validaciones/[id]/signed-url`, `validaciones/[id]/upload`
- `admin/observaciones/[id]`
- `admin/onboarding/reenviar-invitacion` (usa `session.user.name`, no provisto por el helper)

## Fuera del alcance del burn-down

No gatean por rol (solo requieren sesión; el check de rol es bypass de rate-limit): `chat`, `feedback`, `upload/imagenes`, `denuncias` POST (público). `auth/registro/*` usa `body.role` (input, no sesión).

## Cambio de comportamiento

Un usuario **logueado pero sin el rol** ahora recibe **403** (antes algunos devolvían 401). El 401 queda solo para sin-sesión. Test `admin-logs-api` actualizado 401→403.

## Tests

- `permisos.test.ts` ya cubre A / B / 401-sin-sesión / 403-INSUFFICIENT_ROLE / dual ESTADO+ADMIN. Como los 40 endpoints delegan en el helper, eso cubre su gating.
- Se agrega bloque de **membresía multi-rol**: `[TALLER, MARCA]` con `activeMode=TALLER` pasa un gate de `MARCA`; single-rol no; fallback de sesión vieja sin `roles[]`.

Refs spec `v4-u-03` sección 'PR2 — Plan de burn-down'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)