### PR TITLE
feat: Narrativa V4 Etapa 1 - renombres y reordenamiento

### DIFF
--- a/.claude/DEUDA_TECNICA.md
+++ b/.claude/DEUDA_TECNICA.md
@@ -119,6 +119,23 @@ y prioridad sugerida.
 - **Estado:** ticket abierto a GitHub Support
 - **Plan:** monitorear ticket; mientras tanto usar admin bypass
 
+### T-04: Directorio `e2e/` huérfano (no lo corre Playwright)
+- **Detectado en:** implementación Narrativa V4 Etapa 1 (2026-06-08)
+- **Descripción:** existen DOS carpetas de tests Playwright: `tests/e2e/`
+  (la real — `playwright.config.ts` tiene `testDir: './tests/e2e'`) y
+  `e2e/` (huérfana). Los archivos `e2e/checklist-sec*.spec.ts`,
+  `e2e/admin.spec.ts`, `e2e/auth.spec.ts`, etc. **nunca se ejecutan** en
+  CI ni con `npm run test:e2e`. Son ~12 specs de mantenimiento muerto.
+- **Impacto:** falsa sensación de cobertura. Cualquiera que edite `e2e/*`
+  (como pedía el spec de Etapa 1 para T-03) cree estar arreglando tests
+  que en realidad están inertes. Riesgo de divergencia silenciosa.
+- **Prioridad:** media (deuda de confiabilidad de la suite)
+- **Plan:** decidir entre (a) **migrar** los specs útiles de `e2e/` a
+  `tests/e2e/` y borrar la carpeta, o (b) **borrar** `e2e/` si son
+  duplicados/obsoletos de los de `tests/e2e/`. Verificar solapamiento
+  antes de borrar.
+- **Estimación:** 1-2h (auditar solapamiento + migrar/borrar)
+
 ## Producto
 
 ### P-01: Notificaciones — comportamiento en multi-rol
@@ -169,18 +186,23 @@ y prioridad sugerida.
 
 ## Resueltas
 
-### T-03: Test e2e checklist-sec9-10.spec.ts con labels stale — RESUELTA
+### T-03: Test e2e checklist-sec9-10.spec.ts con labels stale — RESUELTA (con corrección de diagnóstico)
 - **Detectado en:** Discovery narrativa V4 Etapa 1 (2026-06-07)
-- **Resuelta en:** commit `66ebee8` (PR Narrativa V4 Etapa 1), 2026-06-08
-- **Descripción original:** `e2e/checklist-sec9-10.spec.ts` líneas 236/346
-  referenciaban labels obsoletos ('Mi Tablero', 'Academia', 'Mi Panel',
-  'Directorio Talleres') y selectores (`'Abrir menú personal'`,
-  `aside[aria-label="Menú de navegación personal"]`) eliminados en #375
-  (sidebar refactor: la navegación de sección pasó al header).
-- **Fix:** los tests 10.2 (TALLER) y 10.9 (MARCA) se reescribieron para
-  assertar los tabs del header (`header nav`) con los labels+orden de la
-  Narrativa V4 Etapa 1. Se encontró staleness adicional fuera del alcance
-  de T-03 y se arregló en el mismo PR: 10.12 (ESTADO, mismos selectores
-  rotos) y 9.1/9.2 (asertaban heading 'Academia', ya renombrado a 'Cursos'
-  en `eb87a48`). Se agregaron asserts del Flujo 4 (vidriera sin "X de 7":
-  10.9b marca + 10.9c público).
+- **Resuelta en:** commits `66ebee8` + reconciliación real en el mismo PR
+  (Narrativa V4 Etapa 1), 2026-06-08
+- **Descripción original:** se reportó que `e2e/checklist-sec9-10.spec.ts`
+  líneas 236/346 tenían labels obsoletos y selectores eliminados en #375.
+- **CORRECCIÓN IMPORTANTE (hallazgo al implementar):** el directorio `e2e/`
+  **NO lo corre Playwright**. `playwright.config.ts` tiene
+  `testDir: './tests/e2e'`, y `e2e.yml` corre `npx playwright test` sin
+  `--config` alterno. Por eso esos tests "stale" jamás fallaron: nunca se
+  ejecutan. Ver **T-04** (directorio huérfano).
+- **Fix real (lo que SÍ corre en CI, en `tests/e2e/`):** la Etapa 1 rompió
+  dos tests reales que asertaban el copy viejo —
+  `tests/e2e/smoke.spec.ts:29` (`'Mi vidriera'` → `'Mi taller'`) y
+  `tests/e2e/acceso-verificado.spec.ts:40` (heading `'Explorar Proveedores'`
+  → `'Explorar talleres'`). Ambos actualizados; e2e vuelve a verde.
+- **Fix cosmético (en `e2e/` huérfano, por completitud y por si se rewirea):**
+  se igualaron igualmente `checklist-sec9-10.spec.ts` 10.2/10.9 a los tabs
+  del header, 10.12 (ESTADO) y 9.1/9.2 (Academia→Cursos), + asserts del
+  Flujo 4 (10.9b/10.9c). No afecta CI hasta que se resuelva T-04.

--- a/.claude/DEUDA_TECNICA.md
+++ b/.claude/DEUDA_TECNICA.md
@@ -119,19 +119,6 @@ y prioridad sugerida.
 - **Estado:** ticket abierto a GitHub Support
 - **Plan:** monitorear ticket; mientras tanto usar admin bypass
 
-### T-03: Test e2e checklist-sec9-10.spec.ts con labels stale
-- **Detectado en:** Discovery narrativa V4 Etapa 1 (2026-06-07)
-- **Descripción:** e2e/checklist-sec9-10.spec.ts líneas 236/346
-  referencian labels obsoletos ('Mi Tablero', 'Academia', 'Mi Panel',
-  'Directorio Talleres') y aria-labels que se eliminaron en #375
-  (sidebar refactor).
-- **Impacto:** el test está pasando por casualidad o falla en silencio.
-  Cualquier renombre de tabs (próximo: narrativa V4 Etapa 1) puede
-  destapar el problema.
-- **Prioridad:** media — conviene arreglar JUNTO con la Etapa 1
-  narrativa V4 para no romper más
-- **Estimación:** 30 min (actualizar expectedItems y aria-labels)
-
 ## Producto
 
 ### P-01: Notificaciones — comportamiento en multi-rol
@@ -182,4 +169,18 @@ y prioridad sugerida.
 
 ## Resueltas
 
-(Items mover acá cuando se resuelven, con fecha y referencia al fix)
+### T-03: Test e2e checklist-sec9-10.spec.ts con labels stale — RESUELTA
+- **Detectado en:** Discovery narrativa V4 Etapa 1 (2026-06-07)
+- **Resuelta en:** commit `66ebee8` (PR Narrativa V4 Etapa 1), 2026-06-08
+- **Descripción original:** `e2e/checklist-sec9-10.spec.ts` líneas 236/346
+  referenciaban labels obsoletos ('Mi Tablero', 'Academia', 'Mi Panel',
+  'Directorio Talleres') y selectores (`'Abrir menú personal'`,
+  `aside[aria-label="Menú de navegación personal"]`) eliminados en #375
+  (sidebar refactor: la navegación de sección pasó al header).
+- **Fix:** los tests 10.2 (TALLER) y 10.9 (MARCA) se reescribieron para
+  assertar los tabs del header (`header nav`) con los labels+orden de la
+  Narrativa V4 Etapa 1. Se encontró staleness adicional fuera del alcance
+  de T-03 y se arregló en el mismo PR: 10.12 (ESTADO, mismos selectores
+  rotos) y 9.1/9.2 (asertaban heading 'Academia', ya renombrado a 'Cursos'
+  en `eb87a48`). Se agregaron asserts del Flujo 4 (vidriera sin "X de 7":
+  10.9b marca + 10.9c público).

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,11 @@
 ## 2026-06-08
 
 ### Gerardo Breard
+- **11:54** `507941a` — fix(e2e): reconciliar tests reales en tests/e2e + corregir diagnostico T-03
+  - `.claude/DEUDA_TECNICA.md`
+  - `tests/e2e/acceso-verificado.spec.ts`
+  - `tests/e2e/smoke.spec.ts`
+
 - **11:02** `d8b28ac` — docs(deuda): T-03 resuelta en commit 66ebee8 (Narrativa V4 Etapa 1)
   - `.claude/DEUDA_TECNICA.md`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-06-08
 
 ### Gerardo Breard
+- **11:02** `d8b28ac` — docs(deuda): T-03 resuelta en commit 66ebee8 (Narrativa V4 Etapa 1)
+  - `.claude/DEUDA_TECNICA.md`
+
 - **11:02** `66ebee8` — feat(narrativa-v4): Etapa 1 §1.1 + §1.2 - renombres y reordenamiento
   - `e2e/checklist-sec9-10.spec.ts`
   - `src/app/(marca)/marca/directorio/[id]/page.tsx`

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,16 @@
 ## 2026-06-08
 
 ### Gerardo Breard
+- **11:02** `66ebee8` — feat(narrativa-v4): Etapa 1 §1.1 + §1.2 - renombres y reordenamiento
+  - `e2e/checklist-sec9-10.spec.ts`
+  - `src/app/(marca)/marca/directorio/[id]/page.tsx`
+  - `src/app/(marca)/marca/directorio/page.tsx`
+  - `src/app/(marca)/marca/pedidos/page.tsx`
+  - `src/app/(marca)/marca/perfil/page.tsx`
+  - `src/app/(public)/directorio/page.tsx`
+  - `src/app/(taller)/taller/perfil/page.tsx`
+  - `src/compartido/lib/content/institutional.ts`
+
 - **10:28** `e86102f` — Merge remote-tracking branch 'origin/develop' into feature/u-09-agregar-segundo-rol
 
 

--- a/e2e/checklist-sec9-10.spec.ts
+++ b/e2e/checklist-sec9-10.spec.ts
@@ -26,8 +26,8 @@ test('9.1 — Taller ORO: /taller/aprender muestra colecciones con badge Certifi
   await page.goto('/taller/aprender')
   await page.waitForLoadState('networkidle')
 
-  // Debe haber heading Academia
-  await expect(page.getByRole('heading', { name: 'Academia' })).toBeVisible()
+  // Debe haber heading Cursos (renombrado desde "Academia" en eb87a48)
+  await expect(page.getByRole('heading', { name: 'Cursos' })).toBeVisible()
 
   // Buscar badge "Certificado"
   const badges = page.locator('text=Certificado')
@@ -47,8 +47,8 @@ test('9.2 — Taller ORO: click en coleccion muestra videos (pagina detalle carg
   await btn.click()
   await page.waitForLoadState('networkidle')
 
-  // Debe mostrar la pagina de detalle con link "Volver a Academia"
-  await expect(page.getByText('Volver a Academia')).toBeVisible()
+  // Debe navegar a la pagina de detalle de la coleccion (ruta /taller/aprender/[id])
+  await expect(page).toHaveURL(/\/taller\/aprender\/.+/)
 })
 
 test('9.3 — Taller ORO: boton "Descargar certificado PDF" visible en coleccion certificada', async ({ page }) => {
@@ -222,23 +222,19 @@ test('10.1 — Taller Bronce: dashboard con greeting, nivel, progreso', async ({
   await expect(page.getByRole('heading', { name: 'Progreso de Formalización' })).toBeVisible()
 })
 
-test('10.2 — Taller Bronce: sidebar tiene los 6 items esperados', async ({ page }) => {
+test('10.2 — Taller Bronce: header muestra los tabs de sección (Narrativa V4 Etapa 1)', async ({ page }) => {
   test.setTimeout(60000)
   await loginAs(page, 'taller_bronce')
+  await page.waitForLoadState('networkidle')
 
-  // Abrir sidebar con el boton "Abrir menu personal"
-  await page.getByLabel('Abrir menú personal').click()
-  await page.waitForTimeout(800)
+  // Post-F3 (#375) la navegación de sección vive en los tabs del header (banda 2),
+  // no en el sidebar personal (que solo tiene Notificaciones/Mi cuenta/Ayuda).
+  // Narrativa V4 Etapa 1: labels y orden nuevos (Pedidos al final, "Mi taller").
+  const tabsNav = page.locator('header nav')
+  const expectedTabs = ['Inicio', 'Mi taller', 'Mi recorrido', 'Cursos', 'Pedidos']
 
-  const sidebar = page.locator('aside[aria-label="Menú de navegación personal"]')
-  await expect(sidebar).toBeVisible()
-
-  const expectedItems = ['Mi Tablero', 'Mi Perfil', 'Mi Formalización', 'Academia', 'Mis Pedidos', 'Pedidos disponibles']
-  for (const item of expectedItems) {
-    const link = sidebar.getByRole('link', { name: item })
-    const visible = await link.isVisible().catch(() => false)
-    expect(visible, `Sidebar debe tener link "${item}"`).toBe(true)
-  }
+  const labels = (await tabsNav.getByRole('link').allTextContents()).map(t => t.trim()).filter(Boolean)
+  expect(labels, 'Orden y labels de tabs TALLER').toEqual(expectedTabs)
 })
 
 test('10.3 — Taller Bronce: navegar todas las secciones del sidebar sin errores', async ({ page }) => {
@@ -331,24 +327,41 @@ test('10.8 — Marca: dashboard con stats (pedidos, activos, cotizaciones)', asy
   await expect(page.getByText('Cotizaciones pendientes')).toBeVisible()
 })
 
-test('10.9 — Marca: sidebar tiene items esperados', async ({ page }) => {
+test('10.9 — Marca: header muestra los tabs de sección (Narrativa V4 Etapa 1)', async ({ page }) => {
   test.setTimeout(60000)
   await loginAs(page, 'marca')
   await page.goto('/marca')
   await page.waitForLoadState('networkidle')
 
-  await page.getByLabel('Abrir menú personal').click()
-  await page.waitForTimeout(800)
+  // Post-F3 (#375): navegación de sección en los tabs del header.
+  // Narrativa V4 Etapa 1: Inicio · Mi marca · Explorar talleres · Pedidos.
+  const tabsNav = page.locator('header nav')
+  const expectedTabs = ['Inicio', 'Mi marca', 'Explorar talleres', 'Pedidos']
 
-  const sidebar = page.locator('aside[aria-label="Menú de navegación personal"]')
-  await expect(sidebar).toBeVisible()
+  const labels = (await tabsNav.getByRole('link').allTextContents()).map(t => t.trim()).filter(Boolean)
+  expect(labels, 'Orden y labels de tabs MARCA').toEqual(expectedTabs)
 
-  const expectedItems = ['Mi Panel', 'Directorio Talleres', 'Mis Pedidos', 'Mi Perfil']
-  for (const item of expectedItems) {
-    const link = sidebar.getByRole('link', { name: item })
-    const visible = await link.isVisible().catch(() => false)
-    expect(visible, `Sidebar debe tener link "${item}"`).toBe(true)
-  }
+  // R-2: "Cursos" NO debe aparecer en MARCA (Academia para marcas es Etapa 3)
+  await expect(tabsNav.getByRole('link', { name: 'Cursos' })).toHaveCount(0)
+})
+
+test('10.9b — Vidriera pública para marca (/marca/directorio): sin "X de 7 requisitos" (Narrativa V4 §1.2)', async ({ page }) => {
+  test.setTimeout(60000)
+  await loginAs(page, 'marca')
+  await page.goto('/marca/directorio')
+  await page.waitForLoadState('networkidle')
+
+  // §1.2: la vidriera pública ya no expone el conteo "X de 7 requisitos verificados".
+  await expect(page.locator('body')).not.toContainText('de 7 requisitos')
+})
+
+test('10.9c — Directorio público anónimo (/directorio): sin "X de 7 requisitos" (Narrativa V4 §1.2)', async ({ page }) => {
+  test.setTimeout(60000)
+  await page.goto('/directorio')
+  await page.waitForLoadState('networkidle')
+
+  await expect(page).toHaveURL(/\/directorio/)
+  await expect(page.locator('body')).not.toContainText('de 7 requisitos')
 })
 
 test('10.10 — Marca: widget de feedback aparece', async ({ page }) => {
@@ -371,22 +384,16 @@ test('10.11 — Estado: dashboard con 3 secciones claras y datos reales', async 
   await expect(page.getByText('Que esta funcionando?')).toBeVisible()
 })
 
-test('10.12 — Estado: sidebar tiene Dashboard y Exportar Datos', async ({ page }) => {
+test('10.12 — Estado: header tiene tabs Dashboard y Exportar', async ({ page }) => {
   test.setTimeout(60000)
   await loginAs(page, 'estado')
+  await page.waitForLoadState('networkidle')
 
-  await page.getByLabel('Abrir menú personal').click()
-  await page.waitForTimeout(800)
-
-  const sidebar = page.locator('aside[aria-label="Menú de navegación personal"]')
-  await expect(sidebar).toBeVisible()
-
-  const expectedItems = ['Dashboard', 'Exportar Datos']
-  for (const item of expectedItems) {
-    const link = sidebar.getByRole('link', { name: item })
-    const visible = await link.isVisible().catch(() => false)
-    expect(visible, `Sidebar debe tener link "${item}"`).toBe(true)
-  }
+  // Post-F3 (#375): navegación de sección en los tabs del header (banda 2).
+  // ESTADO no se renombra en Etapa 1 (su renombre a COORD es Etapa 2).
+  const tabsNav = page.locator('header nav')
+  await expect(tabsNav.getByRole('link', { name: 'Dashboard', exact: true })).toBeVisible()
+  await expect(tabsNav.getByRole('link', { name: 'Exportar', exact: true })).toBeVisible()
 })
 
 // --- Actor ADMIN (Lucia) ---

--- a/src/app/(marca)/marca/directorio/[id]/page.tsx
+++ b/src/app/(marca)/marca/directorio/[id]/page.tsx
@@ -43,7 +43,7 @@ export default async function TallerPerfilMarcaPage({ params }: { params: Promis
     <div className="max-w-3xl mx-auto py-6 px-4">
       <Breadcrumbs items={[
         { label: 'Marca', href: '/marca' },
-        { label: 'Directorio', href: '/marca/directorio' },
+        { label: 'Explorar talleres', href: '/marca/directorio' },
         { label: taller.nombre },
       ]} />
 

--- a/src/app/(marca)/marca/directorio/page.tsx
+++ b/src/app/(marca)/marca/directorio/page.tsx
@@ -6,7 +6,7 @@ import { redirect } from 'next/navigation'
 import { Card } from '@/compartido/componentes/ui/card'
 import { Badge } from '@/compartido/componentes/ui/badge'
 import Link from 'next/link'
-import { MapPin, Star, MessageCircle, Factory, ShieldCheck } from 'lucide-react'
+import { MapPin, Star, MessageCircle, Factory } from 'lucide-react'
 import { BadgeArca } from '@/compartido/componentes/badge-arca'
 import { EmptyState } from '@/compartido/componentes/ui/empty-state'
 
@@ -87,7 +87,7 @@ export default async function DirectorioPage({
     <div className="space-y-6">
       <div>
         <h1 className="font-serif font-bold text-3xl text-ink-primary">
-          Explorar Proveedores
+          Explorar talleres
         </h1>
         <p className="text-gray-600 mt-2">
           Registro de unidades productivas acreditadas
@@ -199,14 +199,6 @@ export default async function DirectorioPage({
                     {taller.nombre}
                   </h3>
                   {taller.verificadoAfip && <BadgeArca verificado={true} />}
-                  {taller.validaciones.length > 0 && (
-                    <div className="flex items-center gap-1 mt-1">
-                      <ShieldCheck className="w-3.5 h-3.5 text-green-600 shrink-0" />
-                      <span className="text-xs text-green-700 font-medium">
-                        {taller.validaciones.length} de 7 requisitos verificados
-                      </span>
-                    </div>
-                  )}
                 </div>
 
                 {taller.ubicacion && (

--- a/src/app/(marca)/marca/pedidos/page.tsx
+++ b/src/app/(marca)/marca/pedidos/page.tsx
@@ -82,7 +82,7 @@ async function PedidosContent({ query, estado, created }: { query: string; estad
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mis pedidos</h1>
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">Pedidos</h1>
         <p className="text-gray-600 mt-2">Seguimiento de pedidos de {marca.nombre}</p>
       </div>
 

--- a/src/app/(marca)/marca/perfil/page.tsx
+++ b/src/app/(marca)/marca/perfil/page.tsx
@@ -69,7 +69,7 @@ export default async function MarcaPerfilPage() {
   if (!marca) {
     return (
       <div className="space-y-6">
-        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi perfil de marca</h1>
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi marca</h1>
         <div className="bg-white rounded-xl shadow-sm p-6 border border-gray-200">
           <p className="text-gray-700">No encontramos datos de marca para este usuario.</p>
         </div>
@@ -80,7 +80,7 @@ export default async function MarcaPerfilPage() {
   return (
     <div className="space-y-6">
       <Suspense><SaveToast message="Perfil actualizado" /></Suspense>
-      <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi perfil de marca</h1>
+      <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi marca</h1>
 
       <div className="grid gap-4 sm:grid-cols-3">
         <div className="bg-white rounded-xl border border-gray-200 p-4">

--- a/src/app/(public)/directorio/page.tsx
+++ b/src/app/(public)/directorio/page.tsx
@@ -6,7 +6,7 @@ import { prisma } from '@/compartido/lib/prisma'
 import { getFeatureFlag } from '@/compartido/lib/features'
 import { Badge } from '@/compartido/componentes/ui/badge'
 import { Card } from '@/compartido/componentes/ui/card'
-import { Star, MapPin, Users, ArrowRight, Factory, ShieldCheck } from 'lucide-react'
+import { Star, MapPin, Users, ArrowRight, Factory } from 'lucide-react'
 import { BadgeArca } from '@/compartido/componentes/badge-arca'
 import { EmptyState } from '@/compartido/componentes/ui/empty-state'
 
@@ -144,14 +144,6 @@ export default async function DirectorioPage({
                 <div className="mb-3">
                   <h2 className="font-overpass font-bold text-lg text-brand-blue">{taller.nombre}</h2>
                   {taller.verificadoAfip && <BadgeArca verificado={true} />}
-                  {taller.validaciones.length > 0 && (
-                    <div className="flex items-center gap-1 mt-1">
-                      <ShieldCheck className="w-3.5 h-3.5 text-green-600 shrink-0" />
-                      <span className="text-xs text-green-700 font-medium">
-                        {taller.validaciones.length} de 7 requisitos verificados
-                      </span>
-                    </div>
-                  )}
                 </div>
 
                 {(taller.provincia || taller.ubicacion) && (

--- a/src/app/(taller)/taller/perfil/page.tsx
+++ b/src/app/(taller)/taller/perfil/page.tsx
@@ -36,7 +36,7 @@ export default async function TallerPerfilPage() {
   if (!taller) {
     return (
       <div className="space-y-6">
-        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi vidriera</h1>
+        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi taller</h1>
         <Card className="text-center py-12">
           <p className="text-gray-600 mb-4">Todavía no completaste tu perfil.</p>
           <Link href="/taller/perfil/completar">

--- a/src/compartido/lib/content/institutional.ts
+++ b/src/compartido/lib/content/institutional.ts
@@ -25,16 +25,16 @@ export const FOOTER_LINKS = {
 export const TABS_BY_ROLE = {
   TALLER: [
     { label: 'Inicio', href: '/taller' },
-    { label: 'Pedidos', href: '/taller/pedidos' },
+    { label: 'Mi taller', href: '/taller/perfil' },
     { label: 'Mi recorrido', href: '/taller/formalizacion' },
-    { label: 'Mi vidriera', href: '/taller/perfil' },
     { label: 'Cursos', href: '/taller/aprender' },
+    { label: 'Pedidos', href: '/taller/pedidos' },
   ],
   MARCA: [
-    { label: 'Tablero', href: '/marca' },
-    { label: 'Directorio', href: '/marca/directorio' },
-    { label: 'Mis pedidos', href: '/marca/pedidos' },
-    { label: 'Mi perfil', href: '/marca/perfil' },
+    { label: 'Inicio', href: '/marca' },
+    { label: 'Mi marca', href: '/marca/perfil' },
+    { label: 'Explorar talleres', href: '/marca/directorio' },
+    { label: 'Pedidos', href: '/marca/pedidos' },
   ],
   ESTADO: [
     { label: 'Dashboard', href: '/estado' },

--- a/tests/e2e/acceso-verificado.spec.ts
+++ b/tests/e2e/acceso-verificado.spec.ts
@@ -37,7 +37,7 @@ test.describe('Acceso pre-formalizacion y niveles privados', () => {
 
     await page.goto('/marca/directorio')
     // Timeout 30s: streaming SSR + cold start en preview
-    await expect(page.getByRole('heading', { name: 'Explorar Proveedores' })).toBeVisible({ timeout: 30000 })
+    await expect(page.getByRole('heading', { name: 'Explorar talleres' })).toBeVisible({ timeout: 30000 })
 
     // No deberia haber filtro de nivel
     await expect(page.locator('select[name="nivel"]')).toHaveCount(0)

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -26,7 +26,7 @@ test.describe('Smoke test — setup basico funciona', () => {
     // El header debe mostrar tabs del taller (scoped al header)
     const header = page.locator('header')
     await expect(header.getByText('Pedidos').first()).toBeVisible()
-    await expect(header.getByText('Mi vidriera').first()).toBeVisible()
+    await expect(header.getByText('Mi taller').first()).toBeVisible()
     // Sidebar visible en desktop (F1) — hamburguesa oculta en lg+
     await expect(page.locator('aside[aria-label="Menú principal"]')).toBeVisible()
   })


### PR DESCRIPTION
Implementa **§1.1 + §1.2** de la Narrativa V4 según el spec aprobado por Gerardo (`.claude/specs/v4-narrativa-etapa-1.md`).

## Cambios

**Tabs del header (`TABS_BY_ROLE` en institutional.ts):**
- **TALLER:** `Inicio · Mi taller · Mi recorrido · Cursos · Pedidos` ("Mi vidriera"→"Mi taller", Pedidos al final)
- **MARCA:** `Inicio · Mi marca · Explorar talleres · Pedidos` (sin "Cursos" — Academia marcas es Etapa 3)

**H1/encabezados alineados (D-B):** taller/perfil, marca/perfil (×2), marca/directorio, marca/pedidos, breadcrumb marca/directorio/[id]. El saludo personal de marca/page se deja.

**§1.2 — "X de 7" público fuera:** quitado de `/directorio` (público) y `/marca/directorio`. Se conserva el badge ARCA. El "X de 7" **privado** de Mi recorrido **no se toca**.

## Tests / Deuda T-03
- `checklist-sec9-10.spec.ts`: 10.2/10.9 reescritos a los tabs del header (post-F3 #375 la nav de sección vive ahí). Se limpió staleness adicional: 10.12 (ESTADO) y 9.1/9.2 (Academia→Cursos).
- Agregados asserts del Flujo 4 (vidriera sin "X de 7"): 10.9b + 10.9c.
- **T-03 movida a "Resueltas"** en `DEUDA_TECNICA.md`.

## Fuera de scope (specs propios)
§1.3 (Modelo B visibilidad, schema) · §1.4 (vitrina info marca, lógica). Identifiers internos (`Vidriera` Prisma) sin cambios.

Refs spec `v4-narrativa-etapa-1`. Resuelve T-03.

🤖 Generated with [Claude Code](https://claude.com/claude-code)