### PR TITLE
feat: U-09 - flujo agregar segundo rol (TALLER <-> MARCA)

### DIFF
--- a/.claude/specs/v4-u-09-agregar-segundo-rol.md
+++ b/.claude/specs/v4-u-09-agregar-segundo-rol.md
@@ -1,0 +1,228 @@
+# SPEC U-09: Flujo "Agregar segundo rol" (single-rol → multi-rol)
+
+> **Plantilla V4** — Discovery + diseño. NO implementar hasta aprobación de Gerardo.
+> **SECCION 0 es BLOQUEANTE.** **SECCION 13 NO SE MODIFICA** durante implementacion.
+
+---
+
+## 0. Pre-flight checks (BLOQUEANTE)
+
+> Hallazgos reales del repo al 2026-06-05. Re-verificar al arrancar.
+
+### 0.1 Verificacion de dependencias
+- [x] **U-04 mergeado** (`0fcf5b1`) — toggle + endpoint `active-mode` + rama `jwt trigger==='update'`. U-09 reusa la sesión normalizada y el toggle.
+- [x] **U-03 mergeado** — gating por membresía en `roles[]`, primitivas `rolesEfectivos`/`modoActivo`.
+- [x] **U-07 (anti-incesto) presente** — `pedidos/[id]/invitaciones/route.ts:45` compara `taller.user.id === pedido.marca.userId`. **Ya cubre el caso same-user** que U-09 habilita a escala (ver §7/§12).
+- [ ] **Develop actualizado** al arrancar.
+
+### 0.2 Verificacion de schema y datos
+- [x] `User.roles UserRole[] @default([])`, `User.activeMode UserRole?` — existen (U-02).
+- [x] `Taller.cuit String` y `Marca.cuit String` — **NO son `@unique`** (schema:248, 326). Solo `User.cuit` es `@unique` (schema:161, pero el registro no lo setea). ⟹ **el mismo CUIT puede existir en un Taller y una Marca** sin violar constraints (habilita decisión 4).
+- [x] **NO se necesita cambio de schema.** U-09 es el primer flujo que *expande* `roles[]` en runtime.
+
+### 0.3 Discovery de impacto tecnico — resultado (ver §5/§6 para detalle)
+- **Ningún endpoint escribe `roles[]` hoy** (grep en `src/app/api` = 0). U-09 es el primer escritor.
+- El endpoint U-04 `PATCH /api/usuarios/me/active-mode` **solo cambia `activeMode`/`role` y valida contra `roles[]` existente — NO agrega roles.** U-09 necesita un endpoint nuevo.
+- La creación de entidad (Taller/Marca) + verificación CUIT vive **inline y duplicada** en 3 rutas (`registro`, `registro/completar`, parcialmente `verificar-cuit`). Conviene **extraer un helper** reusable.
+
+### 0.4 Hallazgo crítico de datos (arrastrado de U-04)
+Los users single-rol pre-U04 tienen **`roles=[]` en DB** (el callback `jwt` deriva `[activeMode]` al vuelo). ⟹ al agregar el 2do rol **NO se puede hacer `roles: { push: nuevoRol }`** (quedaría `[nuevoRol]`, perdiendo el rol original que vive en `User.role` pero no en `roles[]`). Hay que **setear explícitamente** `roles = rolesEfectivos(user) ∪ {nuevoRol}`.
+
+### 0.5 Reporte pre-flight
+- Sin cambio de schema, sin migración.
+- 1 helper extraído (refactor sin cambio de comportamiento) + 1 endpoint nuevo + 1 sección UI en `/cuenta` (+ link opcional en el ModoToggle).
+- Riesgo principal: normalización de `roles[]` (§0.4) y que el nuevo rol cree una entidad mínima válida (la app asume que el Taller/Marca existe). Mitigaciones en §6/§12.
+
+---
+
+## 1. Metadata
+
+| Campo | Valor |
+|---|---|
+| ID | U-09 |
+| Título | Flujo "Agregar segundo rol" (single → multi-rol) |
+| Bloque | U (multi-rol) — spec NUEVO (no estaba en MASTER_V4; lo pidió Sergio en QA de #397) |
+| Depende de | U-04 (done), U-03 (done), U-02 (done) |
+| Relación | U-05 (migración) va DESPUÉS; U-08 (tests) al final |
+| Estimación | 5–7 h (ver §14) |
+| Estado | DISCOVERY — pendiente aprobación |
+
+---
+
+## 2. Contexto
+
+### Por que existe este spec
+Sergio, en el QA de #397 (U-04): *"Hoy el único modo de que un user tenga 2 roles es vía seed o Prisma Studio manual. Falta el flujo 'agregar segundo rol' para que un user single existente pueda volverse multi-rol."* U-04 dejó el toggle y el cambio de modo, pero **el toggle solo aparece si `roles.length > 1`** — y nada en la app le permite a un single-rol llegar a 2 roles. U-09 cierra ese hueco.
+
+### Que resuelve
+Permite que un usuario **TALLER** sume un perfil de **MARCA** (o viceversa), creando la entidad correspondiente y poblando `roles[]` en DB — el primer caso real de multi-rol generado por el propio usuario, no por seed/manual.
+
+### Documentacion de referencia
+- `.claude/specs/v4-u-04-toggle-multi-rol.md` (toggle + endpoint active-mode + rama jwt update).
+- `.claude/specs/v4-u-03-auth-multirol.md` (membresía, primitivas de roles).
+- `.claude/specs/v4-u-07-anti-incesto.md` (auto-contratación: ya cubre same-user).
+- `src/app/api/auth/registro/completar/route.ts` (patrón analogo casi exacto).
+
+---
+
+## 3. Validacion interdisciplinaria
+- **UX (Sergio)**: la acción debe ser descubrible para un single-rol (que NO ve el toggle). Copy claro: "Sumá tu perfil de Marca" / "Sumá tu perfil de Taller". El usuario debe entender que sigue siendo la misma cuenta.
+- **Seguridad (U-03)**: agregar un rol SÍ otorga permisos nuevos (a diferencia de U-04, que solo elegía entre roles ya poseídos). Por eso U-09 **crea una entidad real verificada por CUIT** — no es un click vacío. El rol agregado se limita a TALLER/MARCA (los de equipo no se auto-asignan).
+- **Producto**: caso real del piloto — emprendedores que son taller y marca a la vez. Anti-incesto (U-07) ya impide que se autocontraten.
+
+---
+
+## 4. Que construir
+
+### Funcionalidades
+1. **Sección "Agregar rol" en `/cuenta`** (Mi cuenta) — visible para single-rol TALLER o MARCA. Muestra el rol que le falta del par y un CTA.
+2. **Mini-formulario** (modal o sub-página): `nombre` de la entidad + `CUIT` (pre-llenado con el CUIT actual, editable). Verificación CUIT contra ARCA, igual que el registro.
+3. Al confirmar: crea la entidad (Taller con sus `validaciones`, o Marca), agrega el rol a `roles[]`, setea `activeMode` al nuevo rol, redirige a su dashboard + toast.
+4. **(Opcional)** link "Agregar otro rol" al pie del dropdown `ModoToggle` (para el que ya es multi-rol y quisiera… aunque con el par TALLER/MARCA completo ya no aplica; ver decisión 3).
+
+### Wireframes o referencias visuales
+No hay mockup. Seguir design-system (cards de `/cuenta`, `Input`, `Button`, tokens `brand-blue`/`terra`). El mini-form replica el paso 2 del wizard de `/registro` pero reducido a nombre + CUIT (como `registro/completar`).
+
+### Consideraciones de lenguaje
+- "Sumá tu perfil de Marca" / "Sumá tu perfil de Taller".
+- Toast: "¡Listo! Ahora también operás como Marca (Nombre)". Redirige a `/marca`.
+- Aclarar bajo el CTA: "Es la misma cuenta. Vas a poder cambiar entre tus perfiles desde el menú."
+
+---
+
+## 5. Datos (schema, modelos, queries)
+
+### Cambios en schema Prisma
+**Ninguno.**
+
+### Migraciones SQL
+**Ninguna.**
+
+### Queries / mutaciones nuevas
+- Leer: `prisma.user.findUnique({ where:{id}, include:{ taller:true, marca:true } })` (chequear qué entidad ya tiene).
+- Crear entidad (helper §6): `taller.create` (+ `validacion.createMany` NO_INICIADO) o `marca.create`, en `$transaction` con el `user.update`.
+- Actualizar user: `user.update({ where:{id}, data:{ roles: nuevosRoles, role: nuevoRol, activeMode: nuevoRol } })` — `nuevosRoles` calculado explícitamente (§0.4).
+
+### Seed o data inicial
+Sin cambios. El user dual-role del seed (Julieta, U-04) sigue sirviendo. Para QA de U-09 conviene un user **single-rol "fresco"** (cualquiera del seed: `roberto.gimenez` TALLER) para sumarle MARCA.
+
+---
+
+## 6. Prescripciones tecnicas
+
+### Refactor previo (sin cambio de comportamiento)
+1. **Extraer helper** `crearEntidadParaRol(tx, { userId, role, nombre, cuit, datosArca? })` en `src/compartido/lib/` (server-only):
+   - Para TALLER: `taller.create` con campos AFIP + `validacion.createMany` de `tipoDocumento` activos en `NO_INICIADO` (replica `registro/route.ts:137-153`).
+   - Para MARCA: `marca.create`.
+   - Recibe la `tx` para componer dentro de una transacción.
+   - **Reusar en `registro/completar`** (y, si conviene sin riesgo, en `registro`) para no duplicar. Si el refactor de `registro` (que es más grande) agrega riesgo, dejarlo y solo compartir con `completar`. **Prudencia > completitud.**
+
+### Archivos a crear
+2. **`src/app/api/usuarios/me/roles/route.ts`** — `POST` (agregar rol).
+   - `apiHandler` + `auth()` + `errorAuthRequired`.
+   - Body `{ role: 'TALLER'|'MARCA', nombre, cuit }` (zod). **Rechazar** cualquier rol fuera de `{TALLER, MARCA}` → 400 (los de equipo no se auto-asignan).
+   - Leer user con `taller`/`marca`. Si **ya tiene** el rol solicitado (entidad existe o `rolesEfectivos(user).includes(role)`) → 409.
+   - Verificar CUIT con `consultarPadron` (arca.ts) — **mismo path que el registro primario** (no `afip.ts`, ver §12 inconsistencia). Si `errorBloqueaRegistro` → 400.
+   - `$transaction([ crearEntidadParaRol(...), user.update({ roles, role, activeMode }) ])` con `roles` calculado explícito (§0.4): `const roles = Array.from(new Set([...rolesEfectivos(user), role]))`.
+   - Responder `{ ok: true, activeMode: role, roles }`.
+3. **UI en `/cuenta`** (`src/app/(public)/cuenta/page.tsx` + componente client nuevo `agregar-rol-card.tsx`):
+   - Server: calcular `rolesEfectivos(session.user)`; si incluye ambos TALLER y MARCA → no mostrar nada. Si single → render del card con el rol faltante.
+   - Client: mini-form (nombre + CUIT pre-llenado), `fetch POST /api/usuarios/me/roles`, en éxito `await update({ activeMode: role })` (rama jwt U-04) → `toast` → `router.push('/'+role.toLowerCase())` + `router.refresh()`.
+
+### Archivos a modificar
+4. `src/app/api/auth/registro/completar/route.ts` — usar el helper extraído (refactor).
+5. **(Opcional)** `src/compartido/componentes/layout/modo-toggle.tsx` — link "Agregar otro rol" al pie (solo si la decisión 3 lo amerita; con el par completo, normalmente no).
+
+### Librerias / convenciones
+- Reusar `consultarPadron`/`DatosArca` (arca.ts), `apiHandler`/`errorResponse` (api-errors), `useToast`, `useSession().update`.
+- Server components por defecto; el card de agregar rol es `'use client'`.
+
+---
+
+## 7. Edge cases
+1. **roles[] vacío (single pre-U04)**: setear `roles` explícito = `rolesEfectivos(user) ∪ {nuevoRol}`, no `push` (§0.4).
+2. **Ya tiene la entidad** (ej. tiene Taller, pide TALLER): 409, sin crear nada.
+3. **CUIT no verificable / ARCA caído**: igual que el registro — modo defensivo (crear sin verificación si ARCA no responde; bloquear solo si el error invalida). Definir copy.
+4. **Mismo CUIT para taller y marca**: permitido (schema no lo bloquea). Es el caso default (misma persona). Pre-llenar editable.
+5. **Anti-incesto (U-07)**: un user taller+marca NO puede invitarse a cotizar su propio pedido — **ya cubierto** por `invitaciones/route.ts:45` (compara `userId`). U-09 no agrega lógica acá; **sí debe testear** que el caso sigue bloqueado (§10).
+6. **Transacción a medias**: si la creación de entidad falla, el `user.update` no se aplica (atomicidad de `$transaction`). El user queda single-rol consistente.
+7. **El nuevo Taller arranca con perfil mínimo**: dashboards/vidriera muestran EmptyState; el perfil se completa después con el wizard existente (`/taller/perfil/editar`). Aceptable (el registro primario también arranca mínimo).
+
+---
+
+## 8. Validacion sectorial
+- **Emprendedor taller+marca** (caso piloto): suma su segundo perfil en < 1 min, queda operativo, y el toggle (U-04) le aparece para alternar. Validar copy con Sergio.
+
+---
+
+## 9. Criterios de aceptacion
+- [ ] Un single-rol TALLER ve en `/cuenta` la opción "Sumá tu perfil de Marca" (y MARCA ve la de Taller). Un multi-rol completo no ve nada.
+- [ ] Al completar el mini-form: se crea la Marca (o Taller+validaciones), `roles[]` queda `['TALLER','MARCA']` en DB, `activeMode` y `role` = nuevo rol.
+- [ ] Tras agregar: redirige al dashboard del nuevo rol, toast de confirmación, y el toggle de U-04 ahora aparece.
+- [ ] El endpoint rechaza: rol fuera de TALLER/MARCA (400), rol ya poseído (409), sin sesión (401), CUIT inválido (400 si bloquea).
+- [ ] La invariante `role == activeMode` se mantiene.
+- [ ] Anti-incesto sigue bloqueando que el user se autocontrate (regresión U-07).
+- [ ] `unit` + `e2e` verdes.
+
+---
+
+## 10. Tests (QAs basados en flujos)
+
+### Flujo 1 (e2e): single → dual
+- Login `roberto.gimenez` (TALLER). En `/cuenta` clic "Sumá tu perfil de Marca" → completar nombre+CUIT → redirige a `/marca`, aparece el toggle, y `/cuenta` ya no ofrece sumar Marca.
+
+### Flujo 2 (unit, endpoint)
+- Agregar MARCA a un TALLER sin marca → 200, `roles` = ['TALLER','MARCA'], entidad creada (mock prisma + tx).
+- Pedir un rol ya poseído → 409, sin crear.
+- Pedir ADMIN/ESTADO → 400.
+- Sin sesión → 401.
+- `roles[]` vacío en DB → resultado normaliza a `[original, nuevo]` (no `[nuevo]`).
+
+### Flujo 3 (unit/regresión): anti-incesto
+- User taller+marca: su marca publica pedido; su taller NO puede ser invitado a cotizar (sigue 400/`No podés invitarte…`).
+
+---
+
+## 11. Impacto en handover
+Documentar en `.claude/specs/handover/`:
+- Primer flujo que expande `roles[]` en runtime; la regla de normalización (§0.4).
+- El helper `crearEntidadParaRol` y qué rutas lo comparten.
+- Que U-09 habilita el caso same-user taller+marca → confirmado compatible con anti-incesto (U-07).
+
+---
+
+## 12. Riesgos y mitigaciones
+
+| Riesgo | Sev. | Mitigación |
+|---|---|---|
+| `push` sobre `roles=[]` pierde el rol original | Alta | Setear `roles` explícito = `rolesEfectivos(user) ∪ {nuevo}`. Test Flujo 2. |
+| Crear rol sin entidad rompe la app (dashboards asumen Taller/Marca) | Alta | El mini-form **crea entidad real** (decisión 1=B); no hay "rol vacío". |
+| Inconsistencia de verificación CUIT (3 paths: arca/afip/verificar-cuit) | Media | U-09 usa `consultarPadron` (arca.ts), el del registro primario. No introducir un 4to path. (Limpieza de los 3 → fuera de alcance, anotar.) |
+| Refactor de `registro` (grande) introduce regresión | Media | Compartir helper solo con `completar` si tocar `registro` agrega riesgo. Prudencia. |
+| Self-dealing al ser taller+marca | Media | **Ya mitigado** por U-07 (`userId` check). Cubrir con test de regresión (Flujo 3). |
+| Agregar rol = escalar permisos sin control | Media | Limitado a TALLER/MARCA + entidad verificada por CUIT. Los roles de equipo no se auto-asignan. |
+
+### Rollback
+Revertir el PR. Sin migración. Un `roles[]` ya expandido queda como dato válido (la app lo soporta desde U-03/04). Para "deshacer" un rol agregado en un user puntual: Prisma Studio.
+
+---
+
+## 13. Selectores criticos (NO MODIFICAR en implementacion)
+- `data-testid="agregar-rol-card"` — card en `/cuenta`.
+- `data-testid="agregar-rol-submit"` — botón de confirmar en el mini-form.
+- Endpoint: `POST /api/usuarios/me/roles`, body `{ role, nombre, cuit }`, respuesta `{ ok, activeMode, roles }`.
+
+---
+
+## 14. Plan de implementacion (incremental, sin big-bang)
+
+1. **Helper** `crearEntidadParaRol` + reuso en `registro/completar` + unit. *(~1.5h)*
+2. **Endpoint** `POST /api/usuarios/me/roles` (validación rol, 409 ya-poseído, CUIT, tx, normalización roles[]) + unit (Flujo 2). *(~2h)*
+3. **UI** card "Agregar rol" en `/cuenta` + mini-form → endpoint → update()+redirect+toast. *(~1.5h)*
+4. **Regresión anti-incesto** + e2e single→dual (Flujo 1, 3). *(~1.5h)*
+5. **QA Sergio** (copy/flujo) + ajustes. *(~0.5h)*
+
+**Dependencias / orden:**
+- Requiere **U-04 (done)** — usa el toggle y la rama `jwt update`.
+- **U-05 (migración) va DESPUÉS**: U-05 probablemente backfilea `roles[]`/`activeMode` de los users existentes en DB. U-09 funciona con o sin U-05 (calcula desde `rolesEfectivos`), pero conviene mergear U-09 antes para que el flujo exista cuando U-05 normalice los datos.
+- **U-08 (tests)** consolida al final.

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,12 @@
 ## 2026-06-07
 
 ### Gerardo Breard
+- **22:22** `4475677` — fix(u-09): refresh de sesion tras agregar segundo rol
+  - `e2e/u-09-agregar-segundo-rol.spec.ts`
+  - `src/__tests__/roles-multirol.test.ts`
+  - `src/compartido/componentes/agregar-rol-card.tsx`
+  - `src/compartido/lib/auth.config.ts`
+
 - **20:32** `4ff917c` — fix(u-09): segunda ronda QA Sergio - replanteo /cuenta + copy + skip CUIT
   - `src/__tests__/u-09-agregar-rol.test.ts`
   - `src/app/(public)/cuenta/page.tsx`

--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,17 @@
 # Daily Log
 
+## 2026-06-07
+
+### Gerardo Breard
+- **16:37** `81451f8` — fix(u-09): QA feedback Sergio - sidebar /cuenta + Pill + copy + CUIT skip
+  - `src/__tests__/u-09-agregar-rol.test.ts`
+  - `src/app/(public)/cuenta/page.tsx`
+  - `src/app/(public)/layout.tsx`
+  - `src/app/api/usuarios/me/roles/route.ts`
+  - `src/compartido/componentes/agregar-rol-card.tsx`
+  - `src/compartido/componentes/layout/header.tsx`
+
+
 ## 2026-06-05
 
 ### Gerardo Breard

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,20 @@
 ## 2026-06-05
 
 ### Gerardo Breard
+- **17:57** `847e1ca` — feat(u-09): flujo agregar segundo rol (TALLER <-> MARCA)
+  - `.claude/specs/v4-u-09-agregar-segundo-rol.md`
+  - `e2e/helpers/auth.ts`
+  - `e2e/u-09-agregar-segundo-rol.spec.ts`
+  - `prisma/seed.ts`
+  - `src/__tests__/crear-entidad-rol.test.ts`
+  - `src/__tests__/u-09-agregar-rol.test.ts`
+  - `src/__tests__/u-09-anti-incesto-regresion.test.ts`
+  - `src/app/(public)/cuenta/page.tsx`
+  - `src/app/api/auth/registro/completar/route.ts`
+  - `src/app/api/usuarios/me/roles/route.ts`
+  - `src/compartido/componentes/agregar-rol-card.tsx`
+  - `src/compartido/lib/crear-entidad-rol.ts`
+
 - **14:41** `233e155` — feat(u-04): toggle UI multi-rol estilo Airbnb
   - `.claude/specs/v4-u-04-toggle-multi-rol.md`
   - `e2e/helpers/auth.ts`

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-06-08
 
 ### Gerardo Breard
+- **10:28** `e86102f` — Merge remote-tracking branch 'origin/develop' into feature/u-09-agregar-segundo-rol
+
+
 - **00:26** `c09e67f` — docs: spec Narrativa V4 Etapa 1 (§1.1+§1.2) + nueva deuda T-03
   - `.claude/DEUDA_TECNICA.md`
   - `.claude/specs/v4-narrativa-etapa-1.md`

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-06-07
 
 ### Gerardo Breard
+- **23:11** `e0a8fc7` — ci: re-trigger unit+e2e tras recuperarse Actions
+
+
 - **22:22** `4475677` — fix(u-09): refresh de sesion tras agregar segundo rol
   - `e2e/u-09-agregar-segundo-rol.spec.ts`
   - `src/__tests__/roles-multirol.test.ts`

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,13 @@
 ## 2026-06-07
 
 ### Gerardo Breard
+- **20:32** `4ff917c` — fix(u-09): segunda ronda QA Sergio - replanteo /cuenta + copy + skip CUIT
+  - `src/__tests__/u-09-agregar-rol.test.ts`
+  - `src/app/(public)/cuenta/page.tsx`
+  - `src/app/(public)/layout.tsx`
+  - `src/app/api/usuarios/me/roles/route.ts`
+  - `src/compartido/componentes/layout/user-sidebar.tsx`
+
 - **16:37** `81451f8` — fix(u-09): QA feedback Sergio - sidebar /cuenta + Pill + copy + CUIT skip
   - `src/__tests__/u-09-agregar-rol.test.ts`
   - `src/app/(public)/cuenta/page.tsx`

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,6 +1,6 @@
 import { Page, expect } from '@playwright/test'
 
-export async function loginAs(page: Page, role: 'admin' | 'taller_bronce' | 'taller_oro' | 'marca' | 'estado' | 'contenido' | 'dual') {
+export async function loginAs(page: Page, role: 'admin' | 'taller_bronce' | 'taller_oro' | 'marca' | 'estado' | 'contenido' | 'dual' | 'u09') {
   const credentials = {
     admin: { email: 'lucia.fernandez@pdt.org.ar', password: 'pdt2026' },
     taller_bronce: { email: 'roberto.gimenez@pdt.org.ar', password: 'pdt2026' },
@@ -10,6 +10,8 @@ export async function loginAs(page: Page, role: 'admin' | 'taller_bronce' | 'tal
     contenido: { email: 'sofia.martinez@pdt.org.ar', password: 'pdt2026' },
     // U-04: usuario multi-rol (TALLER + MARCA) para el toggle "Operando como…".
     dual: { email: 'julieta.benitez@pdt.org.ar', password: 'pdt2026' },
+    // U-09: single-rol TALLER dedicado al e2e de "agregar segundo rol".
+    u09: { email: 'u09.test@pdt.org.ar', password: 'pdt2026' },
   }
   const { email, password } = credentials[role]
 

--- a/e2e/u-09-agregar-segundo-rol.spec.ts
+++ b/e2e/u-09-agregar-segundo-rol.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test'
+import { loginAs } from './helpers/auth'
+
+// U-09: un single-rol (Tomás U09, solo TALLER) suma su perfil de MARCA desde
+// /cuenta y queda multi-rol (aparece el toggle de U-04). Usuario dedicado para
+// no contaminar a otros tests al mutar sus roles. ARCA corre en modo mock en CI.
+
+async function abrirMenuUsuario(page: import('@playwright/test').Page) {
+  await page.getByRole('button', { name: 'Menú de usuario' }).click()
+}
+
+test('single-rol ve la card "Agregar rol" en /cuenta y crea su perfil de Marca', async ({ page }) => {
+  await loginAs(page, 'u09')
+
+  // Single-rol: el toggle de U-04 todavía NO aparece.
+  await abrirMenuUsuario(page)
+  await expect(page.getByTestId('modo-toggle')).toHaveCount(0)
+  await page.keyboard.press('Escape')
+
+  // En /cuenta aparece la card de agregar rol (le falta MARCA).
+  await page.goto('/cuenta')
+  const card = page.getByTestId('agregar-rol-card')
+  await expect(card).toBeVisible()
+
+  // Completar nombre + CUIT (el CUIT viene pre-cargado; lo dejamos) y enviar.
+  await page.getByLabel('Nombre de la marca').fill('Marca de Tomás')
+  await page.getByTestId('agregar-rol-submit').click()
+
+  // Redirige al dashboard de Marca.
+  await expect(page).toHaveURL(/\/marca/, { timeout: 20000 })
+
+  // Ahora es multi-rol: el toggle SÍ aparece y /cuenta ya no ofrece sumar rol.
+  await abrirMenuUsuario(page)
+  await expect(page.getByTestId('modo-toggle')).toBeVisible()
+  await expect(page.getByTestId('modo-toggle-option-TALLER')).toBeVisible()
+  await expect(page.getByTestId('modo-toggle-option-MARCA')).toBeVisible()
+  await page.keyboard.press('Escape')
+
+  await page.goto('/cuenta')
+  await expect(page.getByTestId('agregar-rol-card')).toHaveCount(0)
+})

--- a/e2e/u-09-agregar-segundo-rol.spec.ts
+++ b/e2e/u-09-agregar-segundo-rol.spec.ts
@@ -29,12 +29,24 @@ test('single-rol ve la card "Agregar rol" en /cuenta y crea su perfil de Marca',
   // Redirige al dashboard de Marca.
   await expect(page).toHaveURL(/\/marca/, { timeout: 20000 })
 
+  // QA #398 r3 — el redirect anterior es client-side (URL optimista). Forzamos una
+  // navegación DURA a /marca: el middleware re-evalúa la cookie/JWT real. Si la
+  // sesión NO se refrescó (bug), el JWT sigue single-rol TALLER y el middleware manda
+  // a /unauthorized. Esto es lo que NO atrapaba el chequeo de URL optimista.
+  await page.goto('/marca')
+  await expect(page).toHaveURL(/\/marca/)
+  await expect(page).not.toHaveURL(/unauthorized/)
+
   // Ahora es multi-rol: el toggle SÍ aparece y /cuenta ya no ofrece sumar rol.
   await abrirMenuUsuario(page)
   await expect(page.getByTestId('modo-toggle')).toBeVisible()
   await expect(page.getByTestId('modo-toggle-option-TALLER')).toBeVisible()
   await expect(page.getByTestId('modo-toggle-option-MARCA')).toBeVisible()
-  await page.keyboard.press('Escape')
+
+  // El cambio de modo de vuelta a Taller también funciona (la sesión tiene ambos).
+  await page.getByTestId('modo-toggle-option-TALLER').click()
+  await expect(page).toHaveURL(/\/taller/)
+  await expect(page).not.toHaveURL(/unauthorized/)
 
   await page.goto('/cuenta')
   await expect(page.getByTestId('agregar-rol-card')).toHaveCount(0)

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -112,7 +112,29 @@ async function main() {
     },
   })
 
-  console.log('  ✓ 9 usuarios creados (incl. CONTENIDO + multi-rol)')
+  // U-09: usuario single-rol TALLER dedicado al e2e de "agregar segundo rol".
+  // Aislado para que el test pueda convertirlo a multi-rol sin pisar a otros users.
+  await prisma.user.create({
+    data: {
+      email: 'u09.test@pdt.org.ar',
+      password: hash,
+      name: 'Tomás U09',
+      role: 'TALLER',
+      phone: '+5491109090909',
+      active: true,
+      taller: {
+        create: {
+          nombre: 'Taller U09',
+          cuit: '20-40404040-4',
+          nivel: 'BRONCE',
+          ubicacion: 'Quilmes, Buenos Aires',
+          verificadoAfip: true,
+        },
+      },
+    },
+  })
+
+  console.log('  ✓ 10 usuarios creados (incl. CONTENIDO + multi-rol + e2e U-09)')
 
   // ============================================
   // PROCESOS PRODUCTIVOS (5)

--- a/src/__tests__/crear-entidad-rol.test.ts
+++ b/src/__tests__/crear-entidad-rol.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { crearEntidadParaRol } from '@/compartido/lib/crear-entidad-rol'
+import type { Prisma } from '@prisma/client'
+
+// U-09: helper de creación de entidad por rol, dentro de una transacción.
+
+function txMock() {
+  return {
+    taller: { create: vi.fn().mockResolvedValue({ id: 't1' }) },
+    marca: { create: vi.fn().mockResolvedValue({ id: 'm1' }) },
+    tipoDocumento: {
+      findMany: vi.fn().mockResolvedValue([
+        { id: 'td1', nombre: 'CUIT/Monotributo' },
+        { id: 'td2', nombre: 'ART' },
+      ]),
+    },
+    validacion: { createMany: vi.fn().mockResolvedValue({ count: 2 }) },
+  }
+}
+
+let tx: ReturnType<typeof txMock>
+beforeEach(() => {
+  tx = txMock()
+})
+
+describe('crearEntidadParaRol', () => {
+  it('TALLER: crea el taller + las validaciones NO_INICIADO de los tipos activos', async () => {
+    const res = await crearEntidadParaRol(tx as unknown as Prisma.TransactionClient, {
+      userId: 'u1',
+      rol: 'TALLER',
+      nombre: 'Taller La Hormiga',
+      cuit: '20-12345678-9',
+      verificadoAfip: true,
+    })
+    expect(res).toEqual({ id: 't1' })
+    expect(tx.taller.create).toHaveBeenCalled()
+    expect(tx.validacion.createMany).toHaveBeenCalledWith({
+      data: [
+        { tallerId: 't1', tipo: 'CUIT/Monotributo', tipoDocumentoId: 'td1', estado: 'NO_INICIADO' },
+        { tallerId: 't1', tipo: 'ART', tipoDocumentoId: 'td2', estado: 'NO_INICIADO' },
+      ],
+    })
+    expect(tx.marca.create).not.toHaveBeenCalled()
+  })
+
+  it('MARCA: crea la marca y NO crea validaciones', async () => {
+    const res = await crearEntidadParaRol(tx as unknown as Prisma.TransactionClient, {
+      userId: 'u1',
+      rol: 'MARCA',
+      nombre: 'Mi Marca',
+      cuit: '27-99999999-1',
+    })
+    expect(res).toEqual({ id: 'm1' })
+    expect(tx.marca.create).toHaveBeenCalled()
+    expect(tx.taller.create).not.toHaveBeenCalled()
+    expect(tx.validacion.createMany).not.toHaveBeenCalled()
+  })
+
+  it('rol no soportado lanza error', async () => {
+    await expect(
+      crearEntidadParaRol(tx as unknown as Prisma.TransactionClient, {
+        userId: 'u1',
+        // @ts-expect-error: probamos un rol fuera de TALLER/MARCA
+        rol: 'ADMIN',
+        nombre: 'X',
+        cuit: '20-1-9',
+      })
+    ).rejects.toThrow(/rol no soportado/)
+  })
+})

--- a/src/__tests__/roles-multirol.test.ts
+++ b/src/__tests__/roles-multirol.test.ts
@@ -145,4 +145,30 @@ describe('auth.config.ts — jwt trigger==="update" (U-04, cambio de modo)', () 
     expect(token.activeMode).toBe('MARCA')
     expect(token.role).toBe('MARCA')
   })
+
+  // U-09 (QA #398 r3): al agregar un 2º rol, el cliente reenvía el roles[] que
+  // devolvió el endpoint. El callback expande el JWT (sin esto el middleware ve un
+  // token single-rol viejo y manda a /unauthorized).
+  it('U-09: update con roles[] operativos EXPANDE el token y aplica el nuevo activeMode', async () => {
+    const token = await callUpdate(
+      { id: 'u1', role: 'TALLER', roles: ['TALLER'], activeMode: 'TALLER' },
+      { activeMode: 'MARCA', roles: ['TALLER', 'MARCA'] }
+    )
+    expect(token.roles).toEqual(['TALLER', 'MARCA'])
+    expect(token.activeMode).toBe('MARCA')
+    // INVARIANTE role == activeMode
+    expect(token.role).toBe('MARCA')
+  })
+
+  it('U-09: NO escala a un team role aunque venga en roles[] del input (anti-escalación)', async () => {
+    const token = await callUpdate(
+      { id: 'u2', role: 'TALLER', roles: ['TALLER'], activeMode: 'TALLER' },
+      { activeMode: 'ADMIN', roles: ['TALLER', 'ADMIN'] }
+    )
+    // ADMIN se filtra (no es operativo) → no entra al token …
+    expect(token.roles).toEqual(['TALLER'])
+    // … y el activeMode pedido se rechaza porque no pertenece a los roles del token.
+    expect(token.activeMode).toBe('TALLER')
+    expect(token.role).toBe('TALLER')
+  })
 })

--- a/src/__tests__/u-09-agregar-rol.test.ts
+++ b/src/__tests__/u-09-agregar-rol.test.ts
@@ -86,11 +86,11 @@ describe('POST /api/usuarios/me/roles', () => {
     expect(arg.data.roles.set).toEqual(['TALLER', 'MARCA'])
   })
 
-  it('D: CUIT coincide con el del Taller existente → 200 SIN llamar a ARCA', async () => {
-    // Mismo CUIT que su Taller ya verificado → se omite consultarPadron (cache-like).
+  it('D: CUIT coincide con un Taller VERIFICADO → 200 SIN llamar a ARCA', async () => {
+    // Mismo CUIT que su Taller verificadoAfip=true → se omite consultarPadron (cache-like).
     mockUserFind.mockResolvedValue({
       id: 'u1', roles: ['TALLER'], role: 'TALLER',
-      taller: { id: 't1', cuit: '20123456789' }, marca: null,
+      taller: { id: 't1', cuit: '20123456789', verificadoAfip: true }, marca: null,
     })
     mockCrear.mockResolvedValue({ id: 'marca-1' })
 
@@ -104,10 +104,25 @@ describe('POST /api/usuarios/me/roles', () => {
     expect(crearArgs.datosArca).toBeUndefined()
   })
 
+  it('D (caso martin): CUIT coincide pero la entidad NO está verificada → SÍ llama a ARCA', async () => {
+    // Fidedigno a martin.echevarria: marca con cuit presente pero verificadoAfip=false.
+    // El CUIT nunca fue verificado → no se skipea, se manda a ARCA como corresponde.
+    mockUserFind.mockResolvedValue({
+      id: 'u1', roles: ['MARCA'], role: 'MARCA',
+      taller: null, marca: { id: 'm1', cuit: '30718902345', verificadoAfip: false },
+    })
+    mockCrear.mockResolvedValue({ id: 'taller-1' })
+
+    const res = await post({ rol: 'TALLER', nombre: 'Mi Taller', cuit: '30-71890234-5' })
+    expect(res.status).toBe(200)
+    expect(mockPadron).toHaveBeenCalledTimes(1)
+    expect(mockPadron).toHaveBeenCalledWith('30-71890234-5')
+  })
+
   it('D: CUIT difiere del verificado → 200 LLAMANDO a ARCA como antes', async () => {
     mockUserFind.mockResolvedValue({
       id: 'u1', roles: ['TALLER'], role: 'TALLER',
-      taller: { id: 't1', cuit: '20123456789' }, marca: null,
+      taller: { id: 't1', cuit: '20123456789', verificadoAfip: true }, marca: null,
     })
     mockCrear.mockResolvedValue({ id: 'marca-1' })
 

--- a/src/__tests__/u-09-agregar-rol.test.ts
+++ b/src/__tests__/u-09-agregar-rol.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// U-09: endpoint POST /api/usuarios/me/roles. Agrega un 2do rol (TALLER⇄MARCA),
+// crea la entidad y expande roles[] de forma explícita (rolesEfectivos ∪ {nuevo}),
+// manteniendo role == activeMode. La creación de entidad se mockea (helper aparte).
+
+vi.mock('@/compartido/lib/auth', () => ({ auth: vi.fn() }))
+vi.mock('@/compartido/lib/prisma', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}))
+vi.mock('@/compartido/lib/crear-entidad-rol', () => ({
+  crearEntidadParaRol: vi.fn(),
+}))
+vi.mock('@/compartido/lib/arca', () => ({
+  consultarPadron: vi.fn(),
+  errorBloqueaRegistro: vi.fn(),
+  mensajeErrorArca: vi.fn().mockReturnValue('CUIT invalido'),
+}))
+vi.mock('@/compartido/lib/log', () => ({ logActividad: vi.fn() }))
+
+import { auth } from '@/compartido/lib/auth'
+import { prisma } from '@/compartido/lib/prisma'
+import { crearEntidadParaRol } from '@/compartido/lib/crear-entidad-rol'
+import { consultarPadron, errorBloqueaRegistro } from '@/compartido/lib/arca'
+import { POST } from '@/app/api/usuarios/me/roles/route'
+
+const mockAuth = auth as ReturnType<typeof vi.fn>
+const mockUserFind = prisma.user.findUnique as ReturnType<typeof vi.fn>
+const mockTx = prisma.$transaction as ReturnType<typeof vi.fn>
+const mockCrear = crearEntidadParaRol as ReturnType<typeof vi.fn>
+const mockPadron = consultarPadron as ReturnType<typeof vi.fn>
+const mockBloquea = errorBloqueaRegistro as ReturnType<typeof vi.fn>
+
+const txUserUpdate = vi.fn()
+
+const post = (body?: unknown) =>
+  POST(
+    new NextRequest('http://localhost/api/usuarios/me/roles', {
+      method: 'POST',
+      body: body === undefined ? undefined : JSON.stringify(body),
+    }) as NextRequest,
+    {} as never
+  )
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockAuth.mockResolvedValue({ user: { id: 'u1' } })
+  // $transaction(cb) ejecuta el callback con un tx que expone user.update
+  mockTx.mockImplementation(async (cb: (tx: unknown) => unknown) =>
+    cb({ user: { update: txUserUpdate } })
+  )
+  mockPadron.mockResolvedValue({ exitosa: true, datos: { nombre: 'X', cuit: '20-1-2' } })
+  mockBloquea.mockReturnValue(false)
+})
+
+describe('POST /api/usuarios/me/roles', () => {
+  it('agrega MARCA a un TALLER (200) y expande roles[] = [TALLER, MARCA]', async () => {
+    mockUserFind.mockResolvedValue({ id: 'u1', roles: [], role: 'TALLER', taller: { id: 't1' }, marca: null })
+    mockCrear.mockResolvedValue({ id: 'marca-1' })
+
+    const res = await post({ rol: 'MARCA', nombre: 'Mi Marca', cuit: '20-12345678-9' })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      rol: 'MARCA',
+      entidadId: 'marca-1',
+      roles: ['TALLER', 'MARCA'],
+      activeMode: 'MARCA',
+    })
+    expect(mockCrear).toHaveBeenCalled()
+    // Unión explícita + invariante role == activeMode
+    expect(txUserUpdate).toHaveBeenCalledWith({
+      where: { id: 'u1' },
+      data: { roles: { set: ['TALLER', 'MARCA'] }, activeMode: 'MARCA', role: 'MARCA' },
+    })
+  })
+
+  it('normalización: user con roles=[] en DB termina en [TALLER, MARCA], no [MARCA]', async () => {
+    mockUserFind.mockResolvedValue({ id: 'u1', roles: [], role: 'TALLER', taller: { id: 't1' }, marca: null })
+    mockCrear.mockResolvedValue({ id: 'marca-1' })
+    await post({ rol: 'MARCA', nombre: 'Mi Marca', cuit: '20-1-9' })
+    const arg = txUserUpdate.mock.calls[0][0]
+    expect(arg.data.roles.set).toEqual(['TALLER', 'MARCA'])
+  })
+
+  it('rol ya poseído → 409, sin crear entidad', async () => {
+    mockUserFind.mockResolvedValue({ id: 'u1', roles: ['TALLER'], role: 'TALLER', taller: { id: 't1' }, marca: null })
+    const res = await post({ rol: 'TALLER', nombre: 'Otro', cuit: '20-1-9' })
+    expect(res.status).toBe(409)
+    expect(mockCrear).not.toHaveBeenCalled()
+  })
+
+  it('rol administrativo (ADMIN) → 400, sin tocar la DB', async () => {
+    const res = await post({ rol: 'ADMIN', nombre: 'X', cuit: '20-1-9' })
+    expect(res.status).toBe(400)
+    expect(mockUserFind).not.toHaveBeenCalled()
+  })
+
+  it('CUIT inválido (ARCA bloquea) → 400, sin crear entidad', async () => {
+    mockUserFind.mockResolvedValue({ id: 'u1', roles: [], role: 'TALLER', taller: { id: 't1' }, marca: null })
+    mockPadron.mockResolvedValue({ exitosa: false, error: 'CUIT_INEXISTENTE' })
+    mockBloquea.mockReturnValue(true)
+    const res = await post({ rol: 'MARCA', nombre: 'Mi Marca', cuit: '99-99999999-9' })
+    expect(res.status).toBe(400)
+    expect(mockCrear).not.toHaveBeenCalled()
+  })
+
+  it('sin sesión → 401', async () => {
+    mockAuth.mockResolvedValue(null)
+    const res = await post({ rol: 'MARCA', nombre: 'Mi Marca', cuit: '20-1-9' })
+    expect(res.status).toBe(401)
+    expect(mockUserFind).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/u-09-agregar-rol.test.ts
+++ b/src/__tests__/u-09-agregar-rol.test.ts
@@ -86,6 +86,37 @@ describe('POST /api/usuarios/me/roles', () => {
     expect(arg.data.roles.set).toEqual(['TALLER', 'MARCA'])
   })
 
+  it('D: CUIT coincide con el del Taller existente → 200 SIN llamar a ARCA', async () => {
+    // Mismo CUIT que su Taller ya verificado → se omite consultarPadron (cache-like).
+    mockUserFind.mockResolvedValue({
+      id: 'u1', roles: ['TALLER'], role: 'TALLER',
+      taller: { id: 't1', cuit: '20123456789' }, marca: null,
+    })
+    mockCrear.mockResolvedValue({ id: 'marca-1' })
+
+    const res = await post({ rol: 'MARCA', nombre: 'Mi Marca', cuit: '20-12345678-9' })
+    expect(res.status).toBe(200)
+    expect(mockPadron).not.toHaveBeenCalled()
+    expect(mockCrear).toHaveBeenCalled()
+    // Se creó igual con verificadoAfip asumido (sin datosArca de ARCA).
+    const crearArgs = mockCrear.mock.calls[0][1]
+    expect(crearArgs.verificadoAfip).toBe(true)
+    expect(crearArgs.datosArca).toBeUndefined()
+  })
+
+  it('D: CUIT difiere del verificado → 200 LLAMANDO a ARCA como antes', async () => {
+    mockUserFind.mockResolvedValue({
+      id: 'u1', roles: ['TALLER'], role: 'TALLER',
+      taller: { id: 't1', cuit: '20123456789' }, marca: null,
+    })
+    mockCrear.mockResolvedValue({ id: 'marca-1' })
+
+    const res = await post({ rol: 'MARCA', nombre: 'Mi Marca', cuit: '27-99999999-3' })
+    expect(res.status).toBe(200)
+    expect(mockPadron).toHaveBeenCalledTimes(1)
+    expect(mockPadron).toHaveBeenCalledWith('27-99999999-3')
+  })
+
   it('rol ya poseído → 409, sin crear entidad', async () => {
     mockUserFind.mockResolvedValue({ id: 'u1', roles: ['TALLER'], role: 'TALLER', taller: { id: 't1' }, marca: null })
     const res = await post({ rol: 'TALLER', nombre: 'Otro', cuit: '20-1-9' })

--- a/src/__tests__/u-09-anti-incesto-regresion.test.ts
+++ b/src/__tests__/u-09-anti-incesto-regresion.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// U-09 (regresión U-07): U-09 hace ALCANZABLE el caso de un user que es taller Y
+// marca a la vez. El guard anti-incesto en /pedidos/[id]/invitaciones (sin tocar)
+// debe seguir bloqueando que se invite a su propio taller a cotizar su propio pedido.
+
+vi.mock('@/compartido/lib/auth', () => ({ auth: vi.fn() }))
+vi.mock('@/compartido/lib/prisma', () => ({
+  prisma: {
+    pedido: { findUnique: vi.fn() },
+    taller: { findMany: vi.fn() },
+  },
+}))
+vi.mock('@/compartido/lib/email', () => ({
+  sendEmail: vi.fn(),
+  buildInvitacionCotizarEmail: vi.fn().mockReturnValue({ subject: 'S', html: 'H' }),
+}))
+
+import { auth } from '@/compartido/lib/auth'
+import { prisma } from '@/compartido/lib/prisma'
+import { POST } from '@/app/api/pedidos/[id]/invitaciones/route'
+
+const mockAuth = auth as ReturnType<typeof vi.fn>
+const mockPedidoFind = prisma.pedido.findUnique as ReturnType<typeof vi.fn>
+const mockTallerFind = prisma.taller.findMany as ReturnType<typeof vi.fn>
+
+const ctx = (id = 'p1') => ({ params: Promise.resolve({ id }) })
+const req = (tallerIds: string[]) =>
+  new NextRequest('http://localhost/api/pedidos/p1/invitaciones', {
+    method: 'POST',
+    body: JSON.stringify({ tallerIds }),
+  }) as NextRequest
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('anti-incesto sigue bloqueando al user multi-rol (taller propio)', () => {
+  it('invitar al taller propio a cotizar el propio pedido → 400', async () => {
+    // Mismo user dueño de la marca del pedido y del taller invitado.
+    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'MARCA', activeMode: 'MARCA' } })
+    mockPedidoFind.mockResolvedValue({ estado: 'BORRADOR', marca: { userId: 'u1', nombre: 'Mi Marca' } })
+    mockTallerFind.mockResolvedValue([
+      { id: 't1', nombre: 'Mi Taller', verificadoAfip: true, user: { id: 'u1', email: 'u1@x.com' } },
+    ])
+
+    const res = await POST(req(['t1']), ctx())
+    expect(res.status).toBe(400)
+    const data = await res.json()
+    expect(data.error).toMatch(/no podés invitarte a vos mismo/i)
+  })
+})

--- a/src/app/(public)/cuenta/page.tsx
+++ b/src/app/(public)/cuenta/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { auth } from '@/compartido/lib/auth'
 import { prisma } from '@/compartido/lib/prisma'
+import { rolesEfectivos } from '@/compartido/lib/roles'
 import { Bell, User, ShieldCheck } from 'lucide-react'
 import { CuentaWhatsappForm } from '@/compartido/componentes/cuenta-whatsapp-form'
 import { AgregarRolCard } from '@/compartido/componentes/agregar-rol-card'
@@ -23,6 +24,8 @@ export default async function CuentaPage() {
       name: true,
       phone: true,
       role: true,
+      roles: true,
+      activeMode: true,
       createdAt: true,
       notificacionesWhatsapp: true,
       notificacionesRecibidas: { where: { leida: false }, select: { id: true } },
@@ -43,6 +46,12 @@ export default async function CuentaPage() {
     taller && !marca ? 'MARCA' : marca && !taller ? 'TALLER' : null
   const cuitActual = taller?.cuit ?? marca?.cuit ?? null
 
+  // BUG C (QA #398): "Rol: X" (singular) engañaba a un multi-rol. El rol activo
+  // es user.role (== activeMode por invariante); los demás roles efectivos son "otros".
+  const rolesEfec = rolesEfectivos({ roles: user.roles, role: user.role })
+  const otrosRoles = rolesEfec.filter((r) => r !== user.role)
+  const esMultiRol = rolesEfec.length > 1
+
   return (
     <div className="space-y-6">
       <h1 className="font-overpass font-bold text-3xl text-brand-blue">Mi cuenta</h1>
@@ -53,7 +62,11 @@ export default async function CuentaPage() {
           <p><span className="text-gray-500">Nombre:</span> <span className="font-medium text-gray-800">{user.name || 'Sin nombre'}</span></p>
           <p><span className="text-gray-500">Email:</span> <span className="font-medium text-gray-800">{user.email}</span></p>
           <p><span className="text-gray-500">Telefono:</span> <span className="font-medium text-gray-800">{user.phone || '-'}</span></p>
-          <p><span className="text-gray-500">Rol:</span> <span className="font-medium text-gray-800">{user.role}</span></p>
+          {esMultiRol ? (
+            <p><span className="text-gray-500">Rol activo:</span> <span className="font-medium text-gray-800">{user.role}</span> <span className="text-gray-500">· Otros roles:</span> <span className="font-medium text-gray-800">{otrosRoles.join(', ')}</span></p>
+          ) : (
+            <p><span className="text-gray-500">Rol:</span> <span className="font-medium text-gray-800">{user.role}</span></p>
+          )}
           <p><span className="text-gray-500">Alta:</span> <span className="font-medium text-gray-800">{new Date(user.createdAt).toLocaleDateString('es-AR')}</span></p>
           <p><span className="text-gray-500">No leidas:</span> <span className="font-medium text-gray-800">{user.notificacionesRecibidas.length}</span></p>
         </div>

--- a/src/app/(public)/cuenta/page.tsx
+++ b/src/app/(public)/cuenta/page.tsx
@@ -5,7 +5,7 @@ import { redirect } from 'next/navigation'
 import { auth } from '@/compartido/lib/auth'
 import { prisma } from '@/compartido/lib/prisma'
 import { rolesEfectivos } from '@/compartido/lib/roles'
-import { Bell, User, ShieldCheck } from 'lucide-react'
+import { Bell, User, ShieldCheck, Building2, ShoppingBag, ArrowRight } from 'lucide-react'
 import { CuentaWhatsappForm } from '@/compartido/componentes/cuenta-whatsapp-form'
 import { AgregarRolCard } from '@/compartido/componentes/agregar-rol-card'
 
@@ -36,41 +36,83 @@ export default async function CuentaPage() {
     redirect('/login')
   }
 
+  // Perfiles operativos del USUARIO (puede tener 1 o 2). /cuenta es del user, no del
+  // rol activo: mostramos TODOS sus perfiles, sea cual sea el activeMode.
+  const [taller, marca] = await Promise.all([
+    prisma.taller.findFirst({ where: { userId: user.id }, select: { cuit: true, nombre: true, puntaje: true } }),
+    prisma.marca.findFirst({ where: { userId: user.id }, select: { cuit: true, nombre: true } }),
+  ])
+
   // U-09: ofrecer "agregar segundo rol" solo a un single user-rol (tiene exactamente
   // una de las dos entidades). El CUIT existente pre-llena el formulario.
-  const [taller, marca] = await Promise.all([
-    prisma.taller.findFirst({ where: { userId: user.id }, select: { cuit: true } }),
-    prisma.marca.findFirst({ where: { userId: user.id }, select: { cuit: true } }),
-  ])
   const rolFaltante: 'TALLER' | 'MARCA' | null =
     taller && !marca ? 'MARCA' : marca && !taller ? 'TALLER' : null
   const cuitActual = taller?.cuit ?? marca?.cuit ?? null
 
-  // BUG C (QA #398): "Rol: X" (singular) engañaba a un multi-rol. El rol activo
-  // es user.role (== activeMode por invariante); los demás roles efectivos son "otros".
+  // FIX C (QA #398 r2): "Roles: lista" + "Rol activo: X" en líneas separadas para
+  // multi-rol; "Rol: X" (singular) para single-rol. El rol activo es user.role
+  // (== activeMode por invariante).
   const rolesEfec = rolesEfectivos({ roles: user.roles, role: user.role })
-  const otrosRoles = rolesEfec.filter((r) => r !== user.role)
   const esMultiRol = rolesEfec.length > 1
+
+  // ¿Es un rol operativo (TALLER/MARCA) con perfiles, o un rol de equipo sin perfiles?
+  const tienePerfilesOperativos = Boolean(taller || marca)
 
   return (
     <div className="space-y-6">
       <h1 className="font-overpass font-bold text-3xl text-brand-blue">Mi cuenta</h1>
 
       <section className="rounded-xl border border-gray-200 bg-white p-6">
-        <h2 className="font-overpass font-bold text-lg text-brand-blue mb-4">Resumen</h2>
+        <h2 className="font-overpass font-bold text-lg text-brand-blue mb-4">Datos personales</h2>
         <div className="grid gap-3 sm:grid-cols-2 text-sm">
           <p><span className="text-gray-500">Nombre:</span> <span className="font-medium text-gray-800">{user.name || 'Sin nombre'}</span></p>
           <p><span className="text-gray-500">Email:</span> <span className="font-medium text-gray-800">{user.email}</span></p>
           <p><span className="text-gray-500">Telefono:</span> <span className="font-medium text-gray-800">{user.phone || '-'}</span></p>
+          <p><span className="text-gray-500">Alta:</span> <span className="font-medium text-gray-800">{new Date(user.createdAt).toLocaleDateString('es-AR')}</span></p>
           {esMultiRol ? (
-            <p><span className="text-gray-500">Rol activo:</span> <span className="font-medium text-gray-800">{user.role}</span> <span className="text-gray-500">· Otros roles:</span> <span className="font-medium text-gray-800">{otrosRoles.join(', ')}</span></p>
+            <>
+              <p><span className="text-gray-500">Roles:</span> <span className="font-medium text-gray-800">{rolesEfec.join(', ')}</span></p>
+              <p><span className="text-gray-500">Rol activo:</span> <span className="font-medium text-gray-800">{user.role}</span></p>
+            </>
           ) : (
             <p><span className="text-gray-500">Rol:</span> <span className="font-medium text-gray-800">{user.role}</span></p>
           )}
-          <p><span className="text-gray-500">Alta:</span> <span className="font-medium text-gray-800">{new Date(user.createdAt).toLocaleDateString('es-AR')}</span></p>
-          <p><span className="text-gray-500">No leidas:</span> <span className="font-medium text-gray-800">{user.notificacionesRecibidas.length}</span></p>
         </div>
       </section>
+
+      {/* Tus perfiles activos: cards de Taller/Marca con link a su área. Solo para
+          roles operativos; los roles de equipo (ADMIN/ESTADO/CONTENIDO) no tienen. */}
+      {tienePerfilesOperativos && (
+        <section className="rounded-xl border border-gray-200 bg-white p-6">
+          <h2 className="font-overpass font-bold text-lg text-brand-blue mb-4">Tus perfiles</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {taller && (
+              <div className="rounded-lg border border-gray-200 p-4 flex flex-col gap-2">
+                <div className="flex items-center gap-2">
+                  <Building2 className="w-5 h-5 text-brand-blue" />
+                  <h3 className="font-overpass font-semibold text-gray-800 truncate">{taller.nombre}</h3>
+                </div>
+                <p className="text-sm text-gray-500">Formalización: <span className="font-medium text-gray-700">{taller.puntaje ?? 0}%</span></p>
+                <Link href="/taller" className="mt-1 inline-flex items-center gap-1 text-sm font-overpass font-semibold text-brand-blue hover:underline">
+                  Ir al taller <ArrowRight className="w-4 h-4" />
+                </Link>
+              </div>
+            )}
+            {marca && (
+              <div className="rounded-lg border border-gray-200 p-4 flex flex-col gap-2">
+                <div className="flex items-center gap-2">
+                  <ShoppingBag className="w-5 h-5 text-terra-600" />
+                  <h3 className="font-overpass font-semibold text-gray-800 truncate">{marca.nombre}</h3>
+                </div>
+                <p className="text-sm text-gray-500">Formalización: <span className="font-medium text-gray-700">—</span></p>
+                <Link href="/marca" className="mt-1 inline-flex items-center gap-1 text-sm font-overpass font-semibold text-terra-600 hover:underline">
+                  Ir a la marca <ArrowRight className="w-4 h-4" />
+                </Link>
+              </div>
+            )}
+          </div>
+        </section>
+      )}
 
       <CuentaWhatsappForm
         phoneInicial={user.phone}

--- a/src/app/(public)/cuenta/page.tsx
+++ b/src/app/(public)/cuenta/page.tsx
@@ -6,6 +6,7 @@ import { auth } from '@/compartido/lib/auth'
 import { prisma } from '@/compartido/lib/prisma'
 import { Bell, User, ShieldCheck } from 'lucide-react'
 import { CuentaWhatsappForm } from '@/compartido/componentes/cuenta-whatsapp-form'
+import { AgregarRolCard } from '@/compartido/componentes/agregar-rol-card'
 
 export default async function CuentaPage() {
   const session = await auth()
@@ -32,6 +33,16 @@ export default async function CuentaPage() {
     redirect('/login')
   }
 
+  // U-09: ofrecer "agregar segundo rol" solo a un single user-rol (tiene exactamente
+  // una de las dos entidades). El CUIT existente pre-llena el formulario.
+  const [taller, marca] = await Promise.all([
+    prisma.taller.findFirst({ where: { userId: user.id }, select: { cuit: true } }),
+    prisma.marca.findFirst({ where: { userId: user.id }, select: { cuit: true } }),
+  ])
+  const rolFaltante: 'TALLER' | 'MARCA' | null =
+    taller && !marca ? 'MARCA' : marca && !taller ? 'TALLER' : null
+  const cuitActual = taller?.cuit ?? marca?.cuit ?? null
+
   return (
     <div className="space-y-6">
       <h1 className="font-overpass font-bold text-3xl text-brand-blue">Mi cuenta</h1>
@@ -52,6 +63,10 @@ export default async function CuentaPage() {
         phoneInicial={user.phone}
         whatsappActivo={user.notificacionesWhatsapp}
       />
+
+      {rolFaltante && (
+        <AgregarRolCard rolFaltante={rolFaltante} cuitActual={cuitActual} />
+      )}
 
       <section className="grid gap-4 sm:grid-cols-2">
         <Link href="/mi-cuenta" className="rounded-xl border border-gray-200 bg-white p-5 hover:border-brand-blue hover:shadow-card transition-all">

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,5 +1,7 @@
 import { auth } from '@/compartido/lib/auth'
 import { modoActivo } from '@/compartido/lib/roles'
+import { prisma } from '@/compartido/lib/prisma'
+import { construirEntidadesModo } from '@/compartido/lib/entidades-modo'
 import { Header, UserSidebar, SidebarProvider } from '@/compartido/componentes/layout'
 import { HeaderPublic } from '@/compartido/componentes/layout/header-public'
 import { Footer } from '@/compartido/componentes/layout/footer'
@@ -12,8 +14,34 @@ export default async function PublicLayout({ children }: { children: React.React
 
   // Logged in: Header global with tabs + sidebar visible en desktop
   if (session?.user) {
-    const userName = session.user.name || 'Usuario'
     const userRole = (modoActivo(session.user) as 'TALLER' | 'MARCA' | 'ESTADO') || 'TALLER'
+
+    // BUG A (QA #398): el sidebar de páginas (public) (ej. /cuenta) debe respetar el
+    // activeMode — mostrar la entidad operativa (nombre/nivel/progreso), no la identidad
+    // del user. Replica la lógica de los layouts (taller)/(marca). Roles operativos:
+    // TALLER → taller, MARCA → marca; ESTADO/ADMIN/CONTENIDO no tienen entidad operativa.
+    let userName = session.user.name || 'Usuario'
+    let userProgress: number | undefined
+    let userLevel: string | undefined
+
+    if (userRole === 'TALLER') {
+      const taller = await prisma.taller.findFirst({
+        where: { userId: session.user.id },
+        select: { nombre: true, nivel: true, puntaje: true },
+      })
+      userName = taller?.nombre || userName
+      userLevel = taller?.nivel || 'BRONCE'
+      userProgress = taller?.puntaje || 0
+    } else if (userRole === 'MARCA') {
+      const marca = await prisma.marca.findFirst({
+        where: { userId: session.user.id },
+        select: { nombre: true },
+      })
+      userName = marca?.nombre || userName
+    }
+
+    // U-04: contexto multi-rol para el toggle + pill "Modo X" (no-op si single-role).
+    const entidades = await construirEntidadesModo(session.user.id, session.user.roles)
 
     return (
       <SidebarProvider>
@@ -22,11 +50,16 @@ export default async function PublicLayout({ children }: { children: React.React
             userName={userName}
             userRole={userRole}
             showPilotPill={showPilotPill}
+            roles={session.user.roles}
+            activeMode={session.user.activeMode ?? undefined}
+            entidades={entidades}
           />
           <div className="flex flex-1">
             <UserSidebar
               userRole={userRole}
               userName={userName}
+              userProgress={userProgress}
+              userLevel={userLevel}
             />
             <main className="flex-grow max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-6">
               {children}

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,6 +1,5 @@
 import { auth } from '@/compartido/lib/auth'
 import { modoActivo } from '@/compartido/lib/roles'
-import { prisma } from '@/compartido/lib/prisma'
 import { construirEntidadesModo } from '@/compartido/lib/entidades-modo'
 import { Header, UserSidebar, SidebarProvider } from '@/compartido/componentes/layout'
 import { HeaderPublic } from '@/compartido/componentes/layout/header-public'
@@ -14,31 +13,12 @@ export default async function PublicLayout({ children }: { children: React.React
 
   // Logged in: Header global with tabs + sidebar visible en desktop
   if (session?.user) {
+    // FIX A replanteado (QA #398 r2): las páginas (public) — sobre todo /cuenta —
+    // son DEL USUARIO, no del perfil/rol activo. El sidebar muestra la identidad del
+    // user (nombre propio, sin "Formalización X%" del taller). El Header sí conserva
+    // el modo activo para tabs + Pill + ModoToggle (contexto global de operación).
+    const userName = session.user.name || 'Usuario'
     const userRole = (modoActivo(session.user) as 'TALLER' | 'MARCA' | 'ESTADO') || 'TALLER'
-
-    // BUG A (QA #398): el sidebar de páginas (public) (ej. /cuenta) debe respetar el
-    // activeMode — mostrar la entidad operativa (nombre/nivel/progreso), no la identidad
-    // del user. Replica la lógica de los layouts (taller)/(marca). Roles operativos:
-    // TALLER → taller, MARCA → marca; ESTADO/ADMIN/CONTENIDO no tienen entidad operativa.
-    let userName = session.user.name || 'Usuario'
-    let userProgress: number | undefined
-    let userLevel: string | undefined
-
-    if (userRole === 'TALLER') {
-      const taller = await prisma.taller.findFirst({
-        where: { userId: session.user.id },
-        select: { nombre: true, nivel: true, puntaje: true },
-      })
-      userName = taller?.nombre || userName
-      userLevel = taller?.nivel || 'BRONCE'
-      userProgress = taller?.puntaje || 0
-    } else if (userRole === 'MARCA') {
-      const marca = await prisma.marca.findFirst({
-        where: { userId: session.user.id },
-        select: { nombre: true },
-      })
-      userName = marca?.nombre || userName
-    }
 
     // U-04: contexto multi-rol para el toggle + pill "Modo X" (no-op si single-role).
     const entidades = await construirEntidadesModo(session.user.id, session.user.roles)
@@ -58,8 +38,7 @@ export default async function PublicLayout({ children }: { children: React.React
             <UserSidebar
               userRole={userRole}
               userName={userName}
-              userProgress={userProgress}
-              userLevel={userLevel}
+              mostrarFormalizacion={false}
             />
             <main className="flex-grow max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-6">
               {children}

--- a/src/app/api/auth/registro/completar/route.ts
+++ b/src/app/api/auth/registro/completar/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/compartido/lib/auth'
 import { prisma } from '@/compartido/lib/prisma'
 import { verificarCuit } from '@/compartido/lib/afip'
+import { crearEntidadParaRol } from '@/compartido/lib/crear-entidad-rol'
 import { z } from 'zod'
 
 const schema = z.object({
@@ -42,20 +43,20 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: afipResult.error || 'CUIT invalido' }, { status: 400 })
   }
 
-  // Transaccion: crear entidad + actualizar usuario
-  await prisma.$transaction([
-    role === 'TALLER'
-      ? prisma.taller.create({
-          data: { userId: user.id, nombre, cuit: cuit.replace(/-/g, ''), verificadoAfip: true },
-        })
-      : prisma.marca.create({
-          data: { userId: user.id, nombre, cuit: cuit.replace(/-/g, ''), verificadoAfip: true },
-        }),
-    prisma.user.update({
+  // Transaccion: crear entidad (+ validaciones si es taller) + actualizar usuario
+  await prisma.$transaction(async (tx) => {
+    await crearEntidadParaRol(tx, {
+      userId: user.id,
+      rol: role,
+      nombre,
+      cuit: cuit.replace(/-/g, ''),
+      verificadoAfip: true,
+    })
+    await tx.user.update({
       where: { id: user.id },
       data: { role, registroCompleto: true },
-    }),
-  ])
+    })
+  })
 
   return NextResponse.json({ ok: true })
 }

--- a/src/app/api/usuarios/me/roles/route.ts
+++ b/src/app/api/usuarios/me/roles/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from 'next/server'
+import type { UserRole } from '@prisma/client'
+import { z } from 'zod'
+import { prisma } from '@/compartido/lib/prisma'
+import { auth } from '@/compartido/lib/auth'
+import {
+  apiHandler,
+  errorAuthRequired,
+  errorConflict,
+  errorResponse,
+} from '@/compartido/lib/api-errors'
+import { rolesEfectivos } from '@/compartido/lib/roles'
+import { crearEntidadParaRol } from '@/compartido/lib/crear-entidad-rol'
+import {
+  consultarPadron,
+  errorBloqueaRegistro,
+  mensajeErrorArca,
+  type DatosArca,
+} from '@/compartido/lib/arca'
+import { logActividad } from '@/compartido/lib/log'
+
+// U-09: agrega un segundo rol de USUARIO (solo TALLER ⇄ MARCA). Crea la entidad
+// correspondiente (verificada por CUIT) y expande User.roles[] de forma explícita
+// (rolesEfectivos ∪ {nuevo}), manteniendo la invariante role == activeMode.
+// Los roles de equipo (ADMIN/ESTADO/CONTENIDO) NO se auto-asignan: el enum los rechaza.
+const bodySchema = z.object({
+  rol: z.enum(['TALLER', 'MARCA']),
+  nombre: z.string().trim().min(1, 'Nombre requerido'),
+  cuit: z.string().trim().min(1, 'CUIT requerido'),
+})
+
+export const POST = apiHandler(async (req: NextRequest) => {
+  const session = await auth()
+  if (!session?.user?.id) return errorAuthRequired()
+
+  const raw = await req.json().catch(() => null)
+  const parsed = bodySchema.safeParse(raw)
+  if (!parsed.success) {
+    return errorResponse({
+      code: 'INVALID_INPUT',
+      message: parsed.error.issues[0]?.message ?? 'Datos invalidos',
+      status: 400,
+    })
+  }
+  const { rol, nombre, cuit } = parsed.data
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: {
+      id: true,
+      roles: true,
+      role: true,
+      taller: { select: { id: true } },
+      marca: { select: { id: true } },
+    },
+  })
+  if (!user) return errorAuthRequired()
+
+  // Roles que YA tiene (normalizado: roles[] vacío de un single-rol pre-U04 → [role]).
+  const rolesActuales = rolesEfectivos({ roles: user.roles, role: user.role })
+
+  // 409 si ya posee el rol (por membresía o porque la entidad ya existe).
+  const yaPoseeEntidad = (rol === 'TALLER' && user.taller) || (rol === 'MARCA' && user.marca)
+  if (rolesActuales.includes(rol) || yaPoseeEntidad) {
+    return errorConflict('Ya tenes ese perfil')
+  }
+
+  // Verificar CUIT con ARCA (mismo path que el registro primario).
+  let verificado = false
+  let datosArca: DatosArca | undefined
+  const resultado = await consultarPadron(cuit)
+  if (resultado.exitosa && resultado.datos) {
+    verificado = true
+    datosArca = resultado.datos
+  } else if (resultado.error && errorBloqueaRegistro(resultado.error)) {
+    return errorResponse({
+      code: 'INVALID_INPUT',
+      message: mensajeErrorArca(resultado.error),
+      status: 400,
+    })
+  }
+  // ARCA_NO_RESPONDE / AFIPSDK_ERROR → continuar sin verificación (modo defensivo).
+
+  // Unión EXPLÍCITA, nunca push: un single-rol pre-U04 tiene roles=[] en DB y
+  // su rol original solo vive en User.role. rolesEfectivos lo recupera.
+  const nuevosRoles = Array.from(new Set([...rolesActuales, rol])) as UserRole[]
+
+  const entidad = await prisma.$transaction(async (tx) => {
+    const e = await crearEntidadParaRol(tx, {
+      userId: user.id,
+      rol,
+      nombre,
+      cuit,
+      verificadoAfip: verificado,
+      datosArca,
+    })
+    await tx.user.update({
+      where: { id: user.id },
+      data: {
+        roles: { set: nuevosRoles },
+        activeMode: rol, // queda activo en el nuevo perfil
+        role: rol, // invariante role == activeMode
+      },
+    })
+    return e
+  })
+
+  logActividad('ROL_AGREGADO', user.id, { rol, entidadId: entidad.id })
+
+  return NextResponse.json({ rol, entidadId: entidad.id, roles: nuevosRoles, activeMode: rol })
+})

--- a/src/app/api/usuarios/me/roles/route.ts
+++ b/src/app/api/usuarios/me/roles/route.ts
@@ -50,8 +50,8 @@ export const POST = apiHandler(async (req: NextRequest) => {
       id: true,
       roles: true,
       role: true,
-      taller: { select: { id: true, cuit: true } },
-      marca: { select: { id: true, cuit: true } },
+      taller: { select: { id: true, cuit: true, verificadoAfip: true } },
+      marca: { select: { id: true, cuit: true, verificadoAfip: true } },
     },
   })
   if (!user) return errorAuthRequired()
@@ -69,11 +69,16 @@ export const POST = apiHandler(async (req: NextRequest) => {
   let verificado = false
   let datosArca: DatosArca | undefined
 
-  // D (QA #398): si el CUIT del request coincide con uno YA verificado del propio
-  // user (su Taller o Marca existente), se omite la llamada a ARCA y se asume OK.
-  // Coherente con la caché de 30 días de sincronizarTaller: no revalidamos lo mismo.
+  // D (QA #398 r2): si el CUIT del request coincide con uno YA VERIFICADO del propio
+  // user (su Taller o Marca con verificadoAfip=true), se omite la llamada a ARCA.
+  // Coherente con la caché de 30 días de sincronizarTaller, que solo cachea
+  // verificaciones EXITOSAS: un CUIT presente pero nunca verificado (verificadoAfip=false,
+  // ej. registro con ARCA caído o dato de seed) SÍ se manda a ARCA.
   const normalizar = (c: string) => c.replace(/-/g, '')
-  const cuitsVerificados = [user.taller?.cuit, user.marca?.cuit]
+  const cuitsVerificados = [
+    user.taller?.verificadoAfip ? user.taller.cuit : null,
+    user.marca?.verificadoAfip ? user.marca.cuit : null,
+  ]
     .filter((c): c is string => Boolean(c))
     .map(normalizar)
   const cuitYaVerificado = cuitsVerificados.includes(normalizar(cuit))

--- a/src/app/api/usuarios/me/roles/route.ts
+++ b/src/app/api/usuarios/me/roles/route.ts
@@ -50,8 +50,8 @@ export const POST = apiHandler(async (req: NextRequest) => {
       id: true,
       roles: true,
       role: true,
-      taller: { select: { id: true } },
-      marca: { select: { id: true } },
+      taller: { select: { id: true, cuit: true } },
+      marca: { select: { id: true, cuit: true } },
     },
   })
   if (!user) return errorAuthRequired()
@@ -65,21 +65,37 @@ export const POST = apiHandler(async (req: NextRequest) => {
     return errorConflict('Ya tenes ese perfil')
   }
 
-  // Verificar CUIT con ARCA (mismo path que el registro primario).
+  // Verificación de CUIT.
   let verificado = false
   let datosArca: DatosArca | undefined
-  const resultado = await consultarPadron(cuit)
-  if (resultado.exitosa && resultado.datos) {
+
+  // D (QA #398): si el CUIT del request coincide con uno YA verificado del propio
+  // user (su Taller o Marca existente), se omite la llamada a ARCA y se asume OK.
+  // Coherente con la caché de 30 días de sincronizarTaller: no revalidamos lo mismo.
+  const normalizar = (c: string) => c.replace(/-/g, '')
+  const cuitsVerificados = [user.taller?.cuit, user.marca?.cuit]
+    .filter((c): c is string => Boolean(c))
+    .map(normalizar)
+  const cuitYaVerificado = cuitsVerificados.includes(normalizar(cuit))
+
+  if (cuitYaVerificado) {
     verificado = true
-    datosArca = resultado.datos
-  } else if (resultado.error && errorBloqueaRegistro(resultado.error)) {
-    return errorResponse({
-      code: 'INVALID_INPUT',
-      message: mensajeErrorArca(resultado.error),
-      status: 400,
-    })
+    logActividad('ARCA_SKIP_CUIT_CONOCIDO', user.id, { rol, cuit: normalizar(cuit) })
+  } else {
+    // CUIT nuevo → verificar con ARCA (mismo path que el registro primario).
+    const resultado = await consultarPadron(cuit)
+    if (resultado.exitosa && resultado.datos) {
+      verificado = true
+      datosArca = resultado.datos
+    } else if (resultado.error && errorBloqueaRegistro(resultado.error)) {
+      return errorResponse({
+        code: 'INVALID_INPUT',
+        message: mensajeErrorArca(resultado.error),
+        status: 400,
+      })
+    }
+    // ARCA_NO_RESPONDE / AFIPSDK_ERROR → continuar sin verificación (modo defensivo).
   }
-  // ARCA_NO_RESPONDE / AFIPSDK_ERROR → continuar sin verificación (modo defensivo).
 
   // Unión EXPLÍCITA, nunca push: un single-rol pre-U04 tiene roles=[] en DB y
   // su rol original solo vive en User.role. rolesEfectivos lo recupera.

--- a/src/compartido/componentes/agregar-rol-card.tsx
+++ b/src/compartido/componentes/agregar-rol-card.tsx
@@ -105,7 +105,7 @@ export function AgregarRolCard({ rolFaltante, cuitActual }: AgregarRolCardProps)
             className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-brand-blue focus:ring-1 focus:ring-brand-blue outline-none"
           />
           <p className="text-xs text-gray-500 mt-1">
-            Pre-cargado con tu CUIT actual. Cambialo si tu {amable.toLowerCase()} usa otro.
+            Pre-cargamos tu CUIT actual. Si usás otro CUIT para tu {amable.toLowerCase()}, lo verificaremos contra ARCA.
           </p>
         </div>
 

--- a/src/compartido/componentes/agregar-rol-card.tsx
+++ b/src/compartido/componentes/agregar-rol-card.tsx
@@ -51,11 +51,17 @@ export function AgregarRolCard({ rolFaltante, cuitActual }: AgregarRolCardProps)
         setCreando(false)
         return
       }
-      // Reflejar el nuevo modo en la sesión viva (rama jwt trigger==='update' de U-04).
-      await update({ activeMode: rolFaltante })
-      toast({ mensaje: `Se creó tu perfil de ${amable}`, tipo: 'success' })
-      router.push(DASHBOARD[rolFaltante])
+      // QA #398 r3 — refresh de sesión completo tras agregar rol:
+      // 1) update() reenvía el roles[] server-computed por el endpoint para que el
+      //    callback jwt expanda el JWT en la cookie (sin esto el JWT queda single-rol
+      //    y el middleware redirige a /unauthorized).
+      // 2) refresh() invalida el cache de RSC para que el server re-lea la cookie nueva.
+      // 3) push() navega al dashboard del nuevo rol ya con la sesión correcta.
+      const nuevoRol = (data?.rol as RolFaltante) ?? rolFaltante
+      await update({ activeMode: nuevoRol, roles: data?.roles })
       router.refresh()
+      toast({ mensaje: `Se creó tu perfil de ${amable}`, tipo: 'success' })
+      router.push(DASHBOARD[nuevoRol])
     } catch {
       setError('No se pudo crear el perfil')
       setCreando(false)

--- a/src/compartido/componentes/agregar-rol-card.tsx
+++ b/src/compartido/componentes/agregar-rol-card.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useSession } from 'next-auth/react'
+import { Button } from '@/compartido/componentes/ui/button'
+import { useToast } from '@/compartido/componentes/ui/toast'
+import { Building2, ShoppingBag } from 'lucide-react'
+
+type RolFaltante = 'TALLER' | 'MARCA'
+
+interface AgregarRolCardProps {
+  /** Rol que el usuario NO tiene todavía (el opuesto al actual). */
+  rolFaltante: RolFaltante
+  /** CUIT de la entidad existente, para pre-llenar (editable). */
+  cuitActual?: string | null
+}
+
+const LABEL: Record<RolFaltante, string> = { TALLER: 'Taller', MARCA: 'Marca' }
+const DASHBOARD: Record<RolFaltante, string> = { TALLER: '/taller', MARCA: '/marca' }
+
+export function AgregarRolCard({ rolFaltante, cuitActual }: AgregarRolCardProps) {
+  const router = useRouter()
+  const { update } = useSession()
+  const { toast } = useToast()
+  const [nombre, setNombre] = useState('')
+  const [cuit, setCuit] = useState(cuitActual ?? '')
+  const [error, setError] = useState<string | null>(null)
+  const [creando, setCreando] = useState(false)
+
+  const amable = LABEL[rolFaltante]
+  const Icono = rolFaltante === 'TALLER' ? Building2 : ShoppingBag
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    if (!nombre.trim() || !cuit.trim()) {
+      setError('Completá el nombre y el CUIT')
+      return
+    }
+    setCreando(true)
+    try {
+      const res = await fetch('/api/usuarios/me/roles', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rol: rolFaltante, nombre: nombre.trim(), cuit: cuit.trim() }),
+      })
+      const data = await res.json().catch(() => null)
+      if (!res.ok) {
+        setError(data?.error?.message ?? 'No se pudo crear el perfil')
+        setCreando(false)
+        return
+      }
+      // Reflejar el nuevo modo en la sesión viva (rama jwt trigger==='update' de U-04).
+      await update({ activeMode: rolFaltante })
+      toast({ mensaje: `Se creó tu perfil de ${amable}`, tipo: 'success' })
+      router.push(DASHBOARD[rolFaltante])
+      router.refresh()
+    } catch {
+      setError('No se pudo crear el perfil')
+      setCreando(false)
+    }
+  }
+
+  return (
+    <section
+      data-testid="agregar-rol-card"
+      className="rounded-xl border border-gray-200 bg-white p-6"
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <Icono className="w-5 h-5 text-brand-blue" />
+        <h2 className="font-overpass font-bold text-lg text-brand-blue">
+          Sumá tu perfil de {amable}
+        </h2>
+      </div>
+      <p className="text-sm text-gray-600 mb-4">
+        Es la misma cuenta. Vas a poder cambiar entre tus perfiles desde el menú del avatar.
+      </p>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="rol-nombre" className="block text-sm font-medium text-gray-700 mb-1">
+            Nombre {rolFaltante === 'TALLER' ? 'del taller' : 'de la marca'}
+          </label>
+          <input
+            id="rol-nombre"
+            type="text"
+            value={nombre}
+            onChange={e => setNombre(e.target.value)}
+            placeholder={rolFaltante === 'TALLER' ? 'Taller La Costura' : 'Mi Marca'}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-brand-blue focus:ring-1 focus:ring-brand-blue outline-none"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="rol-cuit" className="block text-sm font-medium text-gray-700 mb-1">
+            CUIT
+          </label>
+          <input
+            id="rol-cuit"
+            type="text"
+            value={cuit}
+            onChange={e => setCuit(e.target.value)}
+            placeholder="20-12345678-9"
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-brand-blue focus:ring-1 focus:ring-brand-blue outline-none"
+          />
+          <p className="text-xs text-gray-500 mt-1">
+            Pre-cargado con tu CUIT actual. Cambialo si tu {amable.toLowerCase()} usa otro.
+          </p>
+        </div>
+
+        {error && <p className="text-sm text-status-error">{error}</p>}
+
+        <div className="flex justify-end">
+          <Button
+            type="submit"
+            variant="primary"
+            size="sm"
+            loading={creando}
+            data-testid="agregar-rol-submit"
+          >
+            Crear perfil de {amable}
+          </Button>
+        </div>
+      </form>
+    </section>
+  )
+}

--- a/src/compartido/componentes/layout/header.tsx
+++ b/src/compartido/componentes/layout/header.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { Menu, User, LogOut } from 'lucide-react'
-import { signOut } from 'next-auth/react'
+import { signOut, useSession } from 'next-auth/react'
 import type { UserRole } from '@prisma/client'
 import { LogoPDT } from '@/compartido/componentes/ui/logo-pdt'
 import { NotificacionesBell } from './notificaciones-bell'
@@ -56,6 +56,14 @@ export function Header({
   const [menuOpen, setMenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
 
+  // BUG B (QA #398): el Pill "Modo X" tomaba activeMode/roles de un prop server-side
+  // que quedaba vencido tras session.update() (se veía "Modo Marca" y luego "Modo Taller").
+  // La sesión viva de useSession() es la fuente autoritativa; caemos al prop solo mientras
+  // la sesión cliente aún no hidrató (evita parpadeo/mismatch en el primer paint).
+  const { data: liveSession } = useSession()
+  const liveRoles = liveSession?.user?.roles ?? roles
+  const liveActiveMode = (liveSession?.user?.activeMode ?? activeMode) ?? undefined
+
   // Tabs segun rol
   const tabs = TABS_BY_ROLE[userRole] ?? []
 
@@ -75,8 +83,8 @@ export function Header({
     .toUpperCase() || '?'
 
   // U-04: modo activo efectivo + diferenciación visual solo para multi-rol.
-  const modoActual: UserRole = activeMode ?? (userRole as UserRole)
-  const esMultiRol = roles.length > 1
+  const modoActual: UserRole = liveActiveMode ?? (userRole as UserRole)
+  const esMultiRol = liveRoles.length > 1
   const borderAccent = esMultiRol ? MODO_BORDE[modoActual] ?? '' : ''
   const avatarAccent = esMultiRol ? MODO_AVATAR[modoActual] ?? '' : ''
 
@@ -193,7 +201,7 @@ export function Header({
                   </div>
                   {/* U-04: toggle multi-rol (se auto-oculta si roles <= 1) */}
                   <ModoToggle
-                    roles={roles}
+                    roles={liveRoles}
                     activeMode={modoActual}
                     entidades={entidades}
                     onCambio={() => setMenuOpen(false)}

--- a/src/compartido/componentes/layout/user-sidebar.tsx
+++ b/src/compartido/componentes/layout/user-sidebar.tsx
@@ -26,6 +26,12 @@ interface UserSidebarProps {
   userName?: string
   userProgress?: number
   userLevel?: string
+  /**
+   * U-09 (QA #398): en páginas DEL USUARIO (ej. /cuenta) el sidebar muestra la
+   * identidad del user, sin "Formalización X%" (que es del perfil Taller, no del
+   * user). Default true para no afectar los layouts (taller)/(marca)/(estado).
+   */
+  mostrarFormalizacion?: boolean
 }
 
 // F3: solo accesos personales para los 3 roles operativos.
@@ -57,7 +63,8 @@ export function UserSidebar({
   userRole = 'TALLER',
   userName = 'Usuario',
   userProgress = 0,
-  userLevel = 'Bronce'
+  userLevel = 'Bronce',
+  mostrarFormalizacion = true
 }: UserSidebarProps) {
   const pathname = usePathname()
   const { isOpen, close } = useSidebar()
@@ -164,16 +171,17 @@ export function UserSidebar({
               <div className="flex-1 min-w-0">
                 <h2 className="font-overpass font-bold text-lg lg:text-base truncate">{userName}</h2>
                 <p className="text-white/70 text-sm lg:text-xs">
-                  {userRole === 'TALLER' && `Formalización ${userProgress}%`}
-                  {userRole === 'MARCA' && 'Marca'}
-                  {userRole === 'ESTADO' && 'Ente Estatal'}
-                  {userRole === 'ADMIN' && 'Administrador'}
+                  {!mostrarFormalizacion && 'Mi cuenta'}
+                  {mostrarFormalizacion && userRole === 'TALLER' && `Formalización ${userProgress}%`}
+                  {mostrarFormalizacion && userRole === 'MARCA' && 'Marca'}
+                  {mostrarFormalizacion && userRole === 'ESTADO' && 'Ente Estatal'}
+                  {mostrarFormalizacion && userRole === 'ADMIN' && 'Administrador'}
                 </p>
               </div>
             </div>
 
-            {/* Progress bar (solo para talleres) */}
-            {userRole === 'TALLER' && (
+            {/* Progress bar (solo para talleres, y no en páginas del usuario) */}
+            {mostrarFormalizacion && userRole === 'TALLER' && (
               <div className="space-y-1">
                 <div className="flex justify-between text-xs text-white/60">
                   <span>Progreso de formalización</span>

--- a/src/compartido/lib/auth.config.ts
+++ b/src/compartido/lib/auth.config.ts
@@ -88,7 +88,26 @@ export default {
       // DB (autoritativo); acá revalidamos contra los roles que YA están en el token
       // (en memoria, sin Prisma → Edge-safe). Nunca se confía ciegamente en el cliente.
       if (trigger === 'update' && session && typeof session === 'object') {
-        const nuevo = (session as { activeMode?: UserRole | null }).activeMode
+        const s = session as { activeMode?: UserRole | null; roles?: UserRole[] | null }
+
+        // U-09 (QA #398 r3): al AGREGAR un 2º rol el endpoint /me/roles ya expandió
+        // roles[] en DB y reenvía el roles[] server-computed por el cliente. El JWT
+        // (estrategia JWT, self-contained) no se re-emite desde la DB solo, así que lo
+        // ponemos al día acá. SEGURIDAD: solo aceptamos EXPANSIÓN con roles OPERATIVOS
+        // (TALLER/MARCA) — los team roles (ADMIN/ESTADO/CONTENIDO) nunca se auto-asignan
+        // y se filtran, de modo que un input del cliente no puede escalar privilegios.
+        if (Array.isArray(s.roles)) {
+          const OPERATIVOS: UserRole[] = ['TALLER', 'MARCA']
+          const previos = (token.roles as UserRole[] | undefined) ?? []
+          token.roles = Array.from(
+            new Set([...previos, ...s.roles.filter((r) => OPERATIVOS.includes(r))])
+          )
+        }
+
+        // El activeMode solo se acepta si pertenece a los roles del token (ya
+        // expandidos arriba si correspondía). Esto preserva la defensa para el
+        // cambio de modo "normal" de un multi-rol que NO envía roles[].
+        const nuevo = s.activeMode
         const rolesToken = (token.roles as UserRole[] | undefined) ?? []
         if (nuevo && rolesToken.includes(nuevo)) {
           token.activeMode = nuevo

--- a/src/compartido/lib/crear-entidad-rol.ts
+++ b/src/compartido/lib/crear-entidad-rol.ts
@@ -1,0 +1,77 @@
+import type { Prisma } from '@prisma/client'
+import type { DatosArca } from './arca'
+
+export type RolEntidad = 'TALLER' | 'MARCA'
+
+interface CrearEntidadInput {
+  userId: string
+  rol: RolEntidad
+  nombre: string
+  cuit: string
+  verificadoAfip?: boolean
+  /** Datos de ARCA para poblar los campos AFIP de un Taller (opcional). */
+  datosArca?: DatosArca
+}
+
+/**
+ * Crea la entidad (Taller o Marca) que corresponde a un rol, DENTRO de una
+ * transacción (recibe `tx`, no usa el cliente global). Para TALLER crea además
+ * las validaciones NO_INICIADO de los tipos de documento activos.
+ *
+ * Extraído de la lógica duplicada inline en `/api/auth/registro`; reusado por
+ * `/api/auth/registro/completar` y `/api/usuarios/me/roles` (U-09). El formato
+ * del CUIT lo decide cada caller (este helper lo guarda verbatim).
+ */
+export async function crearEntidadParaRol(
+  tx: Prisma.TransactionClient,
+  { userId, rol, nombre, cuit, verificadoAfip = false, datosArca }: CrearEntidadInput
+) {
+  if (rol !== 'TALLER' && rol !== 'MARCA') {
+    throw new Error(`crearEntidadParaRol: rol no soportado "${rol}" (solo TALLER o MARCA)`)
+  }
+
+  if (rol === 'TALLER') {
+    const taller = await tx.taller.create({
+      data: {
+        userId,
+        nombre: datosArca?.nombre || nombre,
+        cuit,
+        verificadoAfip,
+        verificadoAfipAt: verificadoAfip ? new Date() : null,
+        tipoInscripcionAfip: datosArca?.tipoInscripcion ?? null,
+        categoriaMonotributo: datosArca?.categoriaMonotributo ?? null,
+        estadoCuitAfip: datosArca?.estadoCuit ?? null,
+        fechaInscripcionAfip: datosArca?.fechaInscripcion ?? null,
+        actividadesAfip: datosArca?.actividades ?? [],
+        domicilioFiscalAfip: datosArca?.domicilioFiscal ?? undefined,
+      },
+    })
+
+    // Checklist de validaciones inicial (igual que el registro primario).
+    const tiposDoc = await tx.tipoDocumento.findMany({
+      where: { activo: true },
+      select: { id: true, nombre: true },
+    })
+    if (tiposDoc.length > 0) {
+      await tx.validacion.createMany({
+        data: tiposDoc.map((td) => ({
+          tallerId: taller.id,
+          tipo: td.nombre,
+          tipoDocumentoId: td.id,
+          estado: 'NO_INICIADO' as const,
+        })),
+      })
+    }
+    return taller
+  }
+
+  // MARCA
+  return tx.marca.create({
+    data: {
+      userId,
+      nombre: datosArca?.nombre || nombre,
+      cuit,
+      verificadoAfip,
+    },
+  })
+}


### PR DESCRIPTION
Cierra el hueco del QA de #397: un single-rol existente suma el rol que le falta (TALLER<->MARCA) sin Prisma Studio. Helper crearEntidadParaRol reusado en /registro/completar; endpoint POST /api/usuarios/me/roles (valida rol, 409 ya-poseido, CUIT ARCA, roles[] union explicita, invariante role==activeMode); card en /cuenta solo para single-rol. Tests: unit helper + endpoint (6 casos incl. normalizacion) + regresion anti-incesto + e2e single->dual. Refs spec v4-u-09.

🤖 Generated with [Claude Code](https://claude.com/claude-code)