### PR TITLE
chore: sprint deuda tecnica batch-1

### DIFF
--- a/.claude/DEUDA_TECNICA.md
+++ b/.claude/DEUDA_TECNICA.md
@@ -9,35 +9,6 @@ y prioridad sugerida.
 
 ## Frontend / UI
 
-### F-01: Card de perfil muestra Formalización > 100%
-- **Detectado en:** QA r2 de #398 (U-09) por Sergio, con Carlos Mendoza
-- **Descripción:** la card "Corte Sur SRL" en /cuenta mostraba
-  "Formalización: 135%". El cálculo de % suma puntos sin tope al 100%.
-- **Impacto:** UI confusa, valor ilegal matemáticamente
-- **Prioridad:** baja-media (no rompe funcionalidad, solo UX)
-- **Estimación:** 30 min (limitar el % a Math.min(100, ...) en el cálculo)
-
-### F-02: Link a /cuenta no visible para roles operativos
-- **Detectado en:** QA r2 de #398 (U-09) por Sergio
-- **Descripción:** roles ADMIN/ESTADO/CONTENIDO solo acceden a /cuenta
-  escribiendo la URL a mano. No hay link en menú/header/dropdown.
-- **Impacto:** los users de equipo no pueden cambiar contraseña o ver
-  sus datos sin saber la URL
-- **Prioridad:** media (UX rota para roles administrativos)
-- **Estimación:** 1h (agregar link al dropdown del avatar para todos
-  los roles)
-
-### F-03: on-blur sin debounce dispara N requests a ARCA
-- **Detectado en:** Discovery del costo CUIT en #398 (U-09)
-- **Descripción:** src/.../registro/page.tsx línea ~251: el input de
-  CUIT dispara consultarPadron en cada blur, sin debounce. Editar
-  4 veces el campo = 4 requests a AFIP SDK.
-- **Impacto:** a escala piloto (250 calls totales) negligible, pero
-  consume cuota innecesariamente. A escala mayor podría llegar al
-  techo del free tier.
-- **Prioridad:** baja (innecesario en piloto, importante post-piloto)
-- **Estimación:** 30 min (agregar debounce o cachear último CUIT validado)
-
 ### F-04: Cosmético dashboards V4 (X-07b)
 - **Detectado en:** Discovery Nivel 5 (2026-06-08)
 - **Descripción:** ajustes cosméticos menores en dashboards: grays,
@@ -61,57 +32,6 @@ y prioridad sugerida.
 - **Impacto:** mantenimiento duplicado, deuda de consistencia
 - **Prioridad:** baja (no rompe nada, pero ensucia)
 - **Estimación:** 2-3h (unificar en un solo helper)
-
-### B-02: Skip ARCA podría leer User.cuit/verificadoAfip
-- **Detectado en:** Fix D r2 de #398 (U-09), nota del agente
-- **Descripción:** el skip de ARCA en POST /me/roles compara contra
-  CUITs de entidades existentes (Taller.cuit/Marca.cuit). Para users
-  con CUIT verificado en User.cuit pero sin entidad (caso registro
-  abandonado tipo srodriguezunq), el skip no se dispara y siempre va
-  a ARCA.
-- **Impacto:** caso borde raro. Genera un request innecesario en muy
-  pocos casos.
-- **Prioridad:** baja (~2 líneas de código)
-- **Estimación:** 15 min
-
-### B-03: Doble query en layout y page de /cuenta
-- **Detectado en:** Fix A r2 de #398 (U-09)
-- **Descripción:** layout y page de /cuenta consultan taller/marca por
-  separado. Una sola consulta podría servir a ambos.
-- **Impacto:** performance marginal, no es bottleneck
-- **Prioridad:** muy baja (optimización menor)
-- **Estimación:** 30 min
-
-### B-04: isCiBypass con doble responsabilidad (rate-limit + endpoint mutante)
-- **Detectado en:** Auditoría del endpoint reset de test (2026-06-09)
-- **Descripción:** isCiBypass se diseñó para saltar rate-limit (bajo
-  riesgo). Ahora también autoriza el endpoint mutante
-  /api/test-utils/reset-seed-state (riesgo medio). Una relajación futura de
-  isCiBypass por motivos de rate-limit ensancharía silenciosamente la
-  autorización del endpoint destructivo.
-- **Impacto:** acoplamiento de seguridad. No es vuln activa (el endpoint
-  tiene guard de prod + hardcode a un set fijo de users de seed, sin userId
-  del request), pero es deuda de diseño.
-- **ROOT CAUSE del cleanup roto (2026-06-09):** el endpoint vivía en
-  `src/app/api/_test/...`. En el App Router de Next.js, **una carpeta con
-  prefijo `_` es "private folder" y queda EXCLUIDA del routing** → la ruta
-  `/api/_test/...` NUNCA existió: devolvía el 404 HTML de not-found (no el
-  JSON del guard) en TODOS los runs de CI. El cleanup nunca corrió; el
-  diagnóstico previo (NODE_ENV) era un red herring (el guard jamás se
-  ejecutaba). Fix: renombrado `_test` → `test-utils` (ruta
-  `/api/test-utils/reset-seed-state`). Lección: NO usar prefijo `_` en
-  segmentos de ruta del App Router. Verificar siempre el body del 404 (JSON
-  del guard = ruta existe; HTML = ruta no matcheada).
-- **Nota:** el guard de prod usa solo `VERCEL_ENV === 'production'` (NO
-  NODE_ENV, que es SIEMPRE 'production' en deploys Vercel incl. preview).
-  Endpoint: reset-seed-state con allowlist `?user=u09|julieta` (enum cerrado,
-  clave desconocida → 400). Cada spec resetea SOLO su usuario → sin
-  contaminación cruzada entre workers paralelos. El `user` NO es un userId
-  arbitrario (mapea a un email hardcodeado), preserva la propiedad de seguridad.
-- **Prioridad:** baja-media
-- **Solución:** guard dedicado para endpoints mutantes de test,
-  separado del bypass de rate-limit
-- **Estimación:** 30 min
 
 ### B-05: Race de clobbering de cookie en rolling JWT session
 - **Detectado en:** Diagnóstico de fallos e2e u-09 en T-04 (2026-06-09)
@@ -284,6 +204,82 @@ y prioridad sugerida.
 - Items resueltos: mover a sección "Resueltas" con SHA o PR de fix
 
 ## Resueltas
+
+### F-01: Card de perfil muestra Formalización > 100% — RESUELTA
+- **Detectado en:** QA r2 de #398 (U-09) por Sergio, con Carlos Mendoza
+- **Resuelta en:** sprint deuda batch-1 (`chore/deuda-tecnica-batch-1`, 2026-06-09)
+- **Causa raíz:** `taller.puntaje` es un SCORE crudo (suma de `puntosOtorgados`
+  de las validaciones COMPLETADO + bonus AFIP), deliberadamente SIN tope (ver
+  `nivel.test.ts` "no hay cap de puntaje"). La UI lo mostraba directo con `%`, así
+  que un taller con score > 100 mostraba "135%". No era solo falta de Math.min: NO
+  había divisor — se mostraban puntos como porcentaje.
+- **Fix:** helpers `maxPuntosFormalizacion()` + `porcentajeFormalizacion(puntaje)`
+  en `src/compartido/lib/nivel.ts` (punto ÚNICO de cálculo). El % = `puntaje / máx
+  alcanzable`, capado a 100 con `Math.min`. El divisor es DINÁMICO (suma de puntos
+  de los tipos de documento requeridos+activos + AFIP_BONUS) → se ajusta solo al
+  agregar/quitar tipos (arregla el "divisor desactualizado"). Render sites migrados:
+  `(public)/cuenta/page.tsx` y el sidebar del taller vía `(taller)/layout.tsx`
+  (label + barra de progreso). `taller/perfil` muestra `{puntaje} pts` (puntos, no
+  %) — correcto, sin tocar.
+
+### F-02: Link a /cuenta no visible para roles operativos — RESUELTA
+- **Detectado en:** QA r2 de #398 (U-09) por Sergio
+- **Resuelta en:** sprint deuda batch-1 (`chore/deuda-tecnica-batch-1`, 2026-06-09)
+- **Causa raíz:** ESTADO ya usaba el `Header` compartido (que tiene "Mi cuenta" en
+  el dropdown del avatar), pero ADMIN y CONTENIDO usan layouts PROPIOS con headers
+  custom que no incluían el link → solo llegaban a /cuenta por URL.
+- **Fix:** agregado `<Link href="/cuenta">Mi cuenta</Link>` en los headers de
+  `(admin)/layout.tsx` y `(contenido)/layout.tsx`. /cuenta ya maneja roles de
+  equipo (oculta "Tus perfiles" y "Agregar rol"). ESTADO ya estaba cubierto.
+
+### F-03: on-blur sin debounce dispara N requests a ARCA — RESUELTA
+- **Detectado en:** Discovery del costo CUIT en #398 (U-09)
+- **Resuelta en:** sprint deuda batch-1 (`chore/deuda-tecnica-batch-1`, 2026-06-09)
+- **Fix:** `registro/page.tsx` cachea el último CUIT con resultado DEFINITIVO
+  (verificado o inválido) en un `useRef`; un blur con el mismo CUIT ya consultado
+  no re-llama a ARCA. Los resultados transitorios (servicio caído / error de red)
+  NO se cachean → permiten reintento. Si el CUIT cambia, se vuelve a validar. Sin
+  librería de debounce (el cache del último valor alcanza).
+
+### B-02: Skip ARCA podría leer User.cuit/verificadoAfip — RESUELTA
+- **Detectado en:** Fix D r2 de #398 (U-09), nota del agente
+- **Resuelta en:** sprint deuda batch-1 (`chore/deuda-tecnica-batch-1`, 2026-06-09)
+- **Fix:** `POST /api/usuarios/me/roles` agrega `User.cuit` + `User.verificadoAfip`
+  a la lista de CUITs verificados contra la que compara el skip de ARCA. MISMO gate
+  semántico (`verificadoAfip === true`): presencia de CUIT no implica verificación.
+  Cubre el caso "registro abandonado" (CUIT verificado en User sin entidad creada).
+  2 tests nuevos en `u-09-agregar-rol.test.ts` (skip con User verificado; SÍ llama
+  a ARCA si User.cuit presente pero no verificado).
+
+### B-03: Doble query en layout y page de /cuenta — RESUELTA
+- **Detectado en:** Fix A r2 de #398 (U-09)
+- **Resuelta en:** sprint deuda batch-1 (`chore/deuda-tecnica-batch-1`, 2026-06-09)
+- **Verificación:** NO estaban deduplicadas (funciones distintas, selects distintos
+  → React `cache()` no las unía). No era no-op.
+- **Fix:** helper `getPerfilesUsuario(userId)` envuelto en `cache()` de React en
+  `entidades-modo.ts`, con el superset de campos. `construirEntidadesModo` (layout)
+  y `cuenta/page.tsx` ahora pasan por él → dentro de un request comparten una sola
+  ejecución (un multi-rol que abre /cuenta colapsa 4 queries → 2). Se preserva el
+  early-return de single-rol (sin DB hit).
+
+### B-04: isCiBypass con doble responsabilidad — RESUELTA
+- **Detectado en:** Auditoría del endpoint reset de test (2026-06-09)
+- **Resuelta en:** sprint deuda batch-1 (`chore/deuda-tecnica-batch-1`, 2026-06-09)
+- **Fix:** función DEDICADA `isTestMutationAllowed(req)` en `ratelimit.ts`, con las
+  mismas validaciones (token + `VERCEL_ENV != production` + header x-ci-bypass) pero
+  SEPARADA de `isCiBypass` a propósito: relajar el bypass de rate-limit ya no
+  ensancha la autorización del endpoint mutante sin tocar esta función. El endpoint
+  `reset-seed-state` usa el guard nuevo; `ratelimit.ts`/`isCiBypass` quedan intactos
+  para rate-limit. 4 unit tests del guard nuevo (token ausente, prod, header
+  incorrecto → false; caso válido → true).
+- **Nota histórica (ROOT CAUSE del cleanup roto, 2026-06-09):** el endpoint vivía en
+  `src/app/api/_test/...`; el prefijo `_` lo volvía "private folder" del App Router
+  → la ruta nunca existió (404 HTML, no JSON del guard). Resuelto en #407 renombrando
+  `_test` → `test-utils`. Regla: nunca prefijo `_` en segmentos de ruta; verificar el
+  body del 404 (JSON = ruta existe; HTML = no matcheó). Guard de prod usa
+  `VERCEL_ENV` (NO NODE_ENV, siempre 'production' en deploys Vercel). Endpoint con
+  allowlist `?user=u09|julieta` (enum cerrado; clave desconocida → 400; no acepta
+  userId arbitrario).
 
 ### T-03: Test e2e checklist-sec9-10.spec.ts con labels stale — RESUELTA (con corrección de diagnóstico)
 - **Detectado en:** Discovery narrativa V4 Etapa 1 (2026-06-07)

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,21 @@
 ## 2026-06-09
 
 ### Gerardo Breard
+- **23:53** `8aa40e5` — chore: sprint deuda tecnica batch-1 (F-01/02/03 + B-02/03/04)
+  - `.claude/DEUDA_TECNICA.md`
+  - `src/__tests__/ratelimit.test.ts`
+  - `src/__tests__/u-09-agregar-rol.test.ts`
+  - `src/app/(admin)/layout.tsx`
+  - `src/app/(auth)/registro/page.tsx`
+  - `src/app/(contenido)/layout.tsx`
+  - `src/app/(public)/cuenta/page.tsx`
+  - `src/app/(taller)/layout.tsx`
+  - `src/app/api/test-utils/reset-seed-state/route.ts`
+  - `src/app/api/usuarios/me/roles/route.ts`
+  - `src/compartido/lib/entidades-modo.ts`
+  - `src/compartido/lib/nivel.ts`
+  - `src/compartido/lib/ratelimit.ts`
+
 - **22:58** `99d8dbf` — test(t-04): estabilizar u-09 — esperar respuesta de /me/roles antes del redirect
   - `tests/e2e/u-09-agregar-segundo-rol.spec.ts`
 

--- a/src/__tests__/ratelimit.test.ts
+++ b/src/__tests__/ratelimit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { getClientIp, isCiBypass } from '@/compartido/lib/ratelimit'
+import { getClientIp, isCiBypass, isTestMutationAllowed } from '@/compartido/lib/ratelimit'
 import { NextRequest } from 'next/server'
 
 function makeReq(headers: Record<string, string> = {}): NextRequest {
@@ -89,5 +89,50 @@ describe('isCiBypass', () => {
     process.env.VERCEL_ENV = 'preview'
     const req = makeReq()
     expect(isCiBypass(req)).toBe(false)
+  })
+})
+
+// B-04: guard dedicado para endpoints mutantes de test, separado de isCiBypass.
+describe('isTestMutationAllowed', () => {
+  const savedEnv: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    savedEnv.CI_BYPASS_TOKEN = process.env.CI_BYPASS_TOKEN
+    savedEnv.VERCEL_ENV = process.env.VERCEL_ENV
+  })
+
+  afterEach(() => {
+    if (savedEnv.CI_BYPASS_TOKEN === undefined) delete process.env.CI_BYPASS_TOKEN
+    else process.env.CI_BYPASS_TOKEN = savedEnv.CI_BYPASS_TOKEN
+    if (savedEnv.VERCEL_ENV === undefined) delete process.env.VERCEL_ENV
+    else process.env.VERCEL_ENV = savedEnv.VERCEL_ENV
+  })
+
+  it('permite si token matchea y env es preview', () => {
+    process.env.CI_BYPASS_TOKEN = 'test-secret-token'
+    process.env.VERCEL_ENV = 'preview'
+    const req = makeReq({ 'x-ci-bypass': 'test-secret-token' })
+    expect(isTestMutationAllowed(req)).toBe(true)
+  })
+
+  it('NO permite sin token configurado', () => {
+    delete process.env.CI_BYPASS_TOKEN
+    process.env.VERCEL_ENV = 'preview'
+    const req = makeReq({ 'x-ci-bypass': 'any-token' })
+    expect(isTestMutationAllowed(req)).toBe(false)
+  })
+
+  it('NO permite en production (aunque token matchee)', () => {
+    process.env.CI_BYPASS_TOKEN = 'test-secret-token'
+    process.env.VERCEL_ENV = 'production'
+    const req = makeReq({ 'x-ci-bypass': 'test-secret-token' })
+    expect(isTestMutationAllowed(req)).toBe(false)
+  })
+
+  it('NO permite si el header no coincide', () => {
+    process.env.CI_BYPASS_TOKEN = 'real-token'
+    process.env.VERCEL_ENV = 'preview'
+    const req = makeReq({ 'x-ci-bypass': 'wrong-token' })
+    expect(isTestMutationAllowed(req)).toBe(false)
   })
 })

--- a/src/__tests__/u-09-agregar-rol.test.ts
+++ b/src/__tests__/u-09-agregar-rol.test.ts
@@ -119,6 +119,38 @@ describe('POST /api/usuarios/me/roles', () => {
     expect(mockPadron).toHaveBeenCalledWith('30-71890234-5')
   })
 
+  it('B-02: CUIT verificado en User (sin entidad) → 200 SIN llamar a ARCA', async () => {
+    // Caso registro abandonado: el User tiene cuit + verificadoAfip=true pero NO
+    // creó entidad. El skip debe disparar leyendo User.cuit/verificadoAfip.
+    mockUserFind.mockResolvedValue({
+      id: 'u1', roles: ['TALLER'], role: 'TALLER',
+      cuit: '20123456789', verificadoAfip: true,
+      taller: null, marca: null,
+    })
+    mockCrear.mockResolvedValue({ id: 'marca-1' })
+
+    const res = await post({ rol: 'MARCA', nombre: 'Mi Marca', cuit: '20-12345678-9' })
+    expect(res.status).toBe(200)
+    expect(mockPadron).not.toHaveBeenCalled()
+    const crearArgs = mockCrear.mock.calls[0][1]
+    expect(crearArgs.verificadoAfip).toBe(true)
+  })
+
+  it('B-02: CUIT presente en User pero NO verificado → SÍ llama a ARCA', async () => {
+    // Mismo gate semántico que entidades: presencia de CUIT no implica verificación.
+    mockUserFind.mockResolvedValue({
+      id: 'u1', roles: ['TALLER'], role: 'TALLER',
+      cuit: '20123456789', verificadoAfip: false,
+      taller: null, marca: null,
+    })
+    mockCrear.mockResolvedValue({ id: 'marca-1' })
+
+    const res = await post({ rol: 'MARCA', nombre: 'Mi Marca', cuit: '20-12345678-9' })
+    expect(res.status).toBe(200)
+    expect(mockPadron).toHaveBeenCalledTimes(1)
+    expect(mockPadron).toHaveBeenCalledWith('20-12345678-9')
+  })
+
   it('D: CUIT difiere del verificado → 200 LLAMANDO a ARCA como antes', async () => {
     mockUserFind.mockResolvedValue({
       id: 'u1', roles: ['TALLER'], role: 'TALLER',

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -46,6 +46,9 @@ export default async function AdminLayout({ children }: { children: React.ReactN
           <div className="flex items-center gap-4">
             <NotificacionesBell />
             <span className="text-sm text-white/70">{session.user.name}</span>
+            {/* F-02: roles de equipo (ADMIN) usan este header propio, sin el dropdown
+                del Header compartido. Sin este link, /cuenta solo era accesible por URL. */}
+            <Link href="/cuenta" className="text-sm hover:text-white/70 transition-colors">Mi cuenta</Link>
             <Link href="/" className="text-sm hover:text-white/70 transition-colors">Volver al sitio</Link>
             <LogoutButton />
           </div>

--- a/src/app/(auth)/registro/page.tsx
+++ b/src/app/(auth)/registro/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, Suspense } from 'react'
+import { useState, useRef, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { useForm } from 'react-hook-form'
@@ -234,12 +234,22 @@ function StepEntidadInfo({
 
   const cuitValue = watch('cuit')
 
+  // F-03: cache del último CUIT con resultado DEFINITIVO (verificado o inválido).
+  // Cada blur con 11 dígitos dispara una call a ARCA; sin esto, volver al campo y
+  // salir sin cambiar nada re-consultaba el mismo CUIT y gastaba cuota. Solo se
+  // cachean resultados definitivos: un "pendiente" (servicio caído) NO se cachea
+  // para permitir reintento. Si el CUIT cambia, se vuelve a validar (ref distinta).
+  const ultimoCuitConsultado = useRef<string | null>(null)
+
   // Errores que indican que el CUIT es realmente invalido (no que el servicio fallo)
   const ERRORES_CUIT_INVALIDO = ['inexistente', 'inactivo', 'invalido']
 
   async function verificarCuitOnBlur() {
     const limpio = (cuitValue || '').replace(/-/g, '')
     if (limpio.length !== 11) return
+
+    // F-03: mismo CUIT ya consultado con resultado definitivo → no re-llamar a ARCA.
+    if (limpio === ultimoCuitConsultado.current) return
 
     setCuitLoading(true)
     setCuitError('')
@@ -253,18 +263,20 @@ function StepEntidadInfo({
       if (data.valid) {
         setCuitVerificado(true)
         setCuitData({ razonSocial: data.razonSocial })
+        ultimoCuitConsultado.current = limpio // F-03: resultado definitivo → cachear
       } else {
         const errorMsg = (typeof data.error === 'string' ? data.error : data.error?.message || '').toLowerCase()
         const esCuitInvalido = ERRORES_CUIT_INVALIDO.some(e => errorMsg.includes(e))
         if (esCuitInvalido) {
           setCuitError(typeof data.error === 'string' ? data.error : data.error?.message || 'CUIT invalido')
+          ultimoCuitConsultado.current = limpio // F-03: inválido es definitivo → cachear
         } else {
-          // Servicio no disponible — permitir continuar
+          // Servicio no disponible — permitir continuar (transitorio, NO cachear: reintenta)
           setCuitPendiente(true)
         }
       }
     } catch {
-      // Error de red — permitir continuar
+      // Error de red — permitir continuar (transitorio, NO cachear: reintenta)
       setCuitPendiente(true)
     } finally {
       setCuitLoading(false)

--- a/src/app/(contenido)/layout.tsx
+++ b/src/app/(contenido)/layout.tsx
@@ -17,6 +17,11 @@ export default async function ContenidoLayout({ children }: { children: React.Re
             <span className="font-overpass font-bold text-lg">Panel de Contenidos</span>
           </div>
           <div className="flex items-center gap-4">
+            {/* F-02: CONTENIDO usa este header propio, sin el dropdown del Header
+                compartido. Sin este link, /cuenta solo era accesible por URL. */}
+            <Link href="/cuenta" className="text-sm hover:text-white/70 transition-colors">
+              Mi cuenta
+            </Link>
             <Link href="/" className="text-sm hover:text-white/70 transition-colors">
               Volver al sitio
             </Link>

--- a/src/app/(public)/cuenta/page.tsx
+++ b/src/app/(public)/cuenta/page.tsx
@@ -5,6 +5,8 @@ import { redirect } from 'next/navigation'
 import { auth } from '@/compartido/lib/auth'
 import { prisma } from '@/compartido/lib/prisma'
 import { rolesEfectivos } from '@/compartido/lib/roles'
+import { getPerfilesUsuario } from '@/compartido/lib/entidades-modo'
+import { porcentajeFormalizacion } from '@/compartido/lib/nivel'
 import { Bell, User, ShieldCheck, Building2, ShoppingBag, ArrowRight } from 'lucide-react'
 import { CuentaWhatsappForm } from '@/compartido/componentes/cuenta-whatsapp-form'
 import { AgregarRolCard } from '@/compartido/componentes/agregar-rol-card'
@@ -38,10 +40,13 @@ export default async function CuentaPage() {
 
   // Perfiles operativos del USUARIO (puede tener 1 o 2). /cuenta es del user, no del
   // rol activo: mostramos TODOS sus perfiles, sea cual sea el activeMode.
-  const [taller, marca] = await Promise.all([
-    prisma.taller.findFirst({ where: { userId: user.id }, select: { cuit: true, nombre: true, puntaje: true } }),
-    prisma.marca.findFirst({ where: { userId: user.id }, select: { cuit: true, nombre: true } }),
-  ])
+  // B-03: lectura cacheada compartida con el layout (construirEntidadesModo) →
+  // un multi-rol que abre /cuenta no duplica las queries de taller/marca.
+  const { taller, marca } = await getPerfilesUsuario(user.id)
+
+  // F-01: % de formalización capado (0-100). El campo `taller.puntaje` es un score
+  // crudo sin tope; mostrarlo directo con `%` daba valores ilegales (ej. "135%").
+  const formalizacionPct = taller ? await porcentajeFormalizacion(taller.puntaje ?? 0) : 0
 
   // U-09: ofrecer "agregar segundo rol" solo a un single user-rol (tiene exactamente
   // una de las dos entidades). El CUIT existente pre-llena el formulario.
@@ -92,7 +97,7 @@ export default async function CuentaPage() {
                   <Building2 className="w-5 h-5 text-brand-blue" />
                   <h3 className="font-overpass font-semibold text-gray-800 truncate">{taller.nombre}</h3>
                 </div>
-                <p className="text-sm text-gray-500">Formalización: <span className="font-medium text-gray-700">{taller.puntaje ?? 0}%</span></p>
+                <p className="text-sm text-gray-500">Formalización: <span className="font-medium text-gray-700">{formalizacionPct}%</span></p>
                 <Link href="/taller" className="mt-1 inline-flex items-center gap-1 text-sm font-overpass font-semibold text-brand-blue hover:underline">
                   Ir al taller <ArrowRight className="w-4 h-4" />
                 </Link>

--- a/src/app/(taller)/layout.tsx
+++ b/src/app/(taller)/layout.tsx
@@ -3,6 +3,7 @@ import { Footer } from '@/compartido/componentes/layout/footer'
 import { requiereRol } from '@/compartido/lib/permisos'
 import { prisma } from '@/compartido/lib/prisma'
 import { construirEntidadesModo } from '@/compartido/lib/entidades-modo'
+import { porcentajeFormalizacion } from '@/compartido/lib/nivel'
 
 export default async function TallerLayout({ children }: { children: React.ReactNode }) {
   const session = await requiereRol(['TALLER'])
@@ -18,7 +19,9 @@ export default async function TallerLayout({ children }: { children: React.React
 
   const userName = taller?.nombre || session.user.name || 'Mi Taller'
   const userLevel = taller?.nivel || 'BRONCE'
-  const userProgress = taller?.puntaje || 0
+  // F-01: el sidebar muestra esto como "Formalización X%" + barra de progreso, así
+  // que debe ser un porcentaje 0-100 (capado), no el score crudo `puntaje`.
+  const userProgress = await porcentajeFormalizacion(taller?.puntaje ?? 0)
 
   // U-04: datos para el toggle multi-rol (no-op si single-role).
   const entidades = await construirEntidadesModo(session.user.id, session.user.roles)

--- a/src/app/api/test-utils/reset-seed-state/route.ts
+++ b/src/app/api/test-utils/reset-seed-state/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { isCiBypass } from '@/compartido/lib/ratelimit'
+import { isTestMutationAllowed } from '@/compartido/lib/ratelimit'
 
 // Endpoint SOLO-CI — resetea UN usuario mutable del seed a su estado inicial.
 //
@@ -23,10 +23,11 @@ import { isCiBypass } from '@/compartido/lib/ratelimit'
 // afterEach de u-04 pisara a u09 en pleno test de u-09 (y viceversa) → falsos
 // fallos. Por eso el reset es por-usuario.
 //
-// Doble guard: prod explícito + isCiBypass (CI_BYPASS_TOKEN + header x-ci-bypass
-// + VERCEL_ENV != production). Sin bypass válido devuelve 404 (no revela la ruta).
-// El runner de e2e no tiene DATABASE_URL (no hay acceso directo a DB), por eso el
-// cleanup va por API server-side.
+// Doble guard: prod explícito + isTestMutationAllowed (B-04: guard DEDICADO para
+// mutaciones de test, separado de isCiBypass/rate-limit; CI_BYPASS_TOKEN + header
+// x-ci-bypass + VERCEL_ENV != production). Sin permiso válido devuelve 404 (no
+// revela la ruta). El runner de e2e no tiene DATABASE_URL (no hay acceso directo a
+// DB), por eso el cleanup va por API server-side.
 const ALLOWLIST = {
   u09: 'u09.test@pdt.org.ar',
   julieta: 'julieta.benitez@pdt.org.ar',
@@ -45,7 +46,7 @@ export async function POST(req: NextRequest) {
   if (process.env.VERCEL_ENV === 'production') {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
-  if (!isCiBypass(req)) {
+  if (!isTestMutationAllowed(req)) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 

--- a/src/app/api/usuarios/me/roles/route.ts
+++ b/src/app/api/usuarios/me/roles/route.ts
@@ -50,6 +50,10 @@ export const POST = apiHandler(async (req: NextRequest) => {
       id: true,
       roles: true,
       role: true,
+      // B-02: el CUIT verificado del propio User (caso registro abandonado: CUIT
+      // verificado en User pero sin entidad creada todavía) también habilita el skip.
+      cuit: true,
+      verificadoAfip: true,
       taller: { select: { id: true, cuit: true, verificadoAfip: true } },
       marca: { select: { id: true, cuit: true, verificadoAfip: true } },
     },
@@ -76,6 +80,9 @@ export const POST = apiHandler(async (req: NextRequest) => {
   // ej. registro con ARCA caído o dato de seed) SÍ se manda a ARCA.
   const normalizar = (c: string) => c.replace(/-/g, '')
   const cuitsVerificados = [
+    // B-02: mismo gate semántico (verificadoAfip=true) para las 3 fuentes. El CUIT
+    // a nivel User cubre el caso "registro abandonado" (verificado pero sin entidad).
+    user.verificadoAfip ? user.cuit : null,
     user.taller?.verificadoAfip ? user.taller.cuit : null,
     user.marca?.verificadoAfip ? user.marca.cuit : null,
   ]

--- a/src/compartido/lib/entidades-modo.ts
+++ b/src/compartido/lib/entidades-modo.ts
@@ -1,12 +1,41 @@
+import { cache } from 'react'
 import { prisma } from '@/compartido/lib/prisma'
 import type { UserRole } from '@prisma/client'
+
+/**
+ * B-03: lectura única de los perfiles operativos (Taller/Marca) de un usuario.
+ *
+ * Envuelta en `cache()` de React → dentro de UN mismo request, varias llamadas con
+ * el mismo `userId` comparten una sola ejecución (deduplicación). Antes el layout
+ * (`construirEntidadesModo`) y `cuenta/page.tsx` consultaban taller/marca por
+ * separado, con selects distintos, así que NO se deduplicaban. Ahora ambos pasan
+ * por este helper con el mismo `select` (superset) → 1 par de queries por request.
+ *
+ * El select es el superset de lo que necesitan los consumidores: `nombre` (toggle
+ * + cards), `cuit` (pre-llenado de "agregar rol") y `puntaje` (F-01, % del taller).
+ */
+export const getPerfilesUsuario = cache(async (userId: string) => {
+  const [taller, marca] = await Promise.all([
+    prisma.taller.findFirst({
+      where: { userId },
+      select: { cuit: true, nombre: true, puntaje: true },
+    }),
+    prisma.marca.findFirst({
+      where: { userId },
+      select: { cuit: true, nombre: true },
+    }),
+  ])
+  return { taller, marca }
+})
 
 /**
  * U-04: arma el mapa de nombres amables de entidad por rol, para el toggle
  * "Operando como…" (ej. { TALLER: 'Taller La Aguja', MARCA: 'Amapola' }).
  *
  * Server-only (usa Prisma). Solo consulta para usuarios multi-rol: single-role
- * no muestra el toggle, así que devuelve {} sin pegarle a la DB.
+ * no muestra el toggle, así que devuelve {} sin pegarle a la DB. Comparte la
+ * lectura cacheada (`getPerfilesUsuario`) con `cuenta/page.tsx` cuando ambos
+ * corren en el mismo request (B-03).
  */
 export async function construirEntidadesModo(
   userId: string,
@@ -14,23 +43,11 @@ export async function construirEntidadesModo(
 ): Promise<Partial<Record<UserRole, string>>> {
   if (!roles || roles.length <= 1) return {}
 
+  const { taller, marca } = await getPerfilesUsuario(userId)
+
   const entidades: Partial<Record<UserRole, string>> = {}
-
-  if (roles.includes('TALLER')) {
-    const taller = await prisma.taller.findFirst({
-      where: { userId },
-      select: { nombre: true },
-    })
-    if (taller?.nombre) entidades.TALLER = taller.nombre
-  }
-
-  if (roles.includes('MARCA')) {
-    const marca = await prisma.marca.findFirst({
-      where: { userId },
-      select: { nombre: true },
-    })
-    if (marca?.nombre) entidades.MARCA = marca.nombre
-  }
+  if (roles.includes('TALLER') && taller?.nombre) entidades.TALLER = taller.nombre
+  if (roles.includes('MARCA') && marca?.nombre) entidades.MARCA = marca.nombre
 
   return entidades
 }

--- a/src/compartido/lib/nivel.ts
+++ b/src/compartido/lib/nivel.ts
@@ -45,6 +45,10 @@ const cacheReglas = new Map<string, { data: ReglaNivel[]; expira: number }>()
 const cacheTipos = new Map<string, { data: TipoDocCache[]; expira: number }>()
 const CACHE_TTL_MS = 60_000
 
+// Bonus de puntaje por CUIT verificado en ARCA. Universal (no atado a un tipo de
+// documento), por eso se suma aparte del reduce de validaciones.
+const AFIP_BONUS = 10
+
 async function getReglasNivel(): Promise<ReglaNivel[]> {
   const cached = cacheReglas.get('all')
   if (cached && cached.expira > Date.now()) return cached.data
@@ -106,7 +110,7 @@ export async function calcularNivel(tallerId: string): Promise<ResultadoNivel> {
   // Sumar puntosOtorgados de cada validacion COMPLETADO + bonus AFIP
   const puntaje = taller.validaciones.reduce(
     (sum, v) => sum + v.tipoDocumento.puntosOtorgados, 0
-  ) + (taller.verificadoAfip ? 10 : 0)
+  ) + (taller.verificadoAfip ? AFIP_BONUS : 0)
 
   const certificados = taller.certificados.length
   const tiposCompletados = new Set(taller.validaciones.map(v => v.tipoDocumento.id))
@@ -201,7 +205,7 @@ export async function calcularProximoNivel(tallerId: string): Promise<ProximoNiv
 
   const puntosActuales = taller.validaciones.reduce(
     (sum, v) => sum + v.tipoDocumento.puntosOtorgados, 0
-  ) + (taller.verificadoAfip ? 10 : 0)
+  ) + (taller.verificadoAfip ? AFIP_BONUS : 0)
 
   const certificados = taller.certificados.length
   const tiposCompletados = new Set(taller.validaciones.map(v => v.tipoDocumento.id))
@@ -263,4 +267,39 @@ export async function calcularProximoNivel(tallerId: string): Promise<ProximoNiv
     certificadosFaltantes: certsFaltantes,
     beneficiosProximoNivel: reglaProximo.beneficios,
   }
+}
+
+// --- Porcentaje de formalizacion (F-01) ---
+
+// F-01: `taller.puntaje` es un SCORE crudo (suma de puntosOtorgados de las
+// validaciones COMPLETADO + AFIP_BONUS), deliberadamente SIN tope (ver
+// nivel.test.ts "no hay cap de puntaje"). La UI lo mostraba directo con un `%`,
+// así que un taller con score > 100 mostraba "135%". La causa raíz no es solo la
+// falta de Math.min: es que NO había divisor — se mostraban puntos como porcentaje.
+//
+// El fix calcula un porcentaje real contra el MÁXIMO alcanzable y lo capa a 100.
+// El máximo es dinámico (suma de los puntos de todos los tipos de documento
+// requeridos activos + AFIP_BONUS): si se agregan/quitan tipos de documento, el
+// divisor se ajusta solo (evita el "divisor desactualizado" del diagnóstico).
+
+/**
+ * Puntaje máximo alcanzable de formalización: suma de puntos de los tipos de
+ * documento requeridos+activos + el bonus de AFIP. Divisor del % de formalización.
+ * Usa la caché de tipos (TTL 60s) — no agrega carga en hot paths.
+ */
+export async function maxPuntosFormalizacion(): Promise<number> {
+  const tipos = await getTiposActivos()
+  const puntosDocs = tipos.reduce((sum, t) => sum + t.puntosOtorgados, 0)
+  return puntosDocs + AFIP_BONUS
+}
+
+/**
+ * Convierte el score crudo `puntaje` en un porcentaje de formalización 0-100,
+ * capado a 100 (Math.min). 100% = todos los requisitos cubiertos. Punto ÚNICO de
+ * cálculo: todos los renders del % deben usar este helper, nunca `puntaje` directo.
+ */
+export async function porcentajeFormalizacion(puntaje: number): Promise<number> {
+  const max = await maxPuntosFormalizacion()
+  if (max <= 0) return 0
+  return Math.min(100, Math.round((puntaje / max) * 100))
 }

--- a/src/compartido/lib/ratelimit.ts
+++ b/src/compartido/lib/ratelimit.ts
@@ -126,6 +126,28 @@ export function isCiBypass(req: NextRequest): boolean {
 }
 
 /**
+ * B-04: guard DEDICADO para endpoints mutantes de test (ej. reset-seed-state).
+ *
+ * Tiene las MISMAS validaciones que isCiBypass hoy (token presente + VERCEL_ENV !=
+ * production + header x-ci-bypass coincide), pero es una función SEPARADA a
+ * propósito: isCiBypass autoriza saltar rate-limit (riesgo bajo) y podría relajarse
+ * en el futuro por motivos de rate-limit; si los endpoints mutantes dependieran de
+ * él, esa relajación ensancharía silenciosamente la autorización destructiva. Al
+ * ser una función distinta, ampliar el bypass de rate-limit NO afecta esto sin
+ * tocar esta función explícitamente.
+ */
+export function isTestMutationAllowed(req: NextRequest): boolean {
+  const bypassToken = process.env.CI_BYPASS_TOKEN
+  if (!bypassToken) return false
+
+  const currentEnv = process.env.VERCEL_ENV ?? 'development'
+  if (currentEnv === 'production') return false
+
+  const headerValue = req.headers.get('x-ci-bypass')
+  return headerValue === bypassToken
+}
+
+/**
  * Aplica rate limiting a una request.
  * Retorna NextResponse con 429 si se excede el limite, null si pasa.
  *


### PR DESCRIPTION
Sprint de deuda técnica batch-1: los 6 items chicos de `DEUDA_TECNICA.md` en un solo PR. Sin tocar schema, sin rediseño de auth.

## Items resueltos

- **F-01** — % formalización capado a 100. Causa raíz: `taller.puntaje` es un score crudo sin tope mostrado con `%` (daba "135%"). Helper `porcentajeFormalizacion` en `nivel.ts` con divisor **dinámico** (puntos máx posibles + AFIP) + `Math.min(100, …)`, punto único de cálculo. Render sites: card de `/cuenta` + sidebar del taller.
- **F-02** — link "Mi cuenta" para roles de equipo. ESTADO ya lo tenía vía `Header` compartido; **ADMIN** y **CONTENIDO** usan headers propios → se les agregó el link a `/cuenta`.
- **F-03** — input CUIT del registro cachea el último valor validado (resultado definitivo) en un `useRef`; blur sin cambios no re-llama a ARCA. Sin librería de debounce.
- **B-02** — el skip de ARCA en `POST /me/roles` ahora también lee `User.cuit`/`User.verificadoAfip` (caso registro abandonado), mismo gate `verificadoAfip:true`.
- **B-03** — query de taller/marca **deduplicada** con `cache()` de React (`getPerfilesUsuario`) entre el layout y `cuenta/page.tsx` (no estaban deduplicadas: selects distintos).
- **B-04** — guard dedicado `isTestMutationAllowed` para el endpoint mutante de test, separado de `isCiBypass` (que queda solo para rate-limit).

## Tests
- `u-09-agregar-rol.test.ts`: 2 casos B-02 (skip con User verificado; SÍ llama a ARCA si no verificado).
- `ratelimit.test.ts`: 4 casos del guard B-04 (token ausente / prod / header incorrecto → false; válido → true).

## Fuera de scope
B-05 (spec propio), B-01 (PR propio), F-04 (backlog), D-01/D-02 (U-05).

Items movidos a **Resueltas** en `DEUDA_TECNICA.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)