### PR TITLE
feat: U-04 - toggle UI multi-rol

### DIFF
--- a/.claude/specs/v4-u-04-toggle-multi-rol.md
+++ b/.claude/specs/v4-u-04-toggle-multi-rol.md
@@ -1,0 +1,314 @@
+# SPEC U-04: Toggle multi-rol ("Operando como…") en el header
+
+> **Plantilla V4** — Discovery + diseño. NO implementar hasta merge de PR2b (#396) y aprobación de Gerardo.
+> **SECCION 0 es BLOQUEANTE.** **SECCION 13 NO SE MODIFICA** durante implementacion.
+
+---
+
+## 0. Pre-flight checks (BLOQUEANTE)
+
+> Ejecutar ANTES de escribir una sola linea de codigo. El discovery de abajo (secciones 5 y 6) ya
+> recoge los hallazgos reales del repo al 2026-06-05. Re-verificar tras el merge de PR2b.
+
+### 0.1 Verificacion de dependencias
+
+- [ ] **U-03 PR2b (#396) mergeado a develop** — U-04 depende de la sesión normalizada (`roles[]` + `activeMode`) y del helper por membresía. PR2b cierra el burn-down; no bloquea técnicamente pero se espera su merge para arrancar limpio.
+- [x] U-03 PR1 (#391, `93ff5ef`) mergeado — sesión expone `roles[]` + `activeMode`.
+- [x] U-03 PR2a (#393, `2e03066`) mergeado — endpoints gatean por membresía.
+- [x] U-02 schema mergeado — `User.roles UserRole[]` + `User.activeMode UserRole?` existen en `prisma/schema.prisma` (líneas 157-158).
+- [ ] Branch base (`develop`) actualizada.
+
+### 0.2 Verificacion de schema y datos
+
+- [x] `User.roles UserRole[] @default([])` — existe (schema:157).
+- [x] `User.activeMode UserRole?` — existe (schema:158).
+- [x] Enum `UserRole`: `TALLER | MARCA | ESTADO | ADMIN | CONTENIDO` (schema:15-21).
+- [x] **NO se necesita cambio de schema.** Ambas columnas ya existen (U-02). U-04 es la primera funcionalidad que las **escribe** post-login.
+
+### 0.3 Discovery de impacto tecnico — resultado
+
+- **Header**: `src/compartido/componentes/layout/header.tsx` — client component. Recibe `userName`, `userRole: 'TALLER'|'MARCA'|'ESTADO'`, `showPilotPill`. **NO recibe `roles[]` ni `activeMode` hoy.** Ya tiene un dropdown de avatar (líneas 114-157) con "Mi cuenta" + "Cerrar sesión".
+- **Invocación del Header**: 3 layouts server-component, cada uno **hardcodea** `userRole`:
+  - `src/app/(taller)/layout.tsx:29` → `userRole="TALLER"`
+  - `src/app/(marca)/layout.tsx:25` → `userRole="MARCA"`
+  - `src/app/(estado)/layout.tsx:18` → `userRole="ESTADO"`
+- **Gate de layout por membresía**: `requiereRol(['TALLER'])` usa `tieneAlgunRol` (permisos.ts:14-23). ⟹ **un usuario dual-role `[TALLER, MARCA]` pasa los gates de `/taller` Y `/marca`.** No hay que tocar los gates.
+- **Middleware** (`src/middleware.ts:133-140`): redirige `/` al dashboard de `modoActivo(sessionUser)`. Ya respeta el modo activo.
+- **Endpoint de self-update existente** (modelo a copiar): `src/app/api/cuenta/route.ts` PUT — `apiHandler` + `auth()` + `errorAuthRequired()` + `prisma.user.update({ where: { id: session.user.id }, data })`. **No existe** ningún endpoint que escriba `activeMode`.
+- **SessionProvider**: existe en `src/app/providers.tsx` ⟹ `useSession().update()` disponible client-side.
+
+### 0.4 GAP TÉCNICO CRÍTICO (el corazón de U-04)
+
+El callback `jwt` (`src/compartido/lib/auth.config.ts:59-87`) **solo procesa `if (user)`** (rama de login). **NO tiene rama `trigger === 'update'`.** Hoy `activeMode` se deriva una sola vez, al autenticar.
+
+⟹ Para que el toggle cambie el modo **sin re-login**, hay que **AGREGAR una rama `trigger === 'update'`** al callback `jwt` que re-derive `token.activeMode`, `token.roles` y `token.role` desde el `session` payload del `update()`. Sin esto, `useSession().update()` no refleja el cambio en la sesión viva. Este es el único cambio no trivial de auth en U-04.
+
+### 0.5 Reporte pre-flight
+
+- Sin cambio de schema. Sin migración SQL.
+- Cambio de auth acotado: 1 rama nueva en `jwt` (validada contra `roles[]` en DB, ver §6).
+- 1 endpoint nuevo. 1 componente nuevo (toggle) + paso de props en 3 layouts + Header.
+- Riesgo principal: que la rama `update` de `jwt` confíe en input cliente. Mitigación en §6/§12: re-leer `roles[]` de DB y validar membresía server-side.
+
+---
+
+## 1. Metadata
+
+| Campo | Valor |
+|---|---|
+| ID | U-04 |
+| Título | Toggle multi-rol "Operando como…" en el header |
+| Bloque | U (multi-rol) |
+| Depende de | U-03 (PR1+PR2a+PR2b), U-02 (schema) |
+| Habilita | U-05 (otorgar segundo rol), U-08 (e2e multi-rol) |
+| Estimación | 6–8 h (ver §14) |
+| Autor spec | Gerardo |
+| Estado | DISCOVERY — pendiente aprobación |
+
+---
+
+## 2. Contexto
+
+### Por que existe este spec
+Decisión 3.3 del MASTER_V4 ("patrón Airbnb adaptado") + narrativa V4 de Sergio §4.4 + backlog V4 fila 12. Un usuario puede tener más de un rol (ej. dueño de taller que además opera una marca). U-03 ya dejó la base de auth (sesión con `roles[]` + `activeMode`, gates por membresía). Falta la pieza visible: el control para **cambiar de modo** y la **diferenciación visual** del modo activo.
+
+### Que resuelve
+- Da al usuario dual-role un toggle explícito "Operando como Taller / Marca".
+- Persiste el modo elegido (`User.activeMode`) y lo refleja en la sesión viva sin re-login.
+- Redirige al dashboard del nuevo modo y deja el resto de la app (layouts, middleware, helpers) operando con el modo correcto — eso ya funciona por membresía desde U-03.
+
+### Documentacion de referencia
+- `.claude/specs/narrativa-V4-consolidado-niveles-1-a-4.md` §4.4 (diseño de Sergio) + fila 12 de la tabla de decisiones (línea 574).
+- `.claude/specs/v4-u-03-auth-multirol.md` (base de auth).
+- `.claude/specs/v4-u-02-schema-multi-rol.md` (columnas `roles`/`activeMode`).
+
+---
+
+## 3. Validacion interdisciplinaria
+
+- **UX (Sergio)**: el toggle debe leerse como "estado de identidad", no como un menú más. Diferenciación visual fuerte (color de acento por rol) para que el usuario nunca dude en qué modo está operando. Copy en español neutro rioplatense.
+- **Seguridad (U-03)**: el cambio de modo **no otorga permisos nuevos** — solo elige entre roles que el usuario YA tiene en `roles[]`. El endpoint debe rechazar cualquier modo fuera de `roles[]` (no confiar en el cliente). El gate real sigue siendo por membresía (U-03), el `activeMode` es solo "cuál de mis roles estoy usando ahora".
+- **Producto**: en el piloto la mayoría son single-role ⟹ el toggle no debe aparecer ni molestar a quien tiene un solo rol.
+
+---
+
+## 4. Que construir
+
+### Funcionalidades
+
+1. **Toggle en el header, al lado del avatar** (patrón Airbnb). Botón/pill que abre un dropdown:
+   ```
+   Operando como:
+     ● Taller (Taller La Aguja)
+       Marca (Amapola Indumentaria)
+   ```
+   - Solo visible si `roles.length > 1`. Single-role: no se renderiza nada.
+   - El rol activo marcado (●) y deshabilitado para click (ya estás en él).
+   - Click en otro rol → cambia de modo (ver flujo abajo).
+
+2. **Diferenciación visual del modo activo** (§4.4 de Sergio):
+   - Pill al lado del logo: "Modo Taller" / "Modo Marca".
+   - Acento de color: `brand-blue` para Taller, `terra` (terracotta) para Marca.
+   - Borde inferior del header 3–4px del color del rol activo.
+   - Avatar con borde del color del rol activo.
+
+3. **Cambio de modo**:
+   - PATCH a endpoint nuevo → escribe `User.activeMode`.
+   - `useSession().update()` → re-emite el JWT con el nuevo `activeMode` (requiere la rama `trigger==='update'` del §0.4).
+   - Toast: *"Ahora estás operando como Marca (Amapola Indumentaria)"*.
+   - Redirect al dashboard del nuevo modo (`/taller`, `/marca`, `/estado`).
+
+### Wireframes o referencias visuales
+Narrativa V4 §4.4 (texto ASCII arriba). No hay mockup pixel-perfect; seguir el design-system (tokens `brand-blue`, `terra-600`, `font-overpass`).
+
+### Consideraciones de lenguaje
+- "Operando como:" (header del dropdown).
+- "Modo Taller" / "Modo Marca" / "Modo Ente" (pill).
+- Toast: "Ahora estás operando como {Rol amable} ({nombre de la entidad})".
+- Nombres amables, no enums crudos: TALLER→"Taller", MARCA→"Marca", ESTADO→"Ente".
+
+---
+
+## 5. Datos (schema, modelos, queries)
+
+### Cambios en schema Prisma
+**Ninguno.** `User.roles` y `User.activeMode` ya existen (U-02, schema:157-158).
+
+### Migraciones SQL
+**Ninguna.**
+
+### Queries o relaciones nuevas
+- En el endpoint: `prisma.user.update({ where: { id }, data: { activeMode } })`.
+- En el endpoint (validación): `prisma.user.findUnique({ where: { id }, select: { roles: true } })` para verificar membresía server-side (no confiar en `session.user.roles`, ya que el cliente disparó el `update`). Ver §6.
+- Para el dropdown necesitamos el **nombre de la entidad** por rol (Taller La Aguja / Amapola Indumentaria). Query del lado server (en el layout o en el endpoint que alimenta el toggle): `prisma.taller.findFirst({ where: { userId } })` / `prisma.marca.findFirst({ where: { userId } })`. **Decisión D2 (ver §4 decisiones)**: empezar con el nombre del rol solo, y enriquecer con el nombre de la entidad si el layout ya lo tiene a mano (el taller layout ya hace `taller.findFirst`).
+
+### Seed o data inicial
+Hoy el seed setea solo `role`, nunca `roles[]`/`activeMode` (seed.ts:67-95). Todos los usuarios quedan single-role (jwt deriva `[activeMode]`).
+
+**Para testing de U-04** (ver §10): agregar al seed **un usuario dual-role** explícito, ej.:
+```
+roles: ['TALLER', 'MARCA'], activeMode: 'TALLER', role: 'TALLER'
+```
+con su `Taller` y su `Marca` asociados (mismo `userId`). Alternativa manual documentada: Prisma Studio → editar `roles` de un user existente. **No** hace falta el flujo de "agregar segundo rol" (eso es U-05).
+
+---
+
+## 6. Prescripciones tecnicas
+
+### Archivos a crear
+1. **`src/app/api/cuenta/modo/route.ts`** (endpoint PATCH).
+   - Patrón: copiar la estructura de `src/app/api/cuenta/route.ts` (`apiHandler` + `auth()` + `errorAuthRequired` + `errorResponse`).
+   - Body: `{ modo: UserRole }`.
+   - **Validación de seguridad (OBLIGATORIA)**: re-leer `roles[]` desde DB (`prisma.user.findUnique({ where: { id: session.user.id }, select: { roles: true, role: true } })`), normalizar igual que el jwt (si `roles` está vacío, derivar `[role]`), y rechazar con 403 `INVALID_INPUT`/`FORBIDDEN` si `modo` NO está en ese set. **NUNCA** confiar en `session.user.roles` para autorizar el cambio.
+   - `prisma.user.update({ where: { id }, data: { activeMode: modo } })`.
+   - Responder `{ ok: true, activeMode: modo }`.
+
+2. **`src/compartido/componentes/layout/modo-toggle.tsx`** (client component, nuevo).
+   - Props: `roles: UserRole[]`, `activeMode: UserRole`, `entidades?: Partial<Record<UserRole, string>>` (nombres amables de entidad).
+   - Si `roles.length <= 1` → `return null`.
+   - Dropdown con la lista; click en otro rol → `fetch('/api/cuenta/modo', { method: 'PATCH', body })` → `await update()` (de `useSession`) → `toast` → `router.push('/' + modo.toLowerCase())` + `router.refresh()`.
+   - Usar `useToast` de `@/compartido/componentes/ui/toast` (NO `alert`).
+
+### Archivos a modificar
+3. **`src/compartido/lib/auth.config.ts`** — callback `jwt`: AGREGAR rama `trigger === 'update'`.
+   - Firma actual: `async jwt({ token, user })` → pasar a `async jwt({ token, user, trigger, session })`.
+   - Nueva rama (pseudocódigo, validar contra DB NO es posible en Edge/jwt sin Prisma → el jwt callback corre en el server de auth.ts que SÍ tiene Prisma; pero por simplicidad y para no meter Prisma en la config Edge, la **validación de membresía vive en el endpoint** (paso 1), y el `update()` solo transporta el `activeMode` ya validado):
+     ```
+     if (trigger === 'update' && session?.activeMode) {
+       const nuevo = session.activeMode as UserRole
+       // roles ya están en el token (no cambian); solo si nuevo ∈ token.roles
+       if ((token.roles as UserRole[])?.includes(nuevo)) {
+         token.activeMode = nuevo
+         token.role = nuevo   // mantener invariante role == activeMode
+       }
+     }
+     ```
+   - **Defensa en profundidad**: el endpoint valida contra DB (autoritativo); el jwt revalida contra `token.roles`. Doble check, sin meter Prisma en la config Edge.
+   - **Invariante a preservar**: `token.role == token.activeMode` (back-compat U-03). Si se rompe, gates sin migrar ven el modo equivocado.
+
+4. **`src/compartido/componentes/layout/header.tsx`** — aceptar props nuevas `roles: UserRole[]`, `activeMode: UserRole`, `entidades?`, y:
+   - Renderizar `<ModoToggle>` junto al avatar (antes del bloque avatar, dentro del `div` derecho líneas 104-158).
+   - Aplicar el color de acento del modo activo: borde inferior del header + borde del avatar (clases condicionales por `activeMode`).
+   - Renderizar la pill "Modo {X}" junto al logo (banda 1, izquierda, después del `<Link>` del logo).
+   - **No romper** la firma actual: las props nuevas son opcionales; si no llegan, comportamiento idéntico (single-role).
+
+5. **`src/app/(taller)/layout.tsx`**, **`src/app/(marca)/layout.tsx`**, **`src/app/(estado)/layout.tsx`** — pasar `roles={session.user.roles}`, `activeMode={session.user.activeMode ?? session.user.role}`, y `entidades` (al menos el nombre de la propia entidad que el layout ya consulta) al `<Header>`.
+
+### Librerias o paquetes nuevos
+Ninguno. `useSession`/`update` de `next-auth/react` ya disponible. `lucide-react` para íconos ya en uso.
+
+### Convenciones del proyecto a mantener
+- `font-overpass`, tokens `brand-blue`/`terra-600`, `Badge`/pill existentes.
+- Toast V3 (`useToast`), NO `alert`.
+- Server components por defecto; el toggle es `'use client'` (necesita `useSession`/`fetch`/`router`).
+- Sin emojis en código (los `●`/🌐 del diseño son ilustrativos; usar íconos lucide o un dot CSS).
+
+---
+
+## 7. Edge cases
+
+1. **Single-role** (`roles.length <= 1`): el toggle no se renderiza; la pill puede mostrarse o no (decisión D6) pero sin diferenciación que confunda. Comportamiento idéntico al actual.
+2. **`activeMode` no está en `roles[]`** (estado corrupto): el endpoint rechaza el cambio; el header debe defaultear a `roles[0]` para no crashear. Loguear inconsistencia.
+3. **Modo no válido en el body** (ej. `ADMIN` o un rol que el user no tiene): 403 desde el endpoint, sin tocar DB.
+4. **`update()` falla o el JWT no refleja el cambio**: tras el PATCH OK, si el `update()` no propaga, el redirect a `/marca` igual funciona (layout gatea por membresía), pero `activeMode` en sesión quedaría desfasado hasta el próximo refresh. Mitigación: hacer `router.refresh()` además del `update()`; en server components el `auth()` re-lee el token actualizado.
+5. **Trabajo a medio hacer** (form sucio al cambiar de modo): el cambio es navegación explícita; se acepta pérdida de estado no guardado. **Fuera de alcance** un guard de "cambios sin guardar" (se puede agregar después). Documentar como decisión.
+6. **Usuario `ESTADO`/`ADMIN` con multi-rol**: el toggle es genérico sobre `roles[]`; soporta cualquier combinación. La diferenciación de color cubre TALLER/MARCA; para ESTADO usar un tercer acento (definir token) o el neutro.
+7. **Race**: dos pestañas cambian de modo. Última escritura gana en DB; cada pestaña refleja su propio `update()`. Aceptable.
+
+---
+
+## 8. Validacion sectorial
+- **Taller/Marca dual** (caso real del piloto): el usuario entiende de inmediato en qué modo opera y cambia sin fricción. Validar con Sergio el copy y los colores antes de cerrar.
+
+---
+
+## 9. Criterios de aceptacion
+
+- [ ] Un usuario con `roles=['TALLER','MARCA']` ve el toggle "Operando como…" al lado del avatar.
+- [ ] Un usuario single-role NO ve el toggle.
+- [ ] Al cambiar a Marca: (a) `User.activeMode` queda `MARCA` en DB, (b) la sesión viva refleja `activeMode=MARCA` sin re-login, (c) toast "Ahora estás operando como Marca (…)", (d) redirect a `/marca`.
+- [ ] La diferenciación visual (pill "Modo X" + acento de color + borde header/avatar) cambia con el modo.
+- [ ] El endpoint rechaza con 403 un `modo` que no está en `roles[]` del usuario (verificado contra DB, no contra la sesión).
+- [ ] La invariante `session.user.role == session.user.activeMode` se mantiene tras el cambio.
+- [ ] Single-role conserva comportamiento idéntico al actual (sin regresiones en header).
+- [ ] `unit` + `e2e` verdes (CI).
+
+---
+
+## 10. Tests (QAs basados en flujos)
+
+### Flujo 1: Cambio de modo (e2e, Playwright)
+1. Login como el usuario dual-role del seed (`roles=['TALLER','MARCA']`, `activeMode='TALLER'`).
+2. Verificar que aterriza en `/taller` y ve pill "Modo Taller".
+3. Abrir el toggle → click en "Marca".
+4. Verificar: toast, URL `/marca`, pill "Modo Marca", acento terracotta.
+5. Reload → sigue en modo Marca (persistencia en DB).
+
+### Flujo 2: Endpoint de modo (unit, Vitest — route handler)
+- PATCH con `modo` ∈ `roles[]` → 200 + `activeMode` actualizado (mock prisma).
+- PATCH con `modo` ∉ `roles[]` (DB) → 403, sin `user.update`.
+- PATCH sin sesión → 401.
+- PATCH con body inválido → 400.
+
+### Flujo 3: jwt update branch (unit)
+- `trigger==='update'` con `session.activeMode` ∈ `token.roles` → `token.activeMode` y `token.role` cambian, `token.roles` intacto.
+- `trigger==='update'` con modo ∉ `token.roles` → token sin cambios.
+
+### Flujo 4: Visibilidad del toggle (unit, componente)
+- `roles.length === 1` → `ModoToggle` renderiza `null`.
+- `roles.length > 1` → renderiza dropdown con N entradas, la activa marcada/disabled.
+
+### Datos de prueba
+- Extender `prisma/seed.ts` con 1 usuario dual-role (TALLER+MARCA) + su Taller + su Marca.
+- Doc manual (handover): cómo otorgar un segundo rol vía Prisma Studio para QA exploratorio.
+
+---
+
+## 11. Impacto en handover
+Documentar en `.claude/specs/handover/`:
+- La rama `trigger==='update'` del jwt callback (primer uso de `useSession().update()` en el proyecto) y por qué la validación de membresía vive en el endpoint (DB autoritativa).
+- Que `User.activeMode` ahora se **escribe** post-login (antes solo se leía al autenticar).
+- Cómo crear un usuario dual-role para testing.
+
+---
+
+## 12. Riesgos y mitigaciones
+
+| Riesgo | Severidad | Mitigación |
+|---|---|---|
+| El cliente fuerza un `modo` fuera de `roles[]` y escala permisos | Alta | El endpoint valida **contra DB** (no contra la sesión); el jwt revalida contra `token.roles`. Doble check. El gate real sigue siendo por membresía (U-03) — cambiar `activeMode` no abre rutas nuevas. |
+| Romper la invariante `role==activeMode` y desincronizar gates sin migrar | Media | En la rama `update` setear SIEMPRE `token.role = token.activeMode`. Test Flujo 3 lo cubre. |
+| `update()` no propaga y `activeMode` queda desfasado | Media | `router.refresh()` además de `update()`; layouts re-leen `auth()`. |
+| Meter Prisma en `auth.config.ts` (Edge) y romper el límite de 1MB del middleware | Alta | La validación DB va en el **endpoint** (server full), NO en la config Edge. La rama jwt solo valida contra `token.roles` (en memoria). |
+| Header existente regresiona para single-role | Media | Props nuevas opcionales; si no llegan, comportamiento idéntico. Test Flujo 4. |
+
+### Rollback
+Revertir el PR. Sin migración ⟹ sin rollback de DB. `User.activeMode` ya escrito queda como dato inocuo (la app pre-U04 lo ignora salvo en login, donde ya lo respetaba).
+
+---
+
+## 13. Selectores criticos (NO MODIFICAR en implementacion)
+
+- `data-testid="modo-toggle"` — botón que abre el dropdown del toggle.
+- `data-testid="modo-toggle-option-{ROL}"` — cada opción de rol en el dropdown.
+- `data-testid="modo-pill"` — pill "Modo X" junto al logo.
+- Endpoint: `PATCH /api/cuenta/modo`, body `{ modo: UserRole }`, respuesta `{ ok, activeMode }`.
+
+---
+
+## 14. Plan de implementacion
+
+Incremental, sin big-bang. Cada paso compila y testea por separado:
+
+1. **Endpoint** `PATCH /api/cuenta/modo` + unit tests (Flujo 2). Validación contra DB. *(~1.5h)*
+2. **Rama `trigger==='update'`** en `jwt` callback + unit tests (Flujo 3). *(~1h)*
+3. **Componente `ModoToggle`** (sin estilo final): dropdown funcional, llama endpoint + `update()` + redirect + toast. Unit test visibilidad (Flujo 4). *(~1.5h)*
+4. **Integración en Header**: props nuevas, render del toggle, pill, acentos de color. Pasar props desde los 3 layouts. *(~1.5h)*
+5. **Seed dual-role** + e2e (Flujo 1). *(~1.5h)*
+6. **QA visual con Sergio** (colores/copy §4.4) + ajustes. *(~1h)*
+
+**Orden vs otros specs del bloque U:**
+- U-04 **no** crea el flujo de otorgar segundo rol → eso es **U-05** (o donde se decida). U-04 asume que el segundo rol ya existe en `roles[]` (poblado por seed/manual para testing).
+- U-08 (e2e multi-rol completo) consume U-04.
+
+**Dependencia dura**: merge de U-03 PR2b (#396) antes de arrancar.

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,24 @@
 ## 2026-06-05
 
 ### Gerardo Breard
+- **14:41** `233e155` — feat(u-04): toggle UI multi-rol estilo Airbnb
+  - `.claude/specs/v4-u-04-toggle-multi-rol.md`
+  - `e2e/helpers/auth.ts`
+  - `e2e/u-04-toggle-multi-rol.spec.ts`
+  - `prisma/seed.ts`
+  - `src/__tests__/roles-multirol.test.ts`
+  - `src/__tests__/u-04-active-mode.test.ts`
+  - `src/app/(estado)/layout.tsx`
+  - `src/app/(marca)/layout.tsx`
+  - `src/app/(taller)/layout.tsx`
+  - `src/app/api/certificados/[id]/pdf/route.tsx`
+  - `src/app/api/ordenes/[id]/pdf/route.tsx`
+  - `src/app/api/usuarios/me/active-mode/route.ts`
+  - `src/compartido/componentes/layout/header.tsx`
+  - `src/compartido/componentes/layout/modo-toggle.tsx`
+  - `src/compartido/lib/auth.config.ts`
+  - `src/compartido/lib/entidades-modo.ts`
+
 - **11:51** `d05c766` — merge: resolver conflicto de DAILY.md (bitacora autogenerada) con develop
 
 

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,6 +1,6 @@
 import { Page, expect } from '@playwright/test'
 
-export async function loginAs(page: Page, role: 'admin' | 'taller_bronce' | 'taller_oro' | 'marca' | 'estado' | 'contenido') {
+export async function loginAs(page: Page, role: 'admin' | 'taller_bronce' | 'taller_oro' | 'marca' | 'estado' | 'contenido' | 'dual') {
   const credentials = {
     admin: { email: 'lucia.fernandez@pdt.org.ar', password: 'pdt2026' },
     taller_bronce: { email: 'roberto.gimenez@pdt.org.ar', password: 'pdt2026' },
@@ -8,6 +8,8 @@ export async function loginAs(page: Page, role: 'admin' | 'taller_bronce' | 'tal
     marca: { email: 'martin.echevarria@pdt.org.ar', password: 'pdt2026' },
     estado: { email: 'anabelen.torres@pdt.org.ar', password: 'pdt2026' },
     contenido: { email: 'sofia.martinez@pdt.org.ar', password: 'pdt2026' },
+    // U-04: usuario multi-rol (TALLER + MARCA) para el toggle "Operando como…".
+    dual: { email: 'julieta.benitez@pdt.org.ar', password: 'pdt2026' },
   }
   const { email, password } = credentials[role]
 

--- a/e2e/u-04-toggle-multi-rol.spec.ts
+++ b/e2e/u-04-toggle-multi-rol.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test'
+import { loginAs } from './helpers/auth'
+
+// U-04: toggle "Operando como…" estilo Airbnb. Solo visible para multi-rol.
+// El usuario `dual` (Julieta Benítez) tiene roles [TALLER, MARCA], activeMode TALLER.
+
+async function abrirMenuUsuario(page: import('@playwright/test').Page) {
+  await page.getByRole('button', { name: 'Menú de usuario' }).click()
+}
+
+test('multi-rol ve el toggle y arranca en modo Taller', async ({ page }) => {
+  await loginAs(page, 'dual')
+  await expect(page).toHaveURL(/\/taller/)
+
+  await abrirMenuUsuario(page)
+  await expect(page.getByTestId('modo-toggle')).toBeVisible()
+  await expect(page.getByTestId('modo-toggle-option-TALLER')).toBeVisible()
+  await expect(page.getByTestId('modo-toggle-option-MARCA')).toBeVisible()
+})
+
+test('cambiar a Marca redirige a /marca; volver a Taller redirige a /taller', async ({ page }) => {
+  await loginAs(page, 'dual')
+
+  // → Marca
+  await abrirMenuUsuario(page)
+  await page.getByTestId('modo-toggle-option-MARCA').click()
+  await expect(page).toHaveURL(/\/marca/)
+
+  // → Taller
+  await abrirMenuUsuario(page)
+  await page.getByTestId('modo-toggle-option-TALLER').click()
+  await expect(page).toHaveURL(/\/taller/)
+})
+
+test('el modo activo persiste: tras cambiar a Marca, ir a / redirige a /marca', async ({ page }) => {
+  await loginAs(page, 'dual')
+
+  await abrirMenuUsuario(page)
+  await page.getByTestId('modo-toggle-option-MARCA').click()
+  await expect(page).toHaveURL(/\/marca/)
+
+  // El middleware redirige la raíz al dashboard del activeMode persistido en DB.
+  await page.goto('/')
+  await expect(page).toHaveURL(/\/marca/)
+})
+
+test('single-role NO ve el toggle de modo', async ({ page }) => {
+  await loginAs(page, 'taller_bronce')
+  await abrirMenuUsuario(page)
+  await expect(page.getByTestId('modo-toggle')).toHaveCount(0)
+})

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -95,7 +95,24 @@ async function main() {
     data: { email: 'sofia.martinez@pdt.org.ar', password: hash, name: 'Sofía Martínez', role: 'CONTENIDO', phone: '+5491101234567', active: true },
   })
 
-  console.log('  ✓ 8 usuarios creados (incl. CONTENIDO)')
+  // U-04: usuario MULTI-ROL (taller + marca) para probar el toggle "Operando como…".
+  // roles[] poblado explícitamente + activeMode/role invariante. Su Taller y Marca
+  // se crean más abajo (mismo userId). Para otorgar un 2do rol a un user existente
+  // de forma manual: Prisma Studio → User → editar `roles` (array) + `activeMode`.
+  const userDual = await prisma.user.create({
+    data: {
+      email: 'julieta.benitez@pdt.org.ar',
+      password: hash,
+      name: 'Julieta Benítez',
+      role: 'TALLER',
+      roles: ['TALLER', 'MARCA'],
+      activeMode: 'TALLER',
+      phone: '+5491102020202',
+      active: true,
+    },
+  })
+
+  console.log('  ✓ 9 usuarios creados (incl. CONTENIDO + multi-rol)')
 
   // ============================================
   // PROCESOS PRODUCTIVOS (5)
@@ -572,7 +589,35 @@ async function main() {
     },
   })
 
-  console.log('  ✓ 2 marcas creadas')
+  // U-04: Taller + Marca del usuario multi-rol (Julieta Benítez). Le dan al
+  // toggle ambos nombres de entidad ("Taller La Hormiga" / "Marca Benítez").
+  await prisma.taller.create({
+    data: {
+      userId: userDual.id,
+      nombre: 'Taller La Hormiga',
+      cuit: '27-30111222-3',
+      nivel: 'BRONCE',
+      ubicacion: 'Avellaneda, Buenos Aires',
+      provincia: 'Buenos Aires',
+      partido: 'Avellaneda',
+      descripcion: 'Taller propio de Julieta, que además tiene su marca.',
+      capacidadMensual: 500,
+      trabajadoresRegistrados: 2,
+      verificadoAfip: true,
+    },
+  })
+  await prisma.marca.create({
+    data: {
+      userId: userDual.id,
+      nombre: 'Marca Benítez',
+      cuit: '27-30111222-4',
+      ubicacion: 'Avellaneda, Buenos Aires',
+      tipo: 'Diseño independiente',
+      volumenMensual: 200,
+    },
+  })
+
+  console.log('  ✓ 2 marcas creadas (+ taller/marca del user multi-rol)')
 
   // ============================================
   // PEDIDOS

--- a/src/__tests__/roles-multirol.test.ts
+++ b/src/__tests__/roles-multirol.test.ts
@@ -107,3 +107,42 @@ describe('auth.config.ts — callbacks multi-rol (invariante role==activeMode)',
     expect(sess.user.activeMode).toBe(null)
   })
 })
+
+describe('auth.config.ts — jwt trigger==="update" (U-04, cambio de modo)', () => {
+  const jwt = authConfig.callbacks!.jwt!
+
+  // Invoca el callback como lo hace useSession().update(data): trigger update + session=data.
+  const callUpdate = (token: Record<string, unknown>, data: unknown) =>
+    jwt({ token, trigger: 'update', session: data } as never) as Promise<Record<string, unknown>>
+
+  it('cambia activeMode+role si el nuevo modo está en token.roles (multi-rol)', async () => {
+    const token = await callUpdate(
+      { id: 'u1', role: 'TALLER', roles: ['TALLER', 'MARCA'], activeMode: 'TALLER' },
+      { activeMode: 'MARCA' }
+    )
+    expect(token.activeMode).toBe('MARCA')
+    // INVARIANTE role == activeMode
+    expect(token.role).toBe('MARCA')
+    // roles[] no se toca
+    expect(token.roles).toEqual(['TALLER', 'MARCA'])
+  })
+
+  it('IGNORA el cambio si el modo NO está en token.roles (defense-in-depth)', async () => {
+    const token = await callUpdate(
+      { id: 'u2', role: 'TALLER', roles: ['TALLER'], activeMode: 'TALLER' },
+      { activeMode: 'MARCA' }
+    )
+    // Sin cambios: el cliente no puede escalar a un rol que no tiene
+    expect(token.activeMode).toBe('TALLER')
+    expect(token.role).toBe('TALLER')
+  })
+
+  it('IGNORA un update sin activeMode', async () => {
+    const token = await callUpdate(
+      { id: 'u3', role: 'MARCA', roles: ['MARCA', 'TALLER'], activeMode: 'MARCA' },
+      { foo: 'bar' }
+    )
+    expect(token.activeMode).toBe('MARCA')
+    expect(token.role).toBe('MARCA')
+  })
+})

--- a/src/__tests__/u-04-active-mode.test.ts
+++ b/src/__tests__/u-04-active-mode.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// U-04: endpoint PATCH /api/usuarios/me/active-mode.
+// Doble validación: el modo solicitado DEBE estar en User.roles[] LEÍDO DE LA DB.
+// Cambiar de modo no otorga permisos nuevos; el endpoint nunca confía en la sesión.
+
+vi.mock('@/compartido/lib/auth', () => ({ auth: vi.fn() }))
+vi.mock('@/compartido/lib/prisma', () => ({
+  prisma: {
+    user: { findUnique: vi.fn(), update: vi.fn() },
+  },
+}))
+
+import { auth } from '@/compartido/lib/auth'
+import { prisma } from '@/compartido/lib/prisma'
+import { PATCH } from '@/app/api/usuarios/me/active-mode/route'
+
+const mockAuth = auth as ReturnType<typeof vi.fn>
+const mockUserFind = prisma.user.findUnique as ReturnType<typeof vi.fn>
+const mockUserUpdate = prisma.user.update as ReturnType<typeof vi.fn>
+
+function sesion(id = 'u1') {
+  return { user: { id, role: 'TALLER', roles: ['TALLER'], activeMode: 'TALLER' } }
+}
+const req = (body?: unknown) =>
+  new NextRequest('http://localhost/api/usuarios/me/active-mode', {
+    method: 'PATCH',
+    body: body === undefined ? undefined : JSON.stringify(body),
+  }) as NextRequest
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('PATCH /api/usuarios/me/active-mode', () => {
+  it('cambia el modo si está en roles[] de la DB (200)', async () => {
+    mockAuth.mockResolvedValue(sesion())
+    mockUserFind.mockResolvedValue({ roles: ['TALLER', 'MARCA'], role: 'TALLER' })
+    mockUserUpdate.mockResolvedValue({})
+    const res = await PATCH(req({ modo: 'MARCA' }), {} as never)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ activeMode: 'MARCA' })
+    // Persiste manteniendo la invariante role == activeMode
+    expect(mockUserUpdate).toHaveBeenCalledWith({
+      where: { id: 'u1' },
+      data: { activeMode: 'MARCA', role: 'MARCA' },
+    })
+  })
+
+  it('rechaza con 403 un modo que NO está en roles[] de la DB', async () => {
+    mockAuth.mockResolvedValue(sesion())
+    mockUserFind.mockResolvedValue({ roles: ['TALLER'], role: 'TALLER' })
+    const res = await PATCH(req({ modo: 'MARCA' }), {} as never)
+    expect(res.status).toBe(403)
+    expect(mockUserUpdate).not.toHaveBeenCalled()
+  })
+
+  it('single-role con roles[] vacío: fallback a [role], rechaza otro modo (403)', async () => {
+    mockAuth.mockResolvedValue(sesion())
+    mockUserFind.mockResolvedValue({ roles: [], role: 'TALLER' })
+    const res = await PATCH(req({ modo: 'ESTADO' }), {} as never)
+    expect(res.status).toBe(403)
+    expect(mockUserUpdate).not.toHaveBeenCalled()
+  })
+
+  it('sin sesión → 401', async () => {
+    mockAuth.mockResolvedValue(null)
+    const res = await PATCH(req({ modo: 'MARCA' }), {} as never)
+    expect(res.status).toBe(401)
+    expect(mockUserFind).not.toHaveBeenCalled()
+  })
+
+  it('modo inválido o ausente → 400', async () => {
+    mockAuth.mockResolvedValue(sesion())
+    const res = await PATCH(req({ modo: 'PIRATA' }), {} as never)
+    expect(res.status).toBe(400)
+    const res2 = await PATCH(req({}), {} as never)
+    expect(res2.status).toBe(400)
+    expect(mockUserUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/(estado)/layout.tsx
+++ b/src/app/(estado)/layout.tsx
@@ -1,12 +1,16 @@
 import { Header, UserSidebar, SidebarProvider } from '@/compartido/componentes/layout'
 import { Footer } from '@/compartido/componentes/layout/footer'
 import { requiereRol, modoActivo } from '@/compartido/lib/permisos'
+import { construirEntidadesModo } from '@/compartido/lib/entidades-modo'
 
 export default async function EstadoLayout({ children }: { children: React.ReactNode }) {
   const session = await requiereRol(['ESTADO', 'ADMIN'])
 
   const modo = modoActivo(session.user)
   const userName = session.user.name || (modo === 'ADMIN' ? 'Administrador' : 'Ente Estatal')
+
+  // U-04: datos para el toggle multi-rol (no-op si single-role).
+  const entidades = await construirEntidadesModo(session.user.id, session.user.roles)
 
   const isMain = process.env.VERCEL_GIT_COMMIT_REF === 'main'
   const isLocal = !process.env.VERCEL_ENV
@@ -19,6 +23,9 @@ export default async function EstadoLayout({ children }: { children: React.React
           userName={userName}
           userRole="ESTADO"
           showPilotPill={showPilotPill}
+          roles={session.user.roles}
+          activeMode={session.user.activeMode ?? undefined}
+          entidades={entidades}
         />
         <div className="flex flex-1">
           <UserSidebar

--- a/src/app/(marca)/layout.tsx
+++ b/src/app/(marca)/layout.tsx
@@ -2,6 +2,7 @@ import { Header, UserSidebar, SidebarProvider } from '@/compartido/componentes/l
 import { Footer } from '@/compartido/componentes/layout/footer'
 import { requiereRol } from '@/compartido/lib/permisos'
 import { prisma } from '@/compartido/lib/prisma'
+import { construirEntidadesModo } from '@/compartido/lib/entidades-modo'
 
 export default async function MarcaLayout({ children }: { children: React.ReactNode }) {
   const session = await requiereRol(['MARCA'])
@@ -15,6 +16,9 @@ export default async function MarcaLayout({ children }: { children: React.ReactN
 
   const userName = marca?.nombre || session.user.name || 'Mi Marca'
 
+  // U-04: datos para el toggle multi-rol (no-op si single-role).
+  const entidades = await construirEntidadesModo(session.user.id, session.user.roles)
+
   const isMain = process.env.VERCEL_GIT_COMMIT_REF === 'main'
   const isLocal = !process.env.VERCEL_ENV
   const showPilotPill = !isMain && !isLocal
@@ -26,6 +30,9 @@ export default async function MarcaLayout({ children }: { children: React.ReactN
           userName={userName}
           userRole="MARCA"
           showPilotPill={showPilotPill}
+          roles={session.user.roles}
+          activeMode={session.user.activeMode ?? undefined}
+          entidades={entidades}
         />
         <div className="flex flex-1">
           <UserSidebar

--- a/src/app/(taller)/layout.tsx
+++ b/src/app/(taller)/layout.tsx
@@ -2,6 +2,7 @@ import { Header, UserSidebar, SidebarProvider } from '@/compartido/componentes/l
 import { Footer } from '@/compartido/componentes/layout/footer'
 import { requiereRol } from '@/compartido/lib/permisos'
 import { prisma } from '@/compartido/lib/prisma'
+import { construirEntidadesModo } from '@/compartido/lib/entidades-modo'
 
 export default async function TallerLayout({ children }: { children: React.ReactNode }) {
   const session = await requiereRol(['TALLER'])
@@ -19,6 +20,9 @@ export default async function TallerLayout({ children }: { children: React.React
   const userLevel = taller?.nivel || 'BRONCE'
   const userProgress = taller?.puntaje || 0
 
+  // U-04: datos para el toggle multi-rol (no-op si single-role).
+  const entidades = await construirEntidadesModo(session.user.id, session.user.roles)
+
   const isMain = process.env.VERCEL_GIT_COMMIT_REF === 'main'
   const isLocal = !process.env.VERCEL_ENV
   const showPilotPill = !isMain && !isLocal
@@ -30,6 +34,9 @@ export default async function TallerLayout({ children }: { children: React.React
           userName={userName}
           userRole="TALLER"
           showPilotPill={showPilotPill}
+          roles={session.user.roles}
+          activeMode={session.user.activeMode ?? undefined}
+          entidades={entidades}
         />
         <div className="flex flex-1">
           <UserSidebar

--- a/src/app/api/certificados/[id]/pdf/route.tsx
+++ b/src/app/api/certificados/[id]/pdf/route.tsx
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { auth } from '@/compartido/lib/auth'
+import { modoActivo } from '@/compartido/lib/roles'
 import { prisma } from '@/compartido/lib/prisma'
 import { renderToBuffer } from '@react-pdf/renderer'
 import { CertificadoPDF } from '@/compartido/componentes/pdf/certificado-pdf'
@@ -30,7 +31,7 @@ export async function GET(
   }
 
   // Verificar ownership: taller propio o ADMIN
-  const role = (session.user as { role?: string }).role
+  const role = modoActivo(session.user)
   if (role !== 'ADMIN' && certificado.taller.userId !== session.user.id) {
     return NextResponse.json({ error: 'No autorizado' }, { status: 403 })
   }

--- a/src/app/api/ordenes/[id]/pdf/route.tsx
+++ b/src/app/api/ordenes/[id]/pdf/route.tsx
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { auth } from '@/compartido/lib/auth'
+import { modoActivo } from '@/compartido/lib/roles'
 import { prisma } from '@/compartido/lib/prisma'
 import { renderToBuffer } from '@react-pdf/renderer'
 import { OrdenPDF } from '@/compartido/componentes/pdf/orden-pdf'
@@ -37,7 +38,7 @@ export async function GET(
   }
 
   // Verificar ownership: taller asignado, marca dueña del pedido, o ADMIN
-  const role = (session.user as { role?: string }).role
+  const role = modoActivo(session.user)
   const userId = session.user.id
   if (role !== 'ADMIN') {
     const esTaller = orden.taller.userId === userId

--- a/src/app/api/usuarios/me/active-mode/route.ts
+++ b/src/app/api/usuarios/me/active-mode/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+import type { UserRole } from '@prisma/client'
+import { prisma } from '@/compartido/lib/prisma'
+import { auth } from '@/compartido/lib/auth'
+import {
+  apiHandler,
+  errorAuthRequired,
+  errorForbidden,
+  errorResponse,
+} from '@/compartido/lib/api-errors'
+import { rolesEfectivos } from '@/compartido/lib/roles'
+
+const MODOS_VALIDOS: UserRole[] = ['TALLER', 'MARCA', 'ESTADO', 'ADMIN', 'CONTENIDO']
+
+// U-04: cambia el modo activo del usuario (multi-rol).
+// Doble validacion de seguridad: el modo solicitado DEBE estar en User.roles[]
+// LEIDO DE LA DB (autoritativo), nunca se confia en la sesion/cliente. Cambiar
+// el modo NO otorga permisos nuevos: solo elige entre roles que el user YA tiene.
+export const PATCH = apiHandler(async (req: NextRequest) => {
+  const session = await auth()
+  if (!session?.user?.id) return errorAuthRequired()
+
+  const body = (await req.json().catch(() => null)) as { modo?: unknown } | null
+  const modo = body?.modo
+
+  if (typeof modo !== 'string' || !MODOS_VALIDOS.includes(modo as UserRole)) {
+    return errorResponse({
+      code: 'INVALID_INPUT',
+      message: 'Debes enviar un modo valido',
+      status: 400,
+    })
+  }
+  const modoSolicitado = modo as UserRole
+
+  // Membresia CONTRA LA DB (no la sesion): roles[] efectivos, con fallback a
+  // [role] para usuarios sin roles[] poblado (single-role pre-U04).
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { roles: true, role: true },
+  })
+  if (!user) return errorAuthRequired()
+
+  const rolesDb = rolesEfectivos({ roles: user.roles, role: user.role })
+  if (!rolesDb.includes(modoSolicitado)) {
+    return errorForbidden(modoSolicitado)
+  }
+
+  // Persistir + mantener invariante role == activeMode (back-compat U-03).
+  await prisma.user.update({
+    where: { id: session.user.id },
+    data: { activeMode: modoSolicitado, role: modoSolicitado },
+  })
+
+  return NextResponse.json({ activeMode: modoSolicitado })
+})

--- a/src/compartido/componentes/layout/header.tsx
+++ b/src/compartido/componentes/layout/header.tsx
@@ -31,16 +31,16 @@ const MODO_LABEL: Partial<Record<UserRole, string>> = {
   ESTADO: 'Modo Ente',
 }
 const MODO_PILL: Partial<Record<UserRole, string>> = {
-  TALLER: 'bg-brand-blue/10 text-brand-blue',
-  MARCA: 'bg-terra-600/10 text-terra-600',
+  TALLER: 'bg-brand-bg-light text-brand-blue',
+  MARCA: 'bg-terra-100 text-terra-600',
 }
 const MODO_BORDE: Partial<Record<UserRole, string>> = {
   TALLER: 'border-b-brand-blue',
   MARCA: 'border-b-terra-600',
 }
 const MODO_AVATAR: Partial<Record<UserRole, string>> = {
-  TALLER: 'ring-2 ring-brand-blue',
-  MARCA: 'ring-2 ring-terra-600',
+  TALLER: 'ring-4 ring-brand-blue',
+  MARCA: 'ring-4 ring-terra-600',
 }
 
 export function Header({
@@ -112,7 +112,7 @@ export function Header({
   return (
     <header
       className={`sticky top-0 z-40 bg-white border-b ${
-        borderAccent ? `border-b-2 ${borderAccent}` : 'border-gray-100'
+        borderAccent ? `border-b-4 ${borderAccent}` : 'border-gray-100'
       }`}
     >
       {/* Banda 1: topbar */}
@@ -143,7 +143,7 @@ export function Header({
             {esMultiRol && MODO_LABEL[modoActual] && (
               <span
                 data-testid="modo-pill"
-                className={`hidden sm:inline-flex items-center px-2.5 py-1 rounded-full text-xs font-overpass font-semibold ${
+                className={`inline-flex items-center px-2.5 py-1 rounded-full text-sm font-overpass font-bold ${
                   MODO_PILL[modoActual] ?? 'bg-gray-100 text-ink-secondary'
                 }`}
               >

--- a/src/compartido/componentes/layout/header.tsx
+++ b/src/compartido/componentes/layout/header.tsx
@@ -5,8 +5,10 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { Menu, User, LogOut } from 'lucide-react'
 import { signOut } from 'next-auth/react'
+import type { UserRole } from '@prisma/client'
 import { LogoPDT } from '@/compartido/componentes/ui/logo-pdt'
 import { NotificacionesBell } from './notificaciones-bell'
+import { ModoToggle } from './modo-toggle'
 import { useSidebar } from './sidebar-context'
 import { INSTITUTIONAL, TABS_BY_ROLE } from '@/compartido/lib/content/institutional'
 
@@ -14,12 +16,40 @@ interface HeaderProps {
   userName?: string
   userRole?: 'TALLER' | 'MARCA' | 'ESTADO'
   showPilotPill?: boolean
+  /** U-04: roles del usuario; el toggle de modo solo aparece si hay 2+. */
+  roles?: UserRole[]
+  /** U-04: modo activo actual. */
+  activeMode?: UserRole
+  /** U-04: nombre amable de la entidad por rol, para el toggle. */
+  entidades?: Partial<Record<UserRole, string>>
+}
+
+// U-04: nombre amable + acentos de color por modo activo (§4.4 narrativa V4).
+const MODO_LABEL: Partial<Record<UserRole, string>> = {
+  TALLER: 'Modo Taller',
+  MARCA: 'Modo Marca',
+  ESTADO: 'Modo Ente',
+}
+const MODO_PILL: Partial<Record<UserRole, string>> = {
+  TALLER: 'bg-brand-blue/10 text-brand-blue',
+  MARCA: 'bg-terra-600/10 text-terra-600',
+}
+const MODO_BORDE: Partial<Record<UserRole, string>> = {
+  TALLER: 'border-b-brand-blue',
+  MARCA: 'border-b-terra-600',
+}
+const MODO_AVATAR: Partial<Record<UserRole, string>> = {
+  TALLER: 'ring-2 ring-brand-blue',
+  MARCA: 'ring-2 ring-terra-600',
 }
 
 export function Header({
   userName = 'Usuario',
   userRole = 'TALLER',
   showPilotPill = false,
+  roles = [],
+  activeMode,
+  entidades,
 }: HeaderProps) {
   const { open } = useSidebar()
   const pathname = usePathname()
@@ -43,6 +73,12 @@ export function Header({
     .slice(0, 2)
     .join('')
     .toUpperCase() || '?'
+
+  // U-04: modo activo efectivo + diferenciación visual solo para multi-rol.
+  const modoActual: UserRole = activeMode ?? (userRole as UserRole)
+  const esMultiRol = roles.length > 1
+  const borderAccent = esMultiRol ? MODO_BORDE[modoActual] ?? '' : ''
+  const avatarAccent = esMultiRol ? MODO_AVATAR[modoActual] ?? '' : ''
 
   // Avatar click: mobile abre sidebar, desktop abre dropdown
   function handleAvatarClick() {
@@ -74,7 +110,11 @@ export function Header({
   }, [menuOpen])
 
   return (
-    <header className="sticky top-0 z-40 bg-white border-b border-gray-100">
+    <header
+      className={`sticky top-0 z-40 bg-white border-b ${
+        borderAccent ? `border-b-2 ${borderAccent}` : 'border-gray-100'
+      }`}
+    >
       {/* Banda 1: topbar */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-14">
@@ -98,6 +138,18 @@ export function Header({
                 </span>
               </div>
             </Link>
+
+            {/* U-04: pill "Modo X" (solo multi-rol) */}
+            {esMultiRol && MODO_LABEL[modoActual] && (
+              <span
+                data-testid="modo-pill"
+                className={`hidden sm:inline-flex items-center px-2.5 py-1 rounded-full text-xs font-overpass font-semibold ${
+                  MODO_PILL[modoActual] ?? 'bg-gray-100 text-ink-secondary'
+                }`}
+              >
+                {MODO_LABEL[modoActual]}
+              </span>
+            )}
           </div>
 
           {/* Derecha: pill ambiente + bell + avatar */}
@@ -119,7 +171,9 @@ export function Header({
                 aria-expanded={menuOpen}
                 aria-haspopup="true"
               >
-                <div className="w-8 h-8 rounded-full bg-brand-blue text-white flex items-center justify-center font-overpass font-bold text-xs">
+                <div
+                  className={`w-8 h-8 rounded-full bg-brand-blue text-white flex items-center justify-center font-overpass font-bold text-xs ${avatarAccent}`}
+                >
                   {initials}
                 </div>
                 <span className="hidden lg:inline text-sm font-medium text-ink-primary font-overpass">
@@ -137,6 +191,13 @@ export function Header({
                       {userRole === 'ESTADO' && 'Ente Estatal'}
                     </p>
                   </div>
+                  {/* U-04: toggle multi-rol (se auto-oculta si roles <= 1) */}
+                  <ModoToggle
+                    roles={roles}
+                    activeMode={modoActual}
+                    entidades={entidades}
+                    onCambio={() => setMenuOpen(false)}
+                  />
                   <Link
                     href="/cuenta"
                     onClick={() => setMenuOpen(false)}

--- a/src/compartido/componentes/layout/modo-toggle.tsx
+++ b/src/compartido/componentes/layout/modo-toggle.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useSession } from 'next-auth/react'
+import { Check } from 'lucide-react'
+import type { UserRole } from '@prisma/client'
+import { useToast } from '@/compartido/componentes/ui/toast'
+
+interface ModoToggleProps {
+  roles: UserRole[]
+  activeMode: UserRole
+  /** Nombre amable de la entidad por rol (ej. { TALLER: 'Taller La Aguja' }). */
+  entidades?: Partial<Record<UserRole, string>>
+  /** Callback al cambiar de modo (ej. cerrar el dropdown del avatar). */
+  onCambio?: () => void
+}
+
+// Nombres amables (no enums crudos), per narrativa V4 §4.4.
+const NOMBRE_AMABLE: Record<UserRole, string> = {
+  TALLER: 'Taller',
+  MARCA: 'Marca',
+  ESTADO: 'Ente',
+  ADMIN: 'Admin',
+  CONTENIDO: 'Contenido',
+}
+
+// Acento de color por rol (azul brand = Taller, terracotta = Marca).
+const ACENTO: Partial<Record<UserRole, string>> = {
+  TALLER: 'text-brand-blue',
+  MARCA: 'text-terra-600',
+}
+
+const DASHBOARD: Partial<Record<UserRole, string>> = {
+  TALLER: '/taller',
+  MARCA: '/marca',
+  ESTADO: '/estado',
+}
+
+/**
+ * U-04: toggle "Operando como…" estilo Airbnb. Solo se renderiza si el usuario
+ * tiene 2+ roles. Cambiar de modo persiste en DB (endpoint), refleja el cambio
+ * en la sesión viva (useSession().update → rama jwt trigger==='update') y
+ * redirige al dashboard del nuevo modo.
+ */
+export function ModoToggle({ roles, activeMode, entidades, onCambio }: ModoToggleProps) {
+  const router = useRouter()
+  const { update } = useSession()
+  const { toast } = useToast()
+  const [cambiando, setCambiando] = useState<UserRole | null>(null)
+
+  // Single-role: no se muestra nada.
+  if (!roles || roles.length <= 1) return null
+
+  async function cambiarModo(modo: UserRole) {
+    if (modo === activeMode || cambiando) return
+    setCambiando(modo)
+    try {
+      const res = await fetch('/api/usuarios/me/active-mode', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ modo }),
+      })
+      if (!res.ok) {
+        toast({ mensaje: 'No se pudo cambiar de modo', tipo: 'error' })
+        setCambiando(null)
+        return
+      }
+      // Refleja el cambio en la sesión viva sin re-login.
+      await update({ activeMode: modo })
+
+      const amable = NOMBRE_AMABLE[modo] ?? modo
+      const entidad = entidades?.[modo]
+      toast({
+        mensaje: entidad
+          ? `Ahora estás operando como ${amable} (${entidad})`
+          : `Ahora estás operando como ${amable}`,
+        tipo: 'success',
+      })
+      onCambio?.()
+      router.push(DASHBOARD[modo] ?? '/')
+      router.refresh()
+    } catch {
+      toast({ mensaje: 'No se pudo cambiar de modo', tipo: 'error' })
+      setCambiando(null)
+    }
+  }
+
+  return (
+    <div className="px-2 py-2 border-b border-gray-100" data-testid="modo-toggle">
+      <p className="px-2 pb-1.5 text-[11px] font-overpass font-semibold uppercase tracking-wider text-ink-secondary">
+        Operando como
+      </p>
+      <ul className="flex flex-col gap-0.5">
+        {roles.map((modo) => {
+          const activo = modo === activeMode
+          const amable = NOMBRE_AMABLE[modo] ?? modo
+          const entidad = entidades?.[modo]
+          const acento = ACENTO[modo] ?? 'text-ink-primary'
+          return (
+            <li key={modo}>
+              <button
+                type="button"
+                data-testid={`modo-toggle-option-${modo}`}
+                disabled={activo || cambiando !== null}
+                onClick={() => cambiarModo(modo)}
+                className={`w-full flex items-center gap-2.5 px-2 py-2 rounded-md text-left transition-colors ${
+                  activo ? 'bg-gray-50 cursor-default' : 'hover:bg-gray-50'
+                }`}
+              >
+                <span
+                  className={`w-2 h-2 rounded-full shrink-0 ${
+                    activo ? `bg-current ${acento}` : 'border border-gray-300'
+                  }`}
+                />
+                <span className="flex-1 min-w-0">
+                  <span
+                    className={`block text-sm font-overpass font-semibold ${
+                      activo ? acento : 'text-ink-primary'
+                    }`}
+                  >
+                    Modo {amable}
+                  </span>
+                  {entidad && (
+                    <span className="block text-xs font-overpass text-ink-secondary truncate">
+                      {entidad}
+                    </span>
+                  )}
+                </span>
+                {activo && <Check className={`w-4 h-4 shrink-0 ${acento}`} />}
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/src/compartido/lib/auth.config.ts
+++ b/src/compartido/lib/auth.config.ts
@@ -56,7 +56,7 @@ export default {
     },
   },
   callbacks: {
-    async jwt({ token, user }) {
+    async jwt({ token, user, trigger, session }) {
       if (user) {
         const u = user as {
           id: string
@@ -82,6 +82,19 @@ export default {
         token.role = activeMode ?? undefined
         token.registroCompleto =
           (user as { registroCompleto?: boolean }).registroCompleto ?? true
+      }
+      // U-04: cambio de modo activo en caliente vía useSession().update({ activeMode }).
+      // Defense-in-depth: el endpoint /api/usuarios/me/active-mode ya validó contra la
+      // DB (autoritativo); acá revalidamos contra los roles que YA están en el token
+      // (en memoria, sin Prisma → Edge-safe). Nunca se confía ciegamente en el cliente.
+      if (trigger === 'update' && session && typeof session === 'object') {
+        const nuevo = (session as { activeMode?: UserRole | null }).activeMode
+        const rolesToken = (token.roles as UserRole[] | undefined) ?? []
+        if (nuevo && rolesToken.includes(nuevo)) {
+          token.activeMode = nuevo
+          // INVARIANTE: role == activeMode (back-compat U-03).
+          token.role = nuevo
+        }
       }
       return token
     },

--- a/src/compartido/lib/entidades-modo.ts
+++ b/src/compartido/lib/entidades-modo.ts
@@ -1,0 +1,36 @@
+import { prisma } from '@/compartido/lib/prisma'
+import type { UserRole } from '@prisma/client'
+
+/**
+ * U-04: arma el mapa de nombres amables de entidad por rol, para el toggle
+ * "Operando como…" (ej. { TALLER: 'Taller La Aguja', MARCA: 'Amapola' }).
+ *
+ * Server-only (usa Prisma). Solo consulta para usuarios multi-rol: single-role
+ * no muestra el toggle, así que devuelve {} sin pegarle a la DB.
+ */
+export async function construirEntidadesModo(
+  userId: string,
+  roles: UserRole[]
+): Promise<Partial<Record<UserRole, string>>> {
+  if (!roles || roles.length <= 1) return {}
+
+  const entidades: Partial<Record<UserRole, string>> = {}
+
+  if (roles.includes('TALLER')) {
+    const taller = await prisma.taller.findFirst({
+      where: { userId },
+      select: { nombre: true },
+    })
+    if (taller?.nombre) entidades.TALLER = taller.nombre
+  }
+
+  if (roles.includes('MARCA')) {
+    const marca = await prisma.marca.findFirst({
+      where: { userId },
+      select: { nombre: true },
+    })
+    if (marca?.nombre) entidades.MARCA = marca.nombre
+  }
+
+  return entidades
+}


### PR DESCRIPTION
## U-04: toggle "Operando como…" estilo Airbnb

Cierra el bloque U salvo otorgar 2do rol (U-05) y E2E ampliado (U-08). Habilitado por narrativa V4 §4.4 (diseño de Sergio).

### Qué incluye
- **Endpoint** `PATCH /api/usuarios/me/active-mode` — doble validación: el modo solicitado debe estar en `User.roles[]` **leído de la DB** (autoritativo), nunca se confía en la sesión/cliente. Cambiar de modo no otorga permisos nuevos.
- **Auth** — el callback `jwt` gana una rama `trigger==='update'` para reflejar el cambio sin re-login. Revalida contra `token.roles` (defense-in-depth) y mantiene la invariante `role == activeMode`.
- **UI** — `ModoToggle` en el dropdown del avatar. Visible **solo si `roles.length > 1`** (single-role intacto). Pill "Modo X", acento azul (Taller) / terracotta (Marca) en header y avatar, nombre de la entidad por rol. Al cambiar: redirect al dashboard del nuevo modo + toast.
- **Datos** — seed con 1 user dual-role (TALLER+MARCA, `julieta.benitez@pdt.org.ar` / `pdt2026`) + su Taller y Marca. Helper `construirEntidadesModo`.
- **Limpieza** — 2 casts de `role` en rutas PDF `.tsx` (omitidas por el grep `*.ts` de PR2b) migradas a `modoActivo()` → grep de role inline en `src/app/api` = **0**.

### Tests
- Unit `u-04-active-mode`: válido / modo ∉ roles[] (403) / fallback single-role / sin sesión (401) / body inválido (400).
- Unit `roles-multirol` (+bloque): jwt update válido / ignora modo ∉ roles / ignora update sin activeMode.
- E2E `u-04-toggle-multi-rol`: multi-rol ve toggle / cambia a Marca→/marca y vuelta / persistencia (`/`→/marca) / single-role no ve toggle.

### Decisiones (aprobadas)
Toggle solo si roles>1 · redirect al dashboard del nuevo modo · activeMode persistente DB+JWT · form sucio: se acepta perder estado (navegación explícita) · nombres amables "Modo Taller"/"Modo Marca".

Refs spec `v4-u-04-toggle-multi-rol`, narrativa V4 §4.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)