### PR TITLE
feat(u-05): migracion de datos multi-rol

### DIFF
--- a/.claude/specs/handover/DECISIONS.md
+++ b/.claude/specs/handover/DECISIONS.md
@@ -643,3 +643,33 @@ se implementaran como specs aparte despues de X-05.
 - CRUD TipoDocumento para ADMIN (Post-MVP, 3h)
 
 Ver: `AUDITORIA_OPERABILIDAD_2026-05-16.md`
+
+---
+
+## 2026-06-10 — U-05: integridad de datos multi-rol (roles[]/activeMode)
+
+**Problema:** U-02 backfilleó `roles[]`/`activeMode` una vez, pero ninguna fuente
+(registro, registro/completar, seed) los seteaba al crear users → el dato se
+re-desincronizaba (dev en cada seed; prod en cada registro nuevo). El callback `jwt`
+lo enmascaraba derivando desde `role` (fallback load-bearing).
+
+**Decisiones tomadas:**
+- **Backfill núcleo = migración SQL** (`20260610120000_u05_backfill_roles_activemode`),
+  no script: así `prisma migrate deploy` la aplica sola en el build de Vercel contra
+  prod. Idempotente y guardada (`WHERE cardinality(roles)=0` / `activeMode IS NULL`)
+  → no pisa al dual (Julieta) ni el modo elegido por el toggle. Espeja el backfill de U-02.
+- **Cierre de fuente (invariante `roles:[role], activeMode:role`):** se aplicó en los 3
+  puntos — `registro/route.ts` (create), `registro/completar/route.ts` (update, sobre la
+  transacción de U-09 ya mergeado), y `seed.ts` (normalización post-seed, no en cada create).
+- **Scripts:** `scripts/u05-audit.ts` (`--dry-run`/`--verify`, guard anti-PROD) y
+  `scripts/u05-backfill-validaciones.ts` (`--apply`, deuda D-02: talleres sin checklist).
+- **srodriguezunq (registro abandonado sin entidad):** opción D — se migra igual
+  (`roles=[TALLER]`), NO se le inventa entidad. (En DEV no aparece; aplica a prod.)
+
+**Verificado en DEV (2026-06-10):** pre = 9/10 users con `roles=[]`; post-migración =
+0 violaciones (`u05-audit --verify` OK); idempotencia confirmada (2ª corrida = 0 filas).
+Validaciones D-02: 2 talleres incompletos (U09, La Hormiga) → 14 validaciones creadas.
+
+**Pendiente fase PROD (NO ejecutado):** la migración SQL se aplica sola en el próximo
+deploy. El backfill de validaciones en prod requiere `ALLOW_PROD=1 ... --apply` tras
+dimensionar con el dry-run — paso manual y posterior, con OK explícito de Gerardo.

--- a/.claude/specs/v4-u-05-migracion-datos.md
+++ b/.claude/specs/v4-u-05-migracion-datos.md
@@ -224,17 +224,17 @@ Ninguna nueva. `tsx`, `@prisma/client`, `dotenv` ya están.
 
 ## 9. Criterios de aceptación
 
-- [ ] Build de producción pasa (`npm run build`) — incluye `migrate deploy` con la migración nueva.
-- [ ] Tests unit + E2E existentes verdes.
-- [ ] Sin warnings nuevos de TS/ESLint.
-- [ ] Migración SQL idempotente verificada (correr dev 2×: segunda = 0 filas afectadas).
-- [ ] Post-condición en dev: **0** users con `roles=[]`, **0** con `activeMode=null`, invariante `role==activeMode` y `role ∈ roles` para el 100%.
-- [ ] `registro`, `registro/completar` y `seed` setean `roles`/`activeMode` (tests unit lo cubren).
-- [ ] `db:seed` produce un dataset 100% sano (re-seed no reintroduce `[]`/null).
-- [ ] Script de auditoría: `--dry-run` no escribe; `--verify` pasa post-migración.
-- [ ] Paso D (validaciones): dry-run de prod reportado; aplicado solo tras mergear U-09; talleres reportados quedan con checklist completo.
-- [ ] Handover actualizado.
-- [ ] PR mergeado a develop + merge a main.
+- [~] Build de producción pasa (`npm run build`) — incluye `migrate deploy` con la migración nueva. → lo valida CI/Vercel en el PR.
+- [~] Tests unit + E2E existentes verdes. → lo valida CI (toolchain local roto, T-01).
+- [~] Sin warnings nuevos de TS/ESLint. → lo valida CI.
+- [x] Migración SQL idempotente verificada (correr dev 2×: segunda = 0 filas afectadas). → 1ª: 9+9 filas; 2ª: 0+0 (2026-06-10).
+- [x] Post-condición en dev: **0** users con `roles=[]`, **0** con `activeMode=null`, invariante OK 100%. → `u05-audit --verify` OK.
+- [x] `registro`, `registro/completar` y `seed` setean `roles`/`activeMode`. → tests unit (registro/completar) en `u-05-cierre-fuente.test.ts`; seed = normalización post-seed.
+- [~] `db:seed` produce un dataset 100% sano (re-seed no reintroduce `[]`/null). → bloque de seed agregado; NO re-ejecutado (reseed requiere OK explícito de Gerardo + aviso a Sergio).
+- [x] Script de auditoría: `--dry-run` no escribe; `--verify` pasa post-migración. → verificado en DEV.
+- [x] Paso D (validaciones): dry-run reportado; aplicado en DEV (2 talleres, 14 validaciones); idempotente. PROD = fase posterior gated.
+- [x] Handover actualizado. → `DECISIONS.md` 2026-06-10.
+- [ ] PR mergeado a develop + merge a main. → pendiente (QA de Sergio).
 
 ---
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,17 @@
 ## 2026-06-10
 
 ### Gerardo Breard
+- **01:10** `1c0e5f1` — feat(u-05): migracion de datos multi-rol + cierre de fuente (refs D-01/D-02)
+  - `.claude/specs/handover/DECISIONS.md`
+  - `.claude/specs/v4-u-05-migracion-datos.md`
+  - `prisma/migrations/20260610120000_u05_backfill_roles_activemode/migration.sql`
+  - `prisma/seed.ts`
+  - `scripts/u05-audit.ts`
+  - `scripts/u05-backfill-validaciones.ts`
+  - `src/__tests__/u-05-cierre-fuente.test.ts`
+  - `src/app/api/auth/registro/completar/route.ts`
+  - `src/app/api/auth/registro/route.ts`
+
 - **00:39** `7e50231` — docs(u-08): corregir supuesto de seed en CI + nota de reseed coordinado
   - `.claude/specs/v4-u-08-tests-e2e-multi-rol.md`
 

--- a/prisma/migrations/20260610120000_u05_backfill_roles_activemode/migration.sql
+++ b/prisma/migrations/20260610120000_u05_backfill_roles_activemode/migration.sql
@@ -1,0 +1,23 @@
+-- U-05: re-sincroniza roles[]/activeMode con el escalar role.
+--
+-- Por qué existe: U-02 backfilleó estos campos una vez, pero las fuentes (registro,
+-- registro/completar, seed) no los seteaban al crear users → el dato se vuelve a
+-- desincronizar (dev en cada seed; prod en cada registro nuevo). Esta migración
+-- re-sincroniza el dato histórico; el cierre de la fuente (en el mismo PR) evita que
+-- se vuelva a ensuciar.
+--
+-- Idempotente y guardado: solo toca filas desincronizadas, nunca pisa decisiones
+-- deliberadas (dual-role, activeMode elegido por el toggle U-04). Espeja literalmente
+-- el backfill de U-02 (20260519200000), agregándole los WHERE de protección.
+
+-- roles[] vacío -> [role]
+-- El guard cardinality(roles)=0 protege a los dual (ej. Julieta ["TALLER","MARCA"]).
+UPDATE "users"
+   SET "roles" = ARRAY["role"::"UserRole"]
+ WHERE cardinality("roles") = 0;
+
+-- activeMode null -> role  (invariante role == activeMode para single-rol)
+-- El guard activeMode IS NULL protege cualquier modo elegido por el toggle.
+UPDATE "users"
+   SET "activeMode" = "role"
+ WHERE "activeMode" IS NULL;

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1301,6 +1301,25 @@ async function main() {
   console.log('  ✓ 5 novedades')
 
   // ============================================
+  // U-05: NORMALIZACIÓN roles[]/activeMode (cierre de fuente)
+  // ============================================
+  // Espeja la migración u05_backfill_roles_activemode: todo user single-rol queda con
+  // roles=[role] y activeMode=role. Se hace post-seed (no en cada create) para no tocar
+  // los ~10 creates uno por uno; el dual (Julieta) ya trae roles/activeMode explícitos
+  // y los guards (isEmpty / null) NO lo pisan. Idempotente: re-correr = 0 updates.
+  const usersSinNormalizar = await prisma.user.findMany({
+    where: { OR: [{ roles: { isEmpty: true } }, { activeMode: null }] },
+    select: { id: true, role: true },
+  })
+  for (const u of usersSinNormalizar) {
+    await prisma.user.update({
+      where: { id: u.id },
+      data: { roles: [u.role], activeMode: u.role },
+    })
+  }
+  console.log(`  ✓ U-05 normalización: ${usersSinNormalizar.length} users sincronizados (roles/activeMode)`)
+
+  // ============================================
   // RESUMEN
   // ============================================
   const counts = await prisma.$transaction([

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client'
 import bcrypt from 'bcryptjs'
+import { buildValidacionesFaltantes } from './validaciones-helper'
 
 const prisma = new PrismaClient()
 
@@ -524,29 +525,6 @@ async function main() {
 
   console.log('  ✓ Taller ORO: Corte Sur SRL (Avellaneda)')
 
-  // Post-seed: garantizar que cada taller tenga las 7 validaciones.
-  for (const taller of [tallerBronce, tallerPlata, tallerOro]) {
-    const existentes = await prisma.validacion.findMany({
-      where: { tallerId: taller.id },
-      select: { tipo: true },
-    })
-    const nombresExistentes = new Set(existentes.map(v => v.tipo))
-    const faltantes = tiposDoc.filter(td => !nombresExistentes.has(td.nombre))
-
-    if (faltantes.length > 0) {
-      await prisma.validacion.createMany({
-        data: faltantes.map(td => ({
-          tallerId: taller.id,
-          tipo: td.nombre,
-          tipoDocumentoId: td.id,
-          estado: 'NO_INICIADO' as const,
-        })),
-      })
-    }
-  }
-
-  console.log('  ✓ Post-seed: cada taller tiene 7 validaciones')
-
   // ============================================
   // PLANTILLA POR CATEGORÍA DE OFICIO TEXTIL
   // ============================================
@@ -640,6 +618,26 @@ async function main() {
   })
 
   console.log('  ✓ 2 marcas creadas (+ taller/marca del user multi-rol)')
+
+  // U-05 / D-02: garantizar el checklist de validaciones de TODOS los talleres.
+  // Va acá (tras crear La Hormiga y Taller U09, además de bronce/plata/oro) para que
+  // ningún taller del seed quede violando el invariante "1 Validacion NO_INICIADO por
+  // TipoDocumento.activo". Antes el loop solo cubría bronce/plata/oro → U09 y La Hormiga
+  // quedaban sin checklist y obligaban a un backfill manual post-reseed (deuda D-02).
+  // Reusa buildValidacionesFaltantes (misma definición que u05-backfill-validaciones.ts).
+  // Idempotente: solo crea las faltantes (los 3 talleres con checklist rico no se duplican).
+  const tiposActivos = tiposDoc // tiposDoc = tipos activos seedeados arriba
+  for (const taller of await prisma.taller.findMany({ select: { id: true } })) {
+    const existentes = await prisma.validacion.findMany({
+      where: { tallerId: taller.id },
+      select: { tipo: true },
+    })
+    const faltantes = buildValidacionesFaltantes(tiposActivos, new Set(existentes.map((v) => v.tipo)), taller.id)
+    if (faltantes.length > 0) {
+      await prisma.validacion.createMany({ data: faltantes })
+    }
+  }
+  console.log('  ✓ Post-seed: cada taller tiene su checklist de validaciones completo')
 
   // U-08: pedidos publicados/borrador por la marca del user dual (Julieta), para
   // ejercitar la regla anti-incesto E2E. Julieta tiene perfil TALLER y MARCA: no

--- a/prisma/validaciones-helper.ts
+++ b/prisma/validaciones-helper.ts
@@ -1,0 +1,33 @@
+// Fuente única de la definición de "checklist de validaciones de un taller".
+// Usado por el seed (prisma/seed.ts) y por el backfill (scripts/u05-backfill-validaciones.ts)
+// para no duplicar qué validaciones le corresponden a un taller ni su estado inicial.
+//
+// Regla del proyecto (ver registro/route.ts): cada taller arranca con UNA Validacion
+// NO_INICIADO por cada TipoDocumento.activo. La unicidad es por (tallerId, tipo).
+
+export type TipoDocMin = { id: string; nombre: string }
+export type ValidacionInicial = {
+  tallerId: string
+  tipo: string
+  tipoDocumentoId: string
+  estado: 'NO_INICIADO'
+}
+
+// Devuelve las validaciones NO_INICIADO que le FALTAN a un taller para completar su
+// checklist, dado el conjunto de tipos activos y los nombres de tipo que ya existen.
+// Dedupe por nombre de tipo (= @@unique([tallerId, tipo])). Idempotente: si no falta
+// nada, devuelve []. Pasar un Set vacío genera el checklist completo (taller nuevo).
+export function buildValidacionesFaltantes(
+  tiposActivos: TipoDocMin[],
+  tiposExistentes: Set<string>,
+  tallerId: string,
+): ValidacionInicial[] {
+  return tiposActivos
+    .filter((td) => !tiposExistentes.has(td.nombre))
+    .map((td) => ({
+      tallerId,
+      tipo: td.nombre,
+      tipoDocumentoId: td.id,
+      estado: 'NO_INICIADO' as const,
+    }))
+}

--- a/scripts/u05-audit.ts
+++ b/scripts/u05-audit.ts
@@ -1,0 +1,92 @@
+// U-05: auditoría del invariante roles[]/activeMode en User.
+//
+// Invariante objetivo (single y multi-rol):
+//   - cardinality(roles) >= 1  (nunca vacío)
+//   - activeMode != null
+//   - role ∈ roles  y  activeMode ∈ roles
+//
+// Modos:
+//   --dry-run (default): imprime el cuadro de estado actual (counts). NO escribe nada.
+//   --verify           : valida las post-condiciones; sale con código ≠0 si alguna falla
+//                        (pensado para usar tras aplicar la migración / re-seed).
+//
+// Guard anti-PROD: bloquea contra prod salvo ALLOW_PROD=1 (este script es de SOLO
+// LECTURA, pero mantenemos el guard por consistencia con check-db-ref.ts y para que
+// nadie lo confunda con un script de escritura). Espeja el ref de scripts/check-db-ref.ts.
+//
+// Ejecutar:
+//   npx tsx scripts/u05-audit.ts            # dry-run (default)
+//   npx tsx scripts/u05-audit.ts --verify   # post-condición (CI/manual post-migración)
+
+import { PrismaClient, type UserRole } from '@prisma/client'
+
+const PROD_REF = 'nefbhacmjrzynnhvgfnl' // ref de prod, ver scripts/check-db-ref.ts
+const dbUrl = process.env.DATABASE_URL ?? ''
+if (dbUrl.includes(PROD_REF) && process.env.ALLOW_PROD !== '1') {
+  console.error('🔴 BLOQUEADO: DATABASE_URL apunta a PROD. Repetí con ALLOW_PROD=1 (solo lectura) si es deliberado.')
+  process.exit(1)
+}
+
+const prisma = new PrismaClient()
+
+const mode = process.argv.includes('--verify') ? 'verify' : 'dry-run'
+
+type Row = { id: string; email: string; role: UserRole; roles: UserRole[]; activeMode: UserRole | null }
+
+async function main() {
+  const users: Row[] = await prisma.user.findMany({
+    select: { id: true, email: true, role: true, roles: true, activeMode: true },
+    orderBy: { email: 'asc' },
+  })
+
+  const sinRoles = users.filter((u) => u.roles.length === 0)
+  const sinActiveMode = users.filter((u) => u.activeMode === null)
+  // Inconsistencias de invariante (solo entre los que tienen datos): role no está en
+  // roles, o activeMode no está en roles. No las "arregla" la migración (sus WHERE solo
+  // tocan vacío/null); las reportamos para decisión informada.
+  const roleFueraDeRoles = users.filter((u) => u.roles.length > 0 && !u.roles.includes(u.role))
+  const activeModeFueraDeRoles = users.filter(
+    (u) => u.activeMode !== null && u.roles.length > 0 && !u.roles.includes(u.activeMode),
+  )
+
+  console.log(`\n📊 U-05 auditoría (${mode}) — ${users.length} users en total\n`)
+  console.log(`  roles=[] (vacío)         : ${sinRoles.length}`)
+  console.log(`  activeMode=null          : ${sinActiveMode.length}`)
+  console.log(`  role ∉ roles             : ${roleFueraDeRoles.length}`)
+  console.log(`  activeMode ∉ roles       : ${activeModeFueraDeRoles.length}`)
+
+  if (sinRoles.length) {
+    console.log('\n  Users con roles=[] (la migración les pondría roles=[role]):')
+    for (const u of sinRoles) console.log(`    - ${u.email}  role=${u.role}`)
+  }
+  if (sinActiveMode.length) {
+    console.log('\n  Users con activeMode=null (la migración les pondría activeMode=role):')
+    for (const u of sinActiveMode) console.log(`    - ${u.email}  role=${u.role}`)
+  }
+  if (roleFueraDeRoles.length || activeModeFueraDeRoles.length) {
+    console.log('\n  ⚠️  Inconsistencias que la migración NO toca (revisar a mano si aparecen):')
+    for (const u of roleFueraDeRoles) console.log(`    - ${u.email}  role=${u.role} ∉ roles=[${u.roles.join(',')}]`)
+    for (const u of activeModeFueraDeRoles)
+      console.log(`    - ${u.email}  activeMode=${u.activeMode} ∉ roles=[${u.roles.join(',')}]`)
+  }
+
+  if (mode === 'verify') {
+    const fallas = sinRoles.length + sinActiveMode.length + roleFueraDeRoles.length + activeModeFueraDeRoles.length
+    if (fallas > 0) {
+      console.error(`\n❌ verify FALLÓ: ${fallas} violaciones de invariante.\n`)
+      process.exit(1)
+    }
+    console.log('\n✅ verify OK: invariante roles[]/activeMode satisfecho por el 100% de los users.\n')
+  } else {
+    console.log('\n(dry-run: no se escribió nada. La migración SQL aplica el backfill en el build / db:migrate.)\n')
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/scripts/u05-backfill-validaciones.ts
+++ b/scripts/u05-backfill-validaciones.ts
@@ -23,6 +23,7 @@
 //   ALLOW_PROD=1 npx tsx scripts/u05-backfill-validaciones.ts --apply    # aplica en prod (deliberado)
 
 import { PrismaClient } from '@prisma/client'
+import { buildValidacionesFaltantes } from '../prisma/validaciones-helper'
 
 const PROD_REF = 'nefbhacmjrzynnhvgfnl' // ref de prod, ver scripts/check-db-ref.ts
 const dbUrl = process.env.DATABASE_URL ?? ''
@@ -51,23 +52,16 @@ async function main() {
   let validacionesCreadas = 0
 
   for (const t of talleres) {
-    const existentes = new Set(t.validaciones.map((v) => v.tipo))
-    const faltantes = tiposActivos.filter((td) => !existentes.has(td.nombre)) // dedupe por (tallerId, tipo)
+    // Misma definición que el seed (buildValidacionesFaltantes): dedupe por (tallerId, tipo).
+    const faltantes = buildValidacionesFaltantes(tiposActivos, new Set(t.validaciones.map((v) => v.tipo)), t.id)
     if (!faltantes.length) continue
 
     talleresTocados++
     validacionesCreadas += faltantes.length
-    console.log(`  ${t.nombre} (${t.id}): faltan ${faltantes.length} → [${faltantes.map((f) => f.nombre).join(', ')}]`)
+    console.log(`  ${t.nombre} (${t.id}): faltan ${faltantes.length} → [${faltantes.map((f) => f.tipo).join(', ')}]`)
 
     if (apply) {
-      await prisma.validacion.createMany({
-        data: faltantes.map((td) => ({
-          tallerId: t.id,
-          tipo: td.nombre,
-          tipoDocumentoId: td.id,
-          estado: 'NO_INICIADO' as const,
-        })),
-      })
+      await prisma.validacion.createMany({ data: faltantes })
     }
   }
 

--- a/scripts/u05-backfill-validaciones.ts
+++ b/scripts/u05-backfill-validaciones.ts
@@ -1,0 +1,87 @@
+// U-05 (paso D, secundario): backfill de validaciones faltantes (deuda D-02).
+//
+// Por qué existe: talleres creados vía /registro/completar antes del fix de U-09
+// quedaron SIN checklist de Validacion. Este script crea las Validacion NO_INICIADO
+// faltantes (una por cada TipoDocumento.activo) para cada taller con checklist
+// incompleto. La FUENTE ya está cerrada (registro/route.ts y U-09 crean el checklist
+// al alta); esto repara solo el dato histórico.
+//
+// Por qué script (no SQL crudo): para generar cuids correctos y leer TipoDocumento.activo
+// dinámicamente (SQL crudo necesitaría gen_random_uuid() y hardcodear los tipos).
+//
+// Idempotente: dedupe por (tallerId, tipo) = @@unique. Re-correr = 0 inserts.
+//
+// Modos:
+//   (default)  --dry-run : reporta qué crearía, NO escribe.
+//   --apply              : crea las validaciones faltantes.
+// Guard anti-PROD: bloquea contra prod salvo ALLOW_PROD=1.
+//
+// Ejecutar:
+//   npx tsx scripts/u05-backfill-validaciones.ts            # dry-run
+//   ALLOW_PROD=1 npx tsx scripts/u05-backfill-validaciones.ts            # dry-run contra prod (dimensionar)
+//   npx tsx scripts/u05-backfill-validaciones.ts --apply    # aplica en dev
+//   ALLOW_PROD=1 npx tsx scripts/u05-backfill-validaciones.ts --apply    # aplica en prod (deliberado)
+
+import { PrismaClient } from '@prisma/client'
+
+const PROD_REF = 'nefbhacmjrzynnhvgfnl' // ref de prod, ver scripts/check-db-ref.ts
+const dbUrl = process.env.DATABASE_URL ?? ''
+const isProd = dbUrl.includes(PROD_REF)
+if (isProd && process.env.ALLOW_PROD !== '1') {
+  console.error('🔴 BLOQUEADO: DATABASE_URL apunta a PROD. Repetí con ALLOW_PROD=1 si es deliberado.')
+  process.exit(1)
+}
+if (isProd) console.warn('⚠️  ALLOW_PROD=1 — operando contra PROD deliberadamente.')
+
+const prisma = new PrismaClient()
+const apply = process.argv.includes('--apply')
+
+async function main() {
+  const tiposActivos = await prisma.tipoDocumento.findMany({
+    where: { activo: true },
+    select: { id: true, nombre: true },
+  })
+  console.log(`\n📋 U-05 backfill validaciones (${apply ? 'APPLY' : 'dry-run'}) — ${tiposActivos.length} tipos activos\n`)
+
+  const talleres = await prisma.taller.findMany({
+    select: { id: true, nombre: true, validaciones: { select: { tipo: true } } },
+  })
+
+  let talleresTocados = 0
+  let validacionesCreadas = 0
+
+  for (const t of talleres) {
+    const existentes = new Set(t.validaciones.map((v) => v.tipo))
+    const faltantes = tiposActivos.filter((td) => !existentes.has(td.nombre)) // dedupe por (tallerId, tipo)
+    if (!faltantes.length) continue
+
+    talleresTocados++
+    validacionesCreadas += faltantes.length
+    console.log(`  ${t.nombre} (${t.id}): faltan ${faltantes.length} → [${faltantes.map((f) => f.nombre).join(', ')}]`)
+
+    if (apply) {
+      await prisma.validacion.createMany({
+        data: faltantes.map((td) => ({
+          tallerId: t.id,
+          tipo: td.nombre,
+          tipoDocumentoId: td.id,
+          estado: 'NO_INICIADO' as const,
+        })),
+      })
+    }
+  }
+
+  console.log(`\n  Talleres con checklist incompleto: ${talleresTocados} / ${talleres.length}`)
+  console.log(`  Validaciones ${apply ? 'creadas' : 'a crear'}: ${validacionesCreadas}`)
+  if (!apply && talleresTocados > 0) console.log('\n  (dry-run: no se escribió nada. Re-correr con --apply para aplicar.)')
+  console.log('')
+}
+
+main()
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/src/__tests__/u-05-cierre-fuente.test.ts
+++ b/src/__tests__/u-05-cierre-fuente.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// U-05: cierre de la fuente. Las 3 vías que crean/actualizan users deben setear
+// roles=[role] y activeMode=role (invariante role==activeMode, role ∈ roles) para que
+// el dato no se vuelva a desincronizar. Acá cubrimos los 2 handlers (registro y
+// registro/completar); el seed se valida vía script (u05-audit --verify post db:seed).
+
+// ---------- mocks compartidos ----------
+vi.mock('@/compartido/lib/prisma', () => ({
+  prisma: {
+    user: { findUnique: vi.fn(), create: vi.fn() },
+    taller: { findUnique: vi.fn() },
+    tipoDocumento: { findMany: vi.fn().mockResolvedValue([]) },
+    validacion: { createMany: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}))
+vi.mock('@/compartido/lib/arca', () => ({
+  consultarPadron: vi.fn(),
+  errorBloqueaRegistro: vi.fn().mockReturnValue(false),
+  mensajeErrorArca: vi.fn().mockReturnValue('CUIT invalido'),
+}))
+vi.mock('@/compartido/lib/email', () => ({
+  sendEmail: vi.fn().mockResolvedValue(undefined),
+  buildBienvenidaEmail: vi.fn().mockReturnValue({ subject: 's', html: '<p>h</p>' }),
+}))
+vi.mock('@/compartido/lib/ratelimit', () => ({
+  rateLimit: vi.fn().mockResolvedValue(null),
+  getClientIp: vi.fn().mockReturnValue('1.1.1.1'),
+}))
+vi.mock('@/compartido/lib/log', () => ({ logActividad: vi.fn() }))
+vi.mock('bcryptjs', () => ({ default: { hash: vi.fn().mockResolvedValue('hashed') } }))
+vi.mock('@/compartido/lib/auth', () => ({ auth: vi.fn() }))
+vi.mock('@/compartido/lib/afip', () => ({ verificarCuit: vi.fn() }))
+vi.mock('@/compartido/lib/crear-entidad-rol', () => ({ crearEntidadParaRol: vi.fn() }))
+
+import { prisma } from '@/compartido/lib/prisma'
+import { consultarPadron } from '@/compartido/lib/arca'
+import { auth } from '@/compartido/lib/auth'
+import { verificarCuit } from '@/compartido/lib/afip'
+import { crearEntidadParaRol } from '@/compartido/lib/crear-entidad-rol'
+
+import { POST as registroPOST } from '@/app/api/auth/registro/route'
+import { POST as completarPOST } from '@/app/api/auth/registro/completar/route'
+
+const mockUserFind = prisma.user.findUnique as ReturnType<typeof vi.fn>
+const mockUserCreate = prisma.user.create as ReturnType<typeof vi.fn>
+const mockTallerFind = prisma.taller.findUnique as ReturnType<typeof vi.fn>
+const mockTx = prisma.$transaction as ReturnType<typeof vi.fn>
+const mockPadron = consultarPadron as ReturnType<typeof vi.fn>
+const mockAuth = auth as ReturnType<typeof vi.fn>
+const mockVerificarCuit = verificarCuit as ReturnType<typeof vi.fn>
+const mockCrear = crearEntidadParaRol as ReturnType<typeof vi.fn>
+
+const reqRegistro = (body: unknown) =>
+  registroPOST(
+    new NextRequest('http://localhost/api/auth/registro', { method: 'POST', body: JSON.stringify(body) }) as NextRequest,
+    {} as never,
+  )
+
+const reqCompletar = (body: unknown) =>
+  completarPOST(
+    new NextRequest('http://localhost/api/auth/registro/completar', { method: 'POST', body: JSON.stringify(body) }) as NextRequest,
+  )
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockPadron.mockResolvedValue({ exitosa: true, datos: { nombre: 'X' } })
+})
+
+describe('U-05 cierre de fuente — POST /api/auth/registro', () => {
+  it('MARCA nueva: user.create recibe roles=[MARCA] y activeMode=MARCA', async () => {
+    mockUserFind.mockResolvedValue(null)
+    mockUserCreate.mockResolvedValue({ id: 'u1', email: 'm@x.com', name: null, role: 'MARCA' })
+
+    const res = await reqRegistro({
+      email: 'm@x.com',
+      password: 'password123',
+      role: 'MARCA',
+      marcaData: { nombre: 'Mi Marca', cuit: '27-99999999-1' },
+    })
+
+    expect(res.status).toBe(201)
+    const arg = mockUserCreate.mock.calls[0][0]
+    expect(arg.data.role).toBe('MARCA')
+    expect(arg.data.roles).toEqual(['MARCA'])
+    expect(arg.data.activeMode).toBe('MARCA')
+  })
+
+  it('TALLER nuevo: user.create recibe roles=[TALLER] y activeMode=TALLER', async () => {
+    mockUserFind.mockResolvedValue(null)
+    mockUserCreate.mockResolvedValue({ id: 'u2', email: 't@x.com', name: null, role: 'TALLER' })
+    mockTallerFind.mockResolvedValue(null) // corta el subflow de validaciones
+
+    const res = await reqRegistro({
+      email: 't@x.com',
+      password: 'password123',
+      role: 'TALLER',
+      tallerData: { nombre: 'Mi Taller', cuit: '20-12345678-9' },
+    })
+
+    expect(res.status).toBe(201)
+    const arg = mockUserCreate.mock.calls[0][0]
+    expect(arg.data.role).toBe('TALLER')
+    expect(arg.data.roles).toEqual(['TALLER'])
+    expect(arg.data.activeMode).toBe('TALLER')
+  })
+
+  it('invariante: roles contiene siempre al role y activeMode == role', async () => {
+    mockUserFind.mockResolvedValue(null)
+    mockUserCreate.mockResolvedValue({ id: 'u3', email: 'm2@x.com', name: null, role: 'MARCA' })
+    await reqRegistro({ email: 'm2@x.com', password: 'password123', role: 'MARCA', marcaData: { nombre: 'M', cuit: '27-1-1' } })
+    const { role, roles, activeMode } = mockUserCreate.mock.calls[0][0].data
+    expect(roles).toContain(role)
+    expect(activeMode).toBe(role)
+  })
+})
+
+describe('U-05 cierre de fuente — POST /api/auth/registro/completar', () => {
+  beforeEach(() => {
+    mockAuth.mockResolvedValue({ user: { id: 'u1' } })
+    mockVerificarCuit.mockResolvedValue({ valid: true })
+    // $transaction(cb) ejecuta el callback con un tx que expone user.update
+    mockTx.mockImplementation(async (cb: (tx: unknown) => unknown) => cb({ user: { update: txUserUpdate } }))
+  })
+
+  const txUserUpdate = vi.fn()
+
+  it('completar primera entidad: user.update setea role + roles=[role] + activeMode=role', async () => {
+    mockUserFind.mockResolvedValue({ id: 'u1', taller: null, marca: null })
+
+    const res = await reqCompletar({ role: 'TALLER', nombre: 'Mi Taller', cuit: '20-12345678-9' })
+
+    expect(res.status).toBe(200)
+    expect(mockCrear).toHaveBeenCalled()
+    expect(txUserUpdate).toHaveBeenCalledWith({
+      where: { id: 'u1' },
+      data: { role: 'TALLER', roles: ['TALLER'], activeMode: 'TALLER', registroCompleto: true },
+    })
+  })
+
+  it('no sincroniza si el user ya tiene entidad (409, sin tocar el update)', async () => {
+    mockUserFind.mockResolvedValue({ id: 'u1', taller: { id: 't1' }, marca: null })
+    const res = await reqCompletar({ role: 'MARCA', nombre: 'M', cuit: '27-1-1' })
+    expect(res.status).toBe(409)
+    expect(txUserUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/auth/registro/completar/route.ts
+++ b/src/app/api/auth/registro/completar/route.ts
@@ -54,7 +54,10 @@ export async function POST(req: NextRequest) {
     })
     await tx.user.update({
       where: { id: user.id },
-      data: { role, registroCompleto: true },
+      // U-05: el user completa su primera entidad (el guard de arriba garantiza que
+      // no tenía taller/marca → es single-rol). Sincronizamos roles=[role]/activeMode=role
+      // junto al role para no regenerar el dato desincronizado. Ver spec v4-u-05.
+      data: { role, roles: [role], activeMode: role, registroCompleto: true },
     })
   })
 

--- a/src/app/api/auth/registro/route.ts
+++ b/src/app/api/auth/registro/route.ts
@@ -89,6 +89,11 @@ export const POST = apiHandler(async (req: NextRequest) => {
         name: data.name || data.nombre || null,
         phone: data.phone || null,
         role: data.role,
+        // U-05: invariante multi-rol — todo user nuevo sale con roles=[role] y
+        // activeMode=role (role==activeMode, role ∈ roles). Cierra la fuente para que
+        // el dato no se desincronice (ver spec v4-u-05). NO usar push: setear el array.
+        roles: [data.role],
+        activeMode: data.role,
         // MITIGACION #307 (temporal): marcar emailVerified al crear la cuenta para
         // no bloquear el onboarding. El paso "Verificar email" del checklist
         // (onboarding.ts) gatea con !!user.emailVerified y, sin flujo de verificacion

--- a/src/app/api/test-utils/reset-seed-state/route.ts
+++ b/src/app/api/test-utils/reset-seed-state/route.ts
@@ -72,11 +72,13 @@ export async function POST(req: NextRequest) {
       if (u09.marca) {
         await tx.marca.delete({ where: { id: u09.marca.id } })
       }
-      // Estado del seed: single-rol (roles=[] normalizado a [role] por
-      // rolesEfectivos), activeMode null, role TALLER.
+      // Estado del seed POST-U-05: single-rol TALLER con el invariante sincronizado
+      // en DB (roles=[TALLER], activeMode=TALLER), NO roles=[]/null. U-05 cerró la
+      // fuente: el seed ya no produce roles=[] para u09, así que el reset tampoco debe
+      // re-introducir ese estado (sigue siendo single-rol → "Agregar rol" reaparece).
       await tx.user.update({
         where: { id: u09.id },
-        data: { roles: { set: [] }, activeMode: null, role: 'TALLER' },
+        data: { roles: { set: ['TALLER'] }, activeMode: 'TALLER', role: 'TALLER' },
       })
     })
     return NextResponse.json({ ok: true, user: key })


### PR DESCRIPTION
## U-05 — Migración de datos multi-rol + cierre de fuente

Cierra la deuda de U-02: `roles[]`/`activeMode` se backfilleaban una vez pero las fuentes nunca los seteaban → el dato se re-desincronizaba (dev en cada seed; prod en cada registro nuevo). U-05 = backfill idempotente **+** cierre de la fuente.

### Cambios
- **Migración SQL** `20260610120000_u05_backfill_roles_activemode` — `roles=ARRAY[role]` / `activeMode=role` solo en filas desincronizadas (guards `cardinality(roles)=0` / `activeMode IS NULL` → no pisa al dual ni al modo del toggle). La aplica `prisma migrate deploy` en el build de Vercel. Espeja el backfill de U-02.
- **Cierre de fuente** (invariante `roles:[role], activeMode:role`): `registro/route.ts`, `registro/completar/route.ts` (sobre la transacción de U-09, ya mergeado), `seed.ts` (normalización post-seed).
- **`scripts/u05-audit.ts`** — `--dry-run` (default) / `--verify`, guard anti-PROD.
- **`scripts/u05-backfill-validaciones.ts`** — deuda **D-02** (talleres sin checklist), `--apply` + guard anti-PROD. `srodriguezunq` → opción D (loggear y dejar, sin inventar entidad).
- **Tests unit** `u-05-cierre-fuente.test.ts` (registro + completar).

### Verificado en DEV (2026-06-10)
- Pre-migración: **9/10** users con `roles=[]`/`activeMode=null` (0 inconsistencias).
- Post: **0** violaciones (`u05-audit --verify` OK). Idempotente: 1ª corrida 9+9 filas, 2ª 0+0.
- Validaciones D-02: **2** talleres incompletos (U09, La Hormiga) → **14** validaciones creadas; re-dry-run = 0.

### Pendiente fase PROD (NO en este PR)
- La migración SQL se aplica sola en el próximo deploy.
- El backfill de validaciones en prod es un **paso manual posterior, gated** (`ALLOW_PROD=1 ... --apply`) tras dimensionar con el dry-run, con OK explícito.

### Notas
- Toolchain local roto (T-01): no se pudieron correr vitest/prisma/tsc localmente → CI es el validador. La migración se aplicó a DEV vía raw SQL idempotente (el preview build la re-aplica+registra sin conflicto).
- ⚠️ DEV fue tocado (migración + 14 validaciones, additivo/idempotente) — avisar a Sergio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)