### PR TITLE
feat(u-08): tests E2E multi-rol + seed dual (cierre bloque U)

### DIFF
--- a/.claude/specs/v4-u-08-tests-e2e-multi-rol.md
+++ b/.claude/specs/v4-u-08-tests-e2e-multi-rol.md
@@ -203,8 +203,18 @@ Fixture helper `e2e/helpers/auth.ts`: hoy define `dual` = `julieta.benitez@pdt.o
 
 ## 6. Casos borde
 
-- **CI re-seedea fresco** ⇒ los tests mutantes (u-09) pasan; **localmente** una 2ª
-  corrida sin re-seed falla. Documentarlo en el encabezado del test.
+- **⚠️ EL E2E CORRE CONTRA LA DEV DB PERSISTENTE, NO CONTRA UN SEED FRESCO.** El
+  workflow `e2e.yml` ataca el deploy de **preview** (que usa la DB de DEV) y **no**
+  ejecuta `db:seed`. Por eso existe la maquinaria de `reset-seed-state` (la DB
+  persiste entre runs). **Consecuencia operativa:** cualquier cambio en `prisma/seed.ts`
+  que agregue filas que un test E2E necesita (ej. los pedidos DUAL1/DUAL2) **requiere
+  un reseed coordinado de DEV** (`npm run db:check && npm run db:seed`, **avisando a
+  Sergio antes** porque le pisa el estado de QA manual). Sin el reseed, los tests
+  nuevos fallan por falta de datos aunque el código sea correcto. Esto debe ser un
+  paso del checklist, no un hallazgo. (Descubierto al implementar U-08: el supuesto
+  original "CI re-seedea fresco" era falso.)
+- **Tests mutantes (u-09)** ⇒ pasan en CI por el `afterEach` de `reset-seed-state`
+  (no por seed fresco); **localmente** una 2ª corrida sin reset/re-seed falla.
 - **`activeMode` persistente de Julieta** entre tests ⇒ no asumir modo inicial
   (§3.3). Riesgo de flaky por orden de ejecución.
 - **POST autenticado en Playwright** ⇒ usar `page.request` (cookies del context); el

--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,17 @@
 # Daily Log
 
+## 2026-06-10
+
+### Gerardo Breard
+- **00:23** `f8b5512` — feat(u-08): tests E2E multi-rol + seed dual (cierre bloque U)
+  - `prisma/seed.ts`
+  - `src/app/api/test-utils/reset-seed-state/route.ts`
+  - `tests/e2e/u-06-clasificacion-pedidos.spec.ts`
+  - `tests/e2e/u-07-anti-incesto.spec.ts`
+  - `tests/e2e/u-08-cuenta-multirol.spec.ts`
+  - `tests/e2e/u-08-gating-dual.spec.ts`
+
+
 ## 2026-06-09
 
 ### Gerardo Breard

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-06-10
 
 ### Gerardo Breard
+- **00:39** `7e50231` — docs(u-08): corregir supuesto de seed en CI + nota de reseed coordinado
+  - `.claude/specs/v4-u-08-tests-e2e-multi-rol.md`
+
 - **00:23** `f8b5512` — feat(u-08): tests E2E multi-rol + seed dual (cierre bloque U)
   - `prisma/seed.ts`
   - `src/app/api/test-utils/reset-seed-state/route.ts`

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -628,7 +628,7 @@ async function main() {
       verificadoAfip: true,
     },
   })
-  await prisma.marca.create({
+  const marcaBenitez = await prisma.marca.create({
     data: {
       userId: userDual.id,
       nombre: 'Marca Benítez',
@@ -640,6 +640,48 @@ async function main() {
   })
 
   console.log('  ✓ 2 marcas creadas (+ taller/marca del user multi-rol)')
+
+  // U-08: pedidos publicados/borrador por la marca del user dual (Julieta), para
+  // ejercitar la regla anti-incesto E2E. Julieta tiene perfil TALLER y MARCA: no
+  // puede cotizar/invitarse a sí misma en pedidos que publicó como marca
+  // (pedido.marca.userId === su propio userId). Ver v4-u-08-tests-e2e-multi-rol.md.
+  //
+  // Son DOS pedidos a propósito, por el orden de los guards en cada ruta:
+  //   - DUAL1 PUBLICADO/PUBLICO → cotizar: AUTO_COTIZACION dispara antes que el
+  //     chequeo de estado (cotizaciones/route.ts), y disponibles lo excluye por
+  //     ser propio. Necesita estar PUBLICADO+PUBLICO para que la exclusión del
+  //     listado sea significativa (un BORRADOR no aparecería igual).
+  //   - DUAL2 BORRADOR → invitar: en invitaciones/route.ts el gate `estado !==
+  //     'BORRADOR'` (400) dispara ANTES que el anti-incesto ("No podés invitarte
+  //     a vos mismo", 400). Para ejercitar el guard REAL hace falta un pedido en
+  //     BORRADOR; sobre uno PUBLICADO el test pasaría por la razón equivocada.
+  // El reset-seed-state?user=julieta NO toca estos pedidos (solo hace user.update),
+  // así que sobreviven intactos entre corridas E2E.
+  await prisma.pedido.create({
+    data: {
+      omId: 'OM-2026-DUAL1',
+      marcaId: marcaBenitez.id,
+      tipoPrenda: 'Remera',
+      tipoPrendaId: prRemera.id,
+      cantidad: 300,
+      estado: 'PUBLICADO',
+      visibilidad: 'PUBLICO',
+      montoTotal: 270000,
+    },
+  })
+  await prisma.pedido.create({
+    data: {
+      omId: 'OM-2026-DUAL2',
+      marcaId: marcaBenitez.id,
+      tipoPrenda: 'Remera',
+      tipoPrendaId: prRemera.id,
+      cantidad: 150,
+      estado: 'BORRADOR',
+      montoTotal: 135000,
+    },
+  })
+
+  console.log('  ✓ 2 pedidos del user dual (DUAL1 publicado, DUAL2 borrador) para anti-incesto')
 
   // ============================================
   // PEDIDOS

--- a/src/app/api/test-utils/reset-seed-state/route.ts
+++ b/src/app/api/test-utils/reset-seed-state/route.ts
@@ -83,8 +83,11 @@ export async function POST(req: NextRequest) {
   }
 
   // key === 'julieta' → dual con activeMode TALLER (estado del seed). NO se tocan
-  // sus entidades (Taller La Hormiga + Marca Benítez son parte de su seed); solo
-  // se restaura el activeMode/role que u-04 muta. roles queda [TALLER, MARCA].
+  // sus entidades (Taller La Hormiga + Marca Benítez son parte de su seed) ni sus
+  // pedidos (OM-2026-DUAL1 PUBLICADO + OM-2026-DUAL2 BORRADOR, usados por el
+  // anti-incesto de U-08): este reset SOLO hace user.update, así que ambos pedidos
+  // sobreviven intactos entre corridas. Solo se restaura el activeMode/role que
+  // u-04 muta. roles queda [TALLER, MARCA].
   const julieta = await prisma.user.findUnique({
     where: { email },
     select: { id: true },

--- a/tests/e2e/u-06-clasificacion-pedidos.spec.ts
+++ b/tests/e2e/u-06-clasificacion-pedidos.spec.ts
@@ -6,17 +6,18 @@ import { test } from '@playwright/test'
 // prisma). Aca solo quedan los e2e de extremo a extremo, hoy bloqueados.
 // Ver .claude/specs/v4-u-06-clasificacion-pedidos.md
 
-// El campo Pedido.tipo es invisible en UI (la vista de reporte esta diferida a
-// Etapa 2/3) y el caso SUBCONTRATACION necesita un User dual (Marca + Taller) que
-// el seed single-role actual no tiene. Por eso estos e2e quedan `fixme` hasta
-// U-08 (seed dual) + la vista de reporte que exponga el tipo.
+// U-08 ya resolvió el seed dual (Julieta + pedidos OM-2026-DUAL1/DUAL2). El único
+// bloqueo restante es la VISTA DE REPORTE: el campo Pedido.tipo sigue invisible en
+// UI (diferida a Etapa 2/3), así que no hay dónde leer el tipo desde la pantalla.
+// Por eso estos e2e siguen `fixme` (NO por el seed). La lógica de clasificación ya
+// está cubierta a nivel unidad en src/__tests__/u-06-clasificacion-pedidos.test.ts.
 
 test.fixme('e2e: marca pura crea pedido -> tipo COMERCIAL visible en reporte', async () => {
-  // TODO(U-08): requiere vista de reporte (diferida) para poder leer el tipo
-  // desde la UI tras crear el pedido.
+  // BLOQUEADO por la vista de reporte (diferida Etapa 2/3): falta UI que exponga
+  // Pedido.tipo para leerlo tras crear el pedido. Seed ya no es bloqueante.
 })
 
 test.fixme('e2e: user dual crea pedido -> tipo SUBCONTRATACION visible en reporte', async () => {
-  // TODO(U-08): requiere (1) User dual en el seed y (2) vista de reporte que
-  // exponga el tipo. La logica ya esta cubierta por el test unitario.
+  // BLOQUEADO solo por la vista de reporte (diferida Etapa 2/3). El seed dual ya
+  // existe (U-08); la lógica ya está cubierta por el test unitario.
 })

--- a/tests/e2e/u-07-anti-incesto.spec.ts
+++ b/tests/e2e/u-07-anti-incesto.spec.ts
@@ -1,10 +1,10 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import { ensureNotProduction } from './_helpers/safety'
 import { loginAs } from './_helpers/auth-multirol'
 
 // U-07 — Regla anti-incesto (bloque multi-rol).
 // Un User con perfil de taller Y marca no puede cotizar/invitar a sus propios pedidos.
-// Ver .claude/specs/v4-u-07-anti-incesto.md
+// Ver .claude/specs/v4-u-07-anti-incesto.md y v4-u-08-tests-e2e-multi-rol.md (§5.3).
 
 // --- REGRESIÓN (con fixtures single-role actuales) ---
 // Garantiza que el guard 3a (ocultar CotizarForm en pedido propio) NO afecta el
@@ -23,22 +23,90 @@ test('taller viendo pedido ajeno NO ve el aviso anti-incesto', async ({ page }) 
   await expect(page.getByText('Este es un pedido que publicaste como marca')).toHaveCount(0)
 })
 
-// --- CASOS CENTRALES (requieren fixture multi-rol) ---
-// El seed actual es single-role: ningún User tiene Taller Y Marca a la vez.
-// Estos tests se completan en U-08, cuando exista el seed dual (v4-u-02-schema-multi-rol).
-// Se dejan como `fixme` para que queden trackeados y se activen al llegar el fixture.
+// --- CASOS CENTRALES (User dual = Julieta Benítez, seed U-08) ---
+// Estos tests son MODE-INDEPENDENT: el gating de las rutas API es por MEMBRESÍA
+// (requiereRolApi → tieneAlgunRol) y la propiedad del pedido se compara por
+// pedido.marca.userId === session.user.id, no por el activeMode. Por eso NO hace
+// falta fijar el modo (§3.3) ni hay race con u-04, que muta activeMode en paralelo.
+// Además NO mutan estado: los 403/400 retornan ANTES de crear cotización/invitación,
+// así que no hay cleanup que hacer (la corrida N+1 ve el seed igual de limpio).
+//
+// POST autenticado: usamos page.request, que comparte las cookies de sesión del
+// context tras loginAs. Los ids (pedido propio, taller propio) se resuelven desde
+// la UML pública/privada porque el runner de e2e no tiene acceso directo a la DB.
 
-test.fixme('cotizar pedido propio devuelve 403 AUTO_COTIZACION', async () => {
-  // TODO(U-08): requiere User dual (taller+marca). POST /api/cotizaciones sobre
-  // un pedido cuya marca.userId === session.user.id → 403 code AUTO_COTIZACION.
+// Resuelve el id de un pedido propio de Julieta desde /marca/pedidos (filtra por omId;
+// sin filtro de estado lista BORRADOR y PUBLICADO por igual).
+async function resolverPedidoPropio(page: Page, omId: string): Promise<string> {
+  await page.goto(`/marca/pedidos?q=${encodeURIComponent(omId)}`)
+  const link = page.locator('main a[href^="/marca/pedidos/"]').filter({ hasText: omId }).first()
+  await expect(link).toBeVisible()
+  const href = await link.getAttribute('href')
+  expect(href, `no se encontró el pedido ${omId} en /marca/pedidos`).toBeTruthy()
+  return href!.split('/').pop()!
+}
+
+// Resuelve el id del taller propio de Julieta (Taller La Hormiga) desde el directorio
+// público, donde /perfil/[id] está keyeado por taller.id.
+async function resolverTallerPropio(page: Page): Promise<string> {
+  await page.goto('/directorio?q=Hormiga')
+  const link = page.locator('main a[href^="/perfil/"]').filter({ hasText: 'La Hormiga' }).first()
+  await expect(link).toBeVisible()
+  const href = await link.getAttribute('href')
+  expect(href, 'no se encontró Taller La Hormiga en el directorio').toBeTruthy()
+  return href!.split('/').pop()!
+}
+
+test('cotizar un pedido propio devuelve 403 AUTO_COTIZACION', async ({ page }) => {
+  await ensureNotProduction(page)
+  await loginAs(page, 'dual')
+
+  // OM-2026-DUAL1 está PUBLICADO, pero el guard AUTO_COTIZACION dispara ANTES que el
+  // chequeo de estado en cotizaciones/route.ts, así que el 403 es por anti-incesto.
+  const pedidoId = await resolverPedidoPropio(page, 'OM-2026-DUAL1')
+
+  const res = await page.request.post('/api/cotizaciones', {
+    data: { pedidoId, precio: 250000, plazoDias: 30, proceso: 'Confección completa' },
+  })
+  expect(res.status()).toBe(403)
+  const body = await res.json()
+  expect(body.code).toBe('AUTO_COTIZACION')
 })
 
-test.fixme('invitar al taller propio devuelve 400', async () => {
-  // TODO(U-08): requiere User dual. POST /api/pedidos/[id]/invitaciones incluyendo
-  // el taller del propio dueño del pedido → 400 "No podés invitarte a vos mismo...".
+test('invitar al taller propio devuelve 400 anti-incesto', async ({ page }) => {
+  await ensureNotProduction(page)
+  await loginAs(page, 'dual')
+
+  // OM-2026-DUAL2 está en BORRADOR: necesario porque el gate `estado !== 'BORRADOR'`
+  // dispara ANTES que el anti-incesto en invitaciones/route.ts. Sobre un pedido
+  // PUBLICADO el 400 sería por "Solo se puede invitar desde BORRADOR" (razón
+  // equivocada). Verificamos el MENSAJE, no solo el status.
+  const pedidoId = await resolverPedidoPropio(page, 'OM-2026-DUAL2')
+  const tallerPropioId = await resolverTallerPropio(page)
+
+  const res = await page.request.post(`/api/pedidos/${pedidoId}/invitaciones`, {
+    data: { tallerIds: [tallerPropioId] },
+  })
+  expect(res.status()).toBe(400)
+  const body = await res.json()
+  expect(body.error).toContain('invitarte a vos mismo')
 })
 
-test.fixme('listado de disponibles no incluye los pedidos propios del user dual', async () => {
-  // TODO(U-08): requiere User dual. /taller/pedidos/disponibles no debe listar
-  // pedidos cuya marca.userId === session.user.id.
+test('el listado de disponibles no incluye los pedidos propios del user dual', async ({ page }) => {
+  await ensureNotProduction(page)
+  await loginAs(page, 'dual')
+
+  // DUAL1 es PUBLICADO + PUBLICO (aparecería en disponibles si no fuera propio); el
+  // guard del listado lo excluye por pedido.marca.userId === session.user.id.
+  const pedidoId = await resolverPedidoPropio(page, 'OM-2026-DUAL1')
+
+  await page.goto('/taller/pedidos/disponibles')
+  // La página cargó (no redirigió a login/unauthorized): el área es accesible por
+  // membresía TALLER aunque Julieta esté en modo MARCA.
+  await expect(page).toHaveURL(/\/taller\/pedidos\/disponibles/)
+
+  // El pedido propio NO está listado: no hay link a su detalle.
+  await expect(
+    page.locator(`a[href$="/taller/pedidos/disponibles/${pedidoId}"]`)
+  ).toHaveCount(0)
 })

--- a/tests/e2e/u-07-anti-incesto.spec.ts
+++ b/tests/e2e/u-07-anti-incesto.spec.ts
@@ -70,7 +70,8 @@ test('cotizar un pedido propio devuelve 403 AUTO_COTIZACION', async ({ page }) =
   })
   expect(res.status()).toBe(403)
   const body = await res.json()
-  expect(body.code).toBe('AUTO_COTIZACION')
+  // errorResponse() envuelve como { error: { code, message, digest } }.
+  expect(body.error?.code).toBe('AUTO_COTIZACION')
 })
 
 test('invitar al taller propio devuelve 400 anti-incesto', async ({ page }) => {

--- a/tests/e2e/u-08-cuenta-multirol.spec.ts
+++ b/tests/e2e/u-08-cuenta-multirol.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test'
+import { ensureNotProduction } from './_helpers/safety'
+import { loginAs } from './_helpers/auth-multirol'
+
+// U-08 caso #7 — Vista /cuenta para multi-rol vs single-rol.
+// /cuenta es la página del USUARIO (no del rol activo): muestra TODOS sus perfiles.
+// Multi-rol → "Roles: A, B" + "Rol activo: X" (líneas separadas) + cards de ambos
+// perfiles + SIN card "agregar rol". Single-rol → "Rol: X" (singular) + SÍ ofrece
+// agregar el rol faltante.
+//
+// MODE-INDEPENDENT: /cuenta lista los perfiles sea cual sea el activeMode, así que
+// es seguro en paralelo con u-04 (que togglea a Julieta). No mutan estado.
+// Single-rol: usamos taller_bronce (Roberto), un single-rol estable y read-only —
+// NO u09, que u-09 muta a dual en paralelo.
+
+// Scope a <main>: React 19 streaming SSR deja una copia hidden fuera de <main>;
+// scopear evita strict-mode (ver skill playwright-e2e §1).
+
+test('multi-rol: /cuenta muestra "Roles: TALLER, MARCA" y "Rol activo:" en líneas separadas', async ({ page }) => {
+  await ensureNotProduction(page)
+  await loginAs(page, 'dual')
+
+  await page.goto('/cuenta')
+  const main = page.locator('main')
+  await expect(main.getByText('Roles:', { exact: true })).toBeVisible()
+  await expect(main.getByText('TALLER, MARCA')).toBeVisible()
+  // El valor de "Rol activo:" puede ser TALLER o MARCA según el toggle concurrente
+  // de u-04; solo verificamos la etiqueta separada (no asumimos el modo).
+  await expect(main.getByText('Rol activo:', { exact: true })).toBeVisible()
+})
+
+test('multi-rol: /cuenta muestra las cards de Taller La Hormiga y Marca Benítez', async ({ page }) => {
+  await ensureNotProduction(page)
+  await loginAs(page, 'dual')
+
+  await page.goto('/cuenta')
+  const main = page.locator('main')
+  await expect(main.getByRole('heading', { name: 'Taller La Hormiga' })).toBeVisible()
+  await expect(main.getByRole('heading', { name: 'Marca Benítez' })).toBeVisible()
+})
+
+test('multi-rol: /cuenta NO muestra la card "agregar rol"', async ({ page }) => {
+  await ensureNotProduction(page)
+  await loginAs(page, 'dual')
+
+  await page.goto('/cuenta')
+  await expect(page.locator('main').getByTestId('agregar-rol-card')).toHaveCount(0)
+})
+
+test('single-rol: /cuenta muestra "Rol:" (singular) y SÍ ofrece agregar rol', async ({ page }) => {
+  await ensureNotProduction(page)
+  await loginAs(page, 'taller_bronce')
+
+  await page.goto('/cuenta')
+  const main = page.locator('main')
+  // Rama singular: "Rol:" presente, sin "Roles:" ni "Rol activo:".
+  await expect(main.getByText('Rol:', { exact: true })).toBeVisible()
+  await expect(main.getByText('Roles:', { exact: true })).toHaveCount(0)
+  // Single-rol TALLER sin perfil de marca → ofrece sumar el rol faltante.
+  await expect(main.getByTestId('agregar-rol-card')).toBeVisible()
+})

--- a/tests/e2e/u-08-gating-dual.spec.ts
+++ b/tests/e2e/u-08-gating-dual.spec.ts
@@ -18,7 +18,10 @@ test('dual entra a /taller (sin redirect a login/unauthorized)', async ({ page }
   await page.goto('/taller')
   await expect(page).toHaveURL(/\/taller/)
   await expect(page).not.toHaveURL(/unauthorized|login/)
-  await expect(page.locator('main')).toBeVisible()
+  // .first(): React 19 streaming SSR deja brevemente un segundo <main> hidden
+  // (copia de streaming). El primero en el DOM es el visible. La aserción de
+  // gating real son las URLs de arriba; esto solo confirma que el área renderizó.
+  await expect(page.locator('main').first()).toBeVisible()
 })
 
 test('dual entra a /marca (sin redirect a login/unauthorized)', async ({ page }) => {
@@ -28,7 +31,8 @@ test('dual entra a /marca (sin redirect a login/unauthorized)', async ({ page })
   await page.goto('/marca')
   await expect(page).toHaveURL(/\/marca/)
   await expect(page).not.toHaveURL(/unauthorized|login/)
-  await expect(page.locator('main')).toBeVisible()
+  // .first(): ver nota de streaming SSR en el test de /taller.
+  await expect(page.locator('main').first()).toBeVisible()
 })
 
 test('single-rol (taller) entra a /taller pero /marca queda bloqueado', async ({ page }) => {

--- a/tests/e2e/u-08-gating-dual.spec.ts
+++ b/tests/e2e/u-08-gating-dual.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test'
+import { ensureNotProduction } from './_helpers/safety'
+import { loginAs, assertAccesoBloqueado } from './_helpers/auth-multirol'
+
+// U-08 caso #4 — Gating de áreas para el user dual.
+// El acceso a /taller y /marca es por MEMBRESÍA en roles[] (middleware →
+// tieneAlgunRol; requiereRol en el layout), NO por activeMode. Por eso un dual
+// (Julieta: [TALLER, MARCA]) entra a AMBAS áreas sin importar su modo activo, y un
+// single-rol queda bloqueado en el área que no le corresponde.
+//
+// MODE-INDEPENDENT: no asumimos ni fijamos activeMode (§3.3); navegamos explícito.
+// No mutan estado → seguros en paralelo (incl. con u-04 toggleando a Julieta).
+
+test('dual entra a /taller (sin redirect a login/unauthorized)', async ({ page }) => {
+  await ensureNotProduction(page)
+  await loginAs(page, 'dual')
+
+  await page.goto('/taller')
+  await expect(page).toHaveURL(/\/taller/)
+  await expect(page).not.toHaveURL(/unauthorized|login/)
+  await expect(page.locator('main')).toBeVisible()
+})
+
+test('dual entra a /marca (sin redirect a login/unauthorized)', async ({ page }) => {
+  await ensureNotProduction(page)
+  await loginAs(page, 'dual')
+
+  await page.goto('/marca')
+  await expect(page).toHaveURL(/\/marca/)
+  await expect(page).not.toHaveURL(/unauthorized|login/)
+  await expect(page.locator('main')).toBeVisible()
+})
+
+test('single-rol (taller) entra a /taller pero /marca queda bloqueado', async ({ page }) => {
+  await ensureNotProduction(page)
+  await loginAs(page, 'taller_bronce')
+
+  // Su propia área: accesible.
+  await page.goto('/taller')
+  await expect(page).toHaveURL(/\/taller/)
+  await expect(page).not.toHaveURL(/unauthorized|login/)
+
+  // Área de marca: el middleware lo manda a /unauthorized (no es miembro MARCA).
+  await page.goto('/marca')
+  const body = await page.locator('body').textContent()
+  expect(assertAccesoBloqueado(page.url(), body)).toBe(true)
+})


### PR DESCRIPTION
Cierra el **bloque U** (multi-rol "Airbnb") con la cobertura E2E faltante. Spec: `.claude/specs/v4-u-08-tests-e2e-multi-rol.md`.

## Reconciliación vs spec
El spec se escribió antes de T-04 (#407), que ya migró los U-specs a `tests/e2e/` con `_helpers/auth-multirol.ts` (fixtures `dual`/`u09`) y dejó el reset con allowlist `u09|julieta`. #398 (U-09) ya está mergeado → la UI `/cuenta` multi-rol existe. Esas partes del spec ya estaban hechas; este PR hace lo que faltaba.

## Cambios
**Seed dual (`prisma/seed.ts`)**
- `Marca Benítez` asignada a variable.
- `OM-2026-DUAL1` PUBLICADO/PUBLICO → cotizar + exclusión en disponibles.
- `OM-2026-DUAL2` BORRADOR → invitar. **Dos pedidos a propósito**: en `invitaciones/route.ts` el gate `estado !== 'BORRADOR'` dispara *antes* que el anti-incesto, así que ejercitar el guard real exige un pedido BORRADOR. (Decisión consultada con Gerardo.)
- `reset-seed-state?user=julieta` solo hace `user.update` → ambos pedidos sobreviven intactos (comentario actualizado).

**u-07 anti-incesto** — des-fixmeados los 3 (antes: cero cobertura de la regla):
- cotizar propio → 403 `AUTO_COTIZACION`
- invitar taller propio → 400 "invitarte a vos mismo"
- disponibles no lista los pedidos propios
- Mode-independent (membresía + `marca.userId`, no `activeMode`) → sin race con u-04. POST vía `page.request`; ids resueltos desde `/marca/pedidos` y `/directorio`.

**NUEVO `u-08-gating-dual.spec.ts`** (3): dual entra a `/taller` y `/marca`; single-rol bloqueado en `/marca`.

**NUEVO `u-08-cuenta-multirol.spec.ts`** (4): multi-rol "Roles: A, B" + "Rol activo:" + cards de ambos perfiles + sin "agregar rol"; single-rol "Rol:" singular + sí ofrece agregar rol.

**u-06**: nota `fixme` actualizada — seed ya resuelto; bloqueo restante = vista de reporte (Etapa 2/3).

## Criterio de aceptación
- [x] `u-08-gating-dual.spec.ts` (3) + `u-08-cuenta-multirol.spec.ts` (4)
- [x] 3 `fixme` de u-07 des-fixmeados
- [x] seed: Marca Benítez var + pedidos publicado/borrador
- [x] u-06: nota actualizada (sin des-fixmear)
- [ ] unit + e2e + Vercel verdes (CI)
- [x] sin duplicar matriz endpoints×roles (§4.2)

Toolchain local roto (T-01) → validación por CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)