### PR TITLE
fix(b-05): race de clobbering de cookie en sesion JWT

### DIFF
--- a/.claude/specs/v4-b-05-fix-race-sesion.md
+++ b/.claude/specs/v4-b-05-fix-race-sesion.md
@@ -1,0 +1,221 @@
+# B-05 — Fix del race de clobbering de cookie en rolling JWT session
+
+> **Estado:** IMPLEMENTADO (branch `feature/b-05-fix-race-sesion`). Decisiones de Gerardo cerradas (ver §8). NO mergeado — es auth, queda para revisión final + smoke manual.
+>
+> **Decisiones cerradas (Gerardo):**
+> 1. Alcance: **A + B** (middleware read-only + cookie server-side en los 2 endpoints).
+> 2. Trade-off sliding-expiry: **ACEPTADO**, condicionado al gate del PASO 0 (verificado: toda ruta autenticada monta `useSession` vía `SessionProvider` en el root layout + `FeedbackWidget` global + `Header` en taller/marca/estado).
+> 3. `update()` cliente: **queda redundante** (propaga al SessionProvider/broadcast multi-tab); su eliminación es follow-up.
+> 4. Test multi-tab: **SÍ, en este PR** (en `u-04-toggle-multi-rol.spec.ts`, serial + afterEach reset julieta).
+> 5. `updateAge`: queda en config (inerte); **comentario corregido** en `auth.config.ts`.
+> 6. `getToken` vs `decode`: **`decode` manual** (helper único `session-cookie.ts`, reusado por `n/[token]`) + unit test de round-trip y anti-escalación.
+> **Severidad:** MEDIA-ALTA. Reproducible en flujo normal (toggle a Marca → navegar → cae en Taller). Determinístico 3/3 en CI. El usuario queda pisado hasta re-login.
+> **Test de aceptación (ya escrito):** `tests/e2e/u-04-toggle-multi-rol.spec.ts` → `test.fixme('el modo activo persiste…')`. Des-fixmearlo y que pase estable = criterio de éxito.
+
+---
+
+## 1. Contexto
+
+### El síntoma
+Un usuario multi-rol (Julieta: `roles=[TALLER, MARCA]`, `activeMode=TALLER`) abre el toggle "Operando como…", elige **Marca**, es redirigido a `/marca` correctamente. Pero al navegar a `/` (o recargar), el middleware lo manda de vuelta a `/taller`. La DB tiene `activeMode=MARCA`; la **cookie de sesión** quedó pisada en `TALLER`. No se auto-cura: solo el re-login lo arregla (porque `authorize()` relee la DB).
+
+### El mecanismo (verificado en código fuente, no inferido)
+Estrategia de sesión: **JWT** + rolling (`maxAge 7d`, `updateAge 24h`) — `src/compartido/lib/auth.config.ts:29-33`.
+
+**Hallazgo central del discovery (PASO 1):** con `strategy: 'jwt'`, Auth.js v5 **re-encripta y re-emite la cookie de sesión en CADA lectura de sesión, incondicionalmente**. No hay ningún chequeo de `updateAge` en la rama JWT.
+
+Fuente: `node_modules/next-auth/node_modules/@auth/core/lib/actions/session.js`, rama `sessionStrategy === "jwt"` (líneas 21-64):
+
+```js
+// Refresh JWT expiry by re-signing it, with an updated expiry date
+const newToken = await jwt.encode({ ...jwt, token, salt });
+// Set cookie, to also update expiry date on cookie
+const sessionCookies = sessionStore.chunk(newToken, { expires: newExpires });
+response.cookies?.push(...sessionCookies);   // ← SIEMPRE, sin gate de updateAge
+```
+
+`updateAge` **solo** se respeta en la rama de **database-session** (líneas 77-92), y aún ahí solo throttlea el *write a la DB* — la cookie igual se re-emite. **Conclusión: nuestro `updateAge: 24h` es config muerta bajo JWT, y el comentario de `auth.config.ts:32` ("renueva cada 24h si hay actividad") es engañoso.** Esto es **comportamiento esperado de Auth.js v5, NO un bug de configuración nuestro.**
+
+### Por qué el `updateAge` no nos salva (responde la pregunta clave del PASO 1)
+La hipótesis previa era: "si `updateAge=24h`, ¿por qué Set-Cookie en cada GET?". **Respuesta: porque para JWT `updateAge` no gobierna la re-emisión; v5 hace sliding-window re-firmando el token en cada lectura.** No es un bug nuestro ni hay un flag para apagarlo. Esto **descarta** la "OPCIÓN A original" (config / honrar updateAge) como fix de bajo costo, y reorienta el espacio de soluciones (ver §3).
+
+### La vía dominante de re-emisión: el middleware
+`src/middleware.ts` envuelve **todas** las navegaciones de página con `export default auth((req) => {…})`. El wrapper de v5, tras correr nuestro handler, **mergea la cookie re-emitida sobre el `NextResponse`** (incluso sobre un `NextResponse.next()`). Por eso cada navegación re-emite la cookie firmando el token que **esa request transportó**.
+
+> El matcher excluye `/api`, así que `/api/auth/session` (el endpoint de `update()` y del polling de `useSession`) **no** pasa por middleware. La re-emisión problemática viene de las **navegaciones de página**, que son la mayoría del tráfico autenticado.
+
+### La ventana de race (paso a paso del flujo del test)
+1. `cambiarModo('MARCA')` → `PATCH /api/usuarios/me/active-mode` → **DB = MARCA**. (`modo-toggle.tsx:59`)
+2. `await update({ activeMode: 'MARCA' })` → `POST /api/auth/session` (trigger `update`) → callback `jwt` setea `token.activeMode=MARCA` → **Set-Cookie(MARCA)**. La cookie del browser debería quedar en MARCA. (`modo-toggle.tsx:70`)
+3. `router.push('/marca')` + `router.refresh()` (`modo-toggle.tsx:81-82`) → requests de navegación **a través del middleware**. Next.js además dispara **prefetches RSC** automáticos. Cualquiera de esas requests que haya salido con la cookie **previa (TALLER)** —porque se despachó antes de que el Set-Cookie del paso 2 se committeara al cookie jar— al pasar por el middleware **re-emite Set-Cookie(TALLER)** → **pisa la cookie MARCA** (last-write-wins en el jar).
+4. `page.goto('/')` → el middleware lee la cookie (ahora **TALLER** pisada) → redirige a `/taller`. El gate lee la cookie, **no la DB**, así que re-navegar no recupera.
+
+### Decisiones de arquitectura que aplican
+- Gating por **membresía en `roles[]`** (`tieneAlgunRol` / `modoActivo`), no por el escalar — el race es sobre `activeMode`, que decide el dashboard, no sobre permisos. **No hay escalada de privilegios** acá: el peor caso es "veo el dashboard del rol equivocado", ambos roles ya son míos.
+- `auth.config.ts` debe seguir siendo Edge-safe (sin Prisma): el middleware corre en Edge.
+- Invariante U-03: `role == activeMode` en el token.
+
+### Flujos afectados
+- **Toggle de modo** (`modo-toggle.tsx` → `update({ activeMode })`).
+- **Agregar rol** (`agregar-rol-card.tsx` → `update({ activeMode, roles })`) — mismo mecanismo, además expande `roles[]` en la cookie; un clobber acá puede devolver el JWT a single-rol y mandar a `/unauthorized`.
+
+---
+
+## 2. Qué construir (resumen; el detalle técnico está en §4)
+
+Eliminar la posibilidad de que una lectura de sesión concurrente pise la cookie recién actualizada por un cambio de modo/rol. Dos palancas independientes y combinables:
+
+- **A — Middleware read-only:** que el middleware **lea** el JWT sin re-emitir Set-Cookie. Remueve la vía dominante de clobbering (toda navegación). **Fix núcleo recomendado.**
+- **B — Set de cookie server-side en los endpoints de mutación:** que `active-mode` y `me/roles` re-firmen el token y seteen la cookie **en la misma response que el cliente espera**, en vez de depender del `update()` cliente posterior. Hardening; complementa A. Precedente en repo: `src/app/n/[token]/route.ts`.
+
+El **criterio de éxito** es des-fixmear `u-04 'el modo activo persiste'` y que pase estable (no flaky), sin romper ningún e2e existente.
+
+---
+
+## 3. Opciones evaluadas (mínimo 3)
+
+### OPCIÓN A — Middleware read-only (decode sin re-emitir) — **RECOMENDADA (núcleo)**
+**Qué cambia:** reemplazar `export default auth((req) => {…})` por un `export default function middleware(req)` que lea el token con `getToken`/`decode` de `next-auth/jwt` (lectura pura, **sin** Set-Cookie), y construya el `FuenteRoles` desde el token decodificado para alimentar la lógica de gating **idéntica** que ya existe.
+
+- **Qué resuelve:** elimina al **único** escritor de cookie en la ruta de navegación. Tras el `update()` del paso 2, nada vuelve a re-emitir en los pasos 3-4 → la cookie MARCA sobrevive. **Des-fixmea el test de forma determinística.**
+- **Qué NO resuelve (honestidad):** dos llamadas concurrentes a `/api/auth/session` (p.ej. dos refetch de `useSession` alrededor del `update()`) podrían todavía pisarse entre sí. Es una ventana mucho menor, no está en la ruta de navegación, y `SessionProvider` de next-auth sincroniza pestañas por broadcast/storage events. Multi-tab queda mitigado, no demostrado al 100%.
+- **Riesgo:** es middleware de auth. Hay que (i) pasar `cookieName` (`__Secure-authjs.session-token` / `authjs.session-token`) y `secret` (`NEXTAUTH_SECRET`) correctos a `getToken`; (ii) reconstruir el shape `{ roles, role, activeMode, registroCompleto }` desde el token; (iii) perder el refresh de expiry sliding que daba el middleware.
+- **Mitigación del (iii):** `useSession` vive en `header.tsx` (layout, todas las páginas autenticadas) → `SessionProvider` (`src/app/providers.tsx`) sigue pegándole a `/api/auth/session`, que **sí** re-emite y refresca la expiry. La ventana sliding se preserva por el cliente, no por el middleware. **A confirmar** que toda página autenticada monta el header (ver §8).
+- **Esfuerzo:** ~0.5 día (reescritura del read del middleware + regresión de auth).
+- **Validación:** des-fixmea u-04 + suite e2e completa (gating por rol) + chequeo manual de login/logout/expiry.
+
+### OPCIÓN B — Set de cookie server-side en `active-mode` y `me/roles` — **RECOMENDADA (hardening)**
+**Qué cambia:** los endpoints, tras confirmar la DB, **re-firman** el token (con el `activeMode`/`roles[]` nuevos) usando `encode` de `next-auth/jwt` y setean la cookie de sesión en la **misma** `NextResponse` (`response.cookies.set`). El `update()` cliente pasa a ser redundante (se puede eliminar o dejar como cinturón-y-tiradores).
+
+- **Viabilidad:** **probada en repo.** `src/app/n/[token]/route.ts:42-66` ya hace exactamente esto para el magic-link: `encode({ token, secret: NEXTAUTH_SECRET, salt: cookieName })` + `response.cookies.set({ name: cookieName, … })`. El patrón es conocido y funciona con nuestras cookies custom.
+- **Qué resuelve:** el estado autoritativo aterriza en la cookie **dentro de la response que el `fetch` del cliente espera** → desaparece el round-trip separado de `update()` que se interleavaba con las navegaciones. Para "agregar rol" garantiza que `roles[]` expandido viaja en la cookie sin depender del `update()`.
+- **Qué NO resuelve por sí sola:** **no** detiene la re-emisión del middleware. Si el middleware sigue con el wrapper `auth()`, una navegación/prefetch stale aún puede pisar. **B sola NO elimina el race** — necesita A (o que A ya esté).
+- **Riesgo:** re-implementa el firmado del token de Auth.js fuera de la librería (acoplamiento a internals/versión). Hay que mantener el payload del token en lockstep con el callback `jwt` (id, role, roles, activeMode, registroCompleto, email, name, sub). Mitigado por: extraer un helper único `firmarSessionToken()` reutilizado por `n/[token]` y los dos endpoints (single source).
+- **Esfuerzo:** ~0.5 día (helper compartido + cablear 2 endpoints + decidir si se borra el `update()` cliente).
+- **Validación:** misma que A; además verificar que tras el PATCH la cookie ya trae el estado nuevo (test de doble-contexto).
+
+### OPCIÓN C — Mitigación cliente: drenar/serializar lecturas antes de navegar — **RECHAZADA como primaria**
+**Qué cambia:** tras `update()`, bloquear la navegación hasta confirmar la cookie nueva (p.ej. re-fetch de `/api/auth/session` y verificar `activeMode`, o un pequeño delay/guard antes de `router.push`).
+
+- **Qué NO resuelve:** los **prefetches RSC automáticos** que Next dispara (hover/viewport) no pasan por este guard; tampoco cubre multi-tab; es timing-dependiente y frágil. El código ya `await`-ea `update()` antes de `push` y aun así el race ocurre, justamente por las lecturas concurrentes fuera del control del componente.
+- **Esfuerzo:** bajo, pero **no es un fix**, es un parche que reduce probabilidad sin cerrar la causa raíz.
+- **Veredicto:** sirve como racionalización del problema, no como solución. Descartada.
+
+### OPCIÓN D — Combinación recomendada: **A (núcleo) + B (hardening)**
+A hace determinístico el flujo testeado (remueve el clobber de navegación). B cierra el residual de concurrencia en `/api/auth/session` y multi-tab, y hace que el estado autoritativo viaje en la response esperada. Con A+B se puede **eliminar el `update()` cliente** (o dejarlo inerte). Es el camino con mejor relación robustez/riesgo.
+
+---
+
+## 4. Prescripciones técnicas
+
+> El alcance final (A-sola vs A+B) lo decide Gerardo en §8. Acá se prescribe cada pieza; el implementador no improvisa arquitectura.
+
+### Pieza A — `src/middleware.ts`
+- **Quitar** el wrapper `export default auth((req) => {…})` y el `const { auth } = NextAuth(authConfig)`.
+- **Usar** `export default async function middleware(req: NextRequest)` (o `proxy.ts` si se migra; ver CLAUDE.md — **no** migrar en este PR salvo decisión explícita).
+- Leer el token con `getToken` de `next-auth/jwt`:
+  ```ts
+  import { getToken } from 'next-auth/jwt'
+  const token = await getToken({
+    req,
+    secret: process.env.NEXTAUTH_SECRET!,
+    secureCookie: process.env.NODE_ENV === 'production',
+    cookieName: process.env.NODE_ENV === 'production'
+      ? '__Secure-authjs.session-token'
+      : 'authjs.session-token',
+    salt: ... // ver nota de versión abajo
+  })
+  ```
+  - **Nota de versión (a validar en implementación):** la firma exacta de `getToken` en `next-auth@5.0.0-beta.30` puede requerir `salt` = `cookieName`. Si `getToken` no expone la firma esperada en esta beta, usar `decode` de `next-auth/jwt` directamente leyendo `req.cookies.get(cookieName)?.value` (mismo patrón que `n/[token]` usa con `encode`). El criterio: **lectura pura, cero `Set-Cookie`.**
+- Reconstruir el `FuenteRoles` desde el token decodificado: `{ roles: token.roles, role: token.role, activeMode: token.activeMode }`. Reemplaza `req.auth?.user`.
+- `isLoggedIn = !!token`. `registroCompleto = token?.registroCompleto`.
+- **La lógica de gating (rutas públicas, redirects por rol, `/` → dashboard) NO cambia** — solo cambia de dónde sale el `sessionUser`/`isLoggedIn`. Cero cambios en `tieneAlgunRol`/`modoActivo`.
+- Mantener `auth.config.ts` como está (lo usan `auth.ts` y los endpoints vía `auth()`); el middleware deja de instanciarlo.
+
+### Pieza B — helper de firmado + endpoints
+- **Crear** `src/compartido/lib/session-cookie.ts` con un único `firmarSessionToken(payload)` + `nombreCookieSesion()` + `opcionesCookieSesion()`, extrayendo la lógica hoy inline en `n/[token]/route.ts` (DRY: refactorizar también `n/[token]` para que lo use — single source del salt/secret/cookieName).
+- En `src/app/api/usuarios/me/active-mode/route.ts`: tras el `prisma.user.update`, leer el token actual (decode de la cookie entrante), mutar `activeMode`/`role`, re-firmar y `response.cookies.set(...)` en la respuesta. Devolver `NextResponse` con la cookie seteada.
+- En `src/app/api/usuarios/me/roles/route.ts`: ídem, con `roles[]` expandido + `activeMode`/`role` nuevos.
+- **Mantener el invariante** `role == activeMode` y el payload del token en lockstep con el callback `jwt` de `auth.config.ts` (id, sub, email, name, role, roles, activeMode, registroCompleto).
+- **Cliente:** decidir (§8) si se elimina `update({…})` en `modo-toggle.tsx` y `agregar-rol-card.tsx` (ya no necesario si B setea la cookie) o se deja como redundancia inofensiva. `router.refresh()`/`router.push()` se mantienen.
+
+### Qué NO tocar
+- El schema de Prisma (no aplica).
+- `auth.ts` / `authorize()` (el login sigue igual).
+- La lógica de negocio de gating.
+- `updateAge`/`maxAge`: **opcional** corregir el comentario engañoso de `auth.config.ts:32` y/o eliminar `updateAge` (es inerte bajo JWT) — decisión en §8, no bloqueante.
+
+---
+
+## 5. Casos borde
+
+| Caso | Comportamiento esperado | Cubierto por |
+|---|---|---|
+| Toggle Taller→Marca→navegar a `/` | Queda en `/marca` (cookie = DB) | u-04 des-fixmeado |
+| Agregar 2º rol y navegar | JWT trae `roles[]` expandido; no cae en `/unauthorized` | u-09 e2e + nuevo |
+| Multi-tab: tab A togglea, tab B tiene `useSession` | Tab B se sincroniza (broadcast) o, con B, su próxima lectura ve cookie nueva | nuevo test doble-contexto (§7) |
+| Sesión expirada / token inválido | Middleware read-only: `getToken`/`decode` → `null` → trata como no logueado → redirect `/login` | e2e existente + manual |
+| Logout | `signOut` limpia cookie; middleware lee `null` → `/login` | e2e + manual |
+| Magic-link (`n/[token]`) | Sigue funcionando; si se refactoriza al helper compartido, mismo resultado | e2e/manual del magic-link |
+| Usuario OAuth/registro incompleto | `token.registroCompleto === false` → redirect `/registro/completar` (lógica intacta) | e2e existente |
+| Token de magic-link sin `roles[]` | (Aside, fuera de scope B-05) el callback `jwt` solo puebla `roles` `if (user)`; magic-link arma token mínimo. Anotar como deuda separada, no resolver acá. | — |
+
+---
+
+## 6. Criterio de aceptación
+
+- [ ] `tests/e2e/u-04-toggle-multi-rol.spec.ts` → `test('el modo activo persiste…')` **des-fixmeado** y verde **estable** (sin flaky; correr el run varias veces / mirar contador flaky).
+- [ ] Ningún e2e existente roto (auth.setup de los 4 roles + u-04 + u-09 + suite completa).
+- [ ] El middleware **no** emite `Set-Cookie` en navegaciones de página (verificable por trace/inspección de headers en una navegación autenticada).
+- [ ] (Si B) Tras `PATCH /me/active-mode`, la response trae `Set-Cookie` con el token re-firmado; el `activeMode` de la cookie coincide con la DB sin pasar por `update()`.
+- [ ] Login, logout y redirect de registro-incompleto siguen funcionando (manual + e2e).
+- [ ] Sin regresión de gating por rol (un TALLER no entra a `/marca`, etc.).
+- [ ] (Opcional, si se decide) comentario de `updateAge` corregido o `updateAge` removido.
+
+---
+
+## 7. Tests
+
+- **Aceptación (existente, des-fixmear):** u-04 "el modo activo persiste". Es la prueba canónica del fix.
+- **Regresión:** suite e2e completa vía CI (corre contra el preview/DEV). Atención al **contador de flaky** (skill playwright-e2e §5): un verde por retry no es verde.
+- **Nuevo — doble contexto / multi-tab (recomendado):** `tests/e2e/u-04-sesion-multitab.spec.ts`:
+  - Dos `browser.newContext()` (o dos páginas en el mismo context que comparten cookie jar) del mismo usuario `dual`.
+  - Contexto A togglea a Marca; contexto B (con `useSession` montado) navega; assert que B no fuerza un re-emit que pise a A. Honestidad: si compartido cookie jar, valida el clobbering real; si contexts separados, valida aislamiento.
+  - **Decisión de alcance en §8:** ¿este test entra en el PR del fix o como follow-up?
+- **Unit (si B):** test del helper `firmarSessionToken()` — round-trip `encode`/`decode` preserva `activeMode`/`roles[]` y respeta el salt = cookieName.
+
+> Recordatorio (memoria de proyecto): tests automatizados son parte del entregable del spec, no opcionales.
+
+---
+
+## 8. Decisiones que necesito de Gerardo
+
+1. **Alcance del fix:** ¿**A sola** (mínimo que des-fixmea el test, ~0.5 día), **A+B** (robusto, cierra residual de concurrencia/multi-tab, ~1 día), o **B sola** (no recomendado: no cierra el clobber de navegación)?
+2. **OPCIÓN A — sliding expiry:** ¿se acepta perder el refresh de expiry vía middleware, apoyándose en que `useSession` (header, `SessionProvider` en `providers.tsx`) refresca por `/api/auth/session`? **Necesito confirmar** que toda página autenticada monta el header (¿hay alguna ruta autenticada sin layout con header?).
+3. **OPCIÓN B — `update()` cliente:** si vamos con B, ¿se **elimina** `update({…})` en `modo-toggle.tsx`/`agregar-rol-card.tsx`, o se deja como redundancia inofensiva?
+4. **Test multi-tab:** ¿el nuevo e2e de doble-contexto entra en **este** PR o como follow-up?
+5. **`updateAge` muerto:** ¿corregimos/eliminamos el `updateAge: 24h` + su comentario engañoso (`auth.config.ts:32`) en este PR, o lo dejamos para no ampliar el diff de auth?
+6. **`getToken` vs `decode` en la beta:** si la firma de `getToken` en `next-auth@5.0.0-beta.30` no encaja con nuestras cookies custom, ¿OK con usar `decode` + lectura manual de la cookie (mismo patrón que `n/[token]`)? (Es detalle de implementación, pero toca auth — lo dejo explícito.)
+
+---
+
+## 9. Riesgos de tocar auth y cómo se cubren
+
+- **Es el core de sesión.** Un error rompe login/logout/gating para todos. Cobertura: A mantiene la lógica de gating **byte-idéntica** (solo cambia el origen de `req.auth`); la suite e2e con los 4 roles + flujos U es la red de seguridad; chequeo manual de logout y expiry.
+- **Acoplamiento a internals de Auth.js (B):** firmar el token a mano puede romperse en un upgrade de `next-auth`. Mitigado por: helper único compartido con `n/[token]` (que ya depende de `encode`), y un unit test de round-trip que falla si el formato cambia.
+- **Edge runtime:** `getToken`/`decode` deben correr en Edge (lo hacen). `auth.config.ts` sigue Edge-safe.
+- **Magic-link:** si se refactoriza `n/[token]` al helper, re-testear ese flujo (no regresión del auto-login por WhatsApp).
+- **Pérdida de sliding expiry por middleware (A):** mitigado por `useSession`/`SessionProvider`; riesgo residual si existe una página autenticada sin header (decisión #2).
+
+---
+
+## Apéndice — evidencia del discovery
+
+- Re-emisión incondicional JWT: `node_modules/next-auth/node_modules/@auth/core/lib/actions/session.js` rama `jwt` (líneas 21-64; `jwt.encode` + `response.cookies.push` sin gate de `updateAge`). `updateAge` solo en rama DB (líneas 77-92).
+- Middleware envuelve toda navegación: `src/middleware.ts` (`export default auth(...)`, matcher excluye `/api`).
+- Mutación de modo: `src/app/api/usuarios/me/active-mode/route.ts` (DB autoritativa, sin set de cookie) + `src/compartido/componentes/layout/modo-toggle.tsx:59-82` (`fetch` + `update()` + `push`/`refresh`).
+- Mutación de rol: `src/app/api/usuarios/me/roles/route.ts` + `src/compartido/componentes/agregar-rol-card.tsx:43-64`.
+- Precedente de set de cookie server-side: `src/app/n/[token]/route.ts:1-66` (`encode` de `next-auth/jwt`, `salt: cookieName`, `secret: NEXTAUTH_SECRET`, `response.cookies.set`).
+- Config de sesión: `src/compartido/lib/auth.config.ts:29-33` (`strategy jwt`, `maxAge 7d`, `updateAge 24h` — inerte), callbacks `jwt`/`session` (líneas 58-132).
+- Test de aceptación: `tests/e2e/u-04-toggle-multi-rol.spec.ts:61-82` (`test.fixme`).
+- `SessionProvider`: `src/app/providers.tsx`; `useSession` en `src/compartido/componentes/layout/header.tsx`.

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,17 @@
 ## 2026-06-10
 
 ### Gerardo Breard
+- **02:14** `2ed80d2` — fix(b-05): race de clobbering de cookie en rolling JWT session
+  - `.claude/specs/v4-b-05-fix-race-sesion.md`
+  - `src/__tests__/session-cookie.test.ts`
+  - `src/app/api/usuarios/me/active-mode/route.ts`
+  - `src/app/api/usuarios/me/roles/route.ts`
+  - `src/app/n/[token]/route.ts`
+  - `src/compartido/lib/auth.config.ts`
+  - `src/compartido/lib/session-cookie.ts`
+  - `src/middleware.ts`
+  - `tests/e2e/u-04-toggle-multi-rol.spec.ts`
+
 - **01:10** `1c0e5f1` — feat(u-05): migracion de datos multi-rol + cierre de fuente (refs D-01/D-02)
   - `.claude/specs/handover/DECISIONS.md`
   - `.claude/specs/v4-u-05-migracion-datos.md`

--- a/src/__tests__/session-cookie.test.ts
+++ b/src/__tests__/session-cookie.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+
+// B-05: helper único de cookie de sesión (encode/decode + merge del delta de modo/rol).
+// El secret se lee lazy en el helper, así que basta setearlo antes de los tests.
+beforeAll(() => {
+  process.env.NEXTAUTH_SECRET = 'test-secret-b05-deadbeefdeadbeefdeadbeef'
+})
+
+import {
+  encodeSessionToken,
+  decodeSessionToken,
+  mergeSessionDelta,
+  SESSION_COOKIE_NAME,
+} from '@/compartido/lib/session-cookie'
+
+describe('session-cookie — nombre/salt', () => {
+  it('SESSION_COOKIE_NAME coincide con el patrón de auth.config (session-token)', () => {
+    expect(SESSION_COOKIE_NAME).toContain('session-token')
+  })
+})
+
+describe('session-cookie — round-trip encode→decode', () => {
+  it('preserva el payload del token de sesión', async () => {
+    const token = {
+      id: 'u1',
+      sub: 'u1',
+      role: 'MARCA',
+      roles: ['TALLER', 'MARCA'],
+      activeMode: 'MARCA',
+      registroCompleto: true,
+    }
+    const jwe = await encodeSessionToken(token)
+    expect(typeof jwe).toBe('string')
+
+    const back = await decodeSessionToken(jwe)
+    expect(back).not.toBeNull()
+    expect(back!.id).toBe('u1')
+    expect(back!.role).toBe('MARCA')
+    expect(back!.roles).toEqual(['TALLER', 'MARCA'])
+    expect(back!.activeMode).toBe('MARCA')
+    expect(back!.registroCompleto).toBe(true)
+  })
+
+  it('decode de basura/cookie ausente → null (no throw)', async () => {
+    expect(await decodeSessionToken(undefined)).toBeNull()
+    expect(await decodeSessionToken('')).toBeNull()
+    expect(await decodeSessionToken('no-es-un-jwe-valido')).toBeNull()
+  })
+})
+
+describe('session-cookie — mergeSessionDelta (semántica del callback jwt update)', () => {
+  const base = { id: 'u1', role: 'TALLER', roles: ['TALLER'], activeMode: 'TALLER' }
+
+  it('cambia activeMode dentro de roles existentes (toggle) + invariante role==activeMode', () => {
+    const out = mergeSessionDelta(
+      { ...base, roles: ['TALLER', 'MARCA'] },
+      { activeMode: 'MARCA' },
+    )
+    expect(out.activeMode).toBe('MARCA')
+    expect(out.role).toBe('MARCA') // invariante
+    expect(out.roles).toEqual(['TALLER', 'MARCA']) // sin cambios
+  })
+
+  it('NO cambia activeMode a un rol que no se posee', () => {
+    const out = mergeSessionDelta({ ...base }, { activeMode: 'MARCA' })
+    expect(out.activeMode).toBe('TALLER') // rechazado: MARCA no está en roles
+    expect(out.role).toBe('TALLER')
+  })
+
+  it('expande roles con un rol OPERATIVO (agregar rol)', () => {
+    const out = mergeSessionDelta({ ...base }, { roles: ['MARCA'], activeMode: 'MARCA' })
+    expect(out.roles).toEqual(['TALLER', 'MARCA'])
+    expect(out.activeMode).toBe('MARCA')
+    expect(out.role).toBe('MARCA')
+  })
+
+  it('ANTI-ESCALACIÓN: un intento de sumar ADMIN/ESTADO/CONTENIDO NO pasa', () => {
+    const out = mergeSessionDelta({ ...base }, { roles: ['ADMIN'], activeMode: 'ADMIN' })
+    // ADMIN no es operativo → no se suma; activeMode ADMIN tampoco se acepta
+    expect(out.roles).toEqual(['TALLER'])
+    expect(out.activeMode).toBe('TALLER')
+    expect(out.role).toBe('TALLER')
+  })
+
+  it('ANTI-ESCALACIÓN: filtra team roles pero acepta el operativo del mismo delta', () => {
+    const out = mergeSessionDelta({ ...base }, { roles: ['ESTADO', 'MARCA'], activeMode: 'MARCA' })
+    expect(out.roles).toEqual(['TALLER', 'MARCA']) // ESTADO filtrado, MARCA sumado
+    expect(out.activeMode).toBe('MARCA')
+  })
+
+  it('preserva un team role PREEXISTENTE en el token (no lo borra al expandir)', () => {
+    // Un user que ya tenía ADMIN (asignado en login desde DB) + suma MARCA: ADMIN se conserva.
+    const out = mergeSessionDelta(
+      { id: 'u2', role: 'ADMIN', roles: ['ADMIN'], activeMode: 'ADMIN' },
+      { roles: ['MARCA'], activeMode: 'MARCA' },
+    )
+    expect(out.roles).toEqual(['ADMIN', 'MARCA'])
+    expect(out.activeMode).toBe('MARCA')
+  })
+
+  it('no muta el token de entrada', () => {
+    const input = { ...base, roles: ['TALLER'] }
+    const snapshot = JSON.stringify(input)
+    mergeSessionDelta(input, { roles: ['MARCA'], activeMode: 'MARCA' })
+    expect(JSON.stringify(input)).toBe(snapshot)
+  })
+})

--- a/src/app/api/usuarios/me/active-mode/route.ts
+++ b/src/app/api/usuarios/me/active-mode/route.ts
@@ -9,6 +9,12 @@ import {
   errorResponse,
 } from '@/compartido/lib/api-errors'
 import { rolesEfectivos } from '@/compartido/lib/roles'
+import {
+  decodeSessionToken,
+  setSessionCookie,
+  mergeSessionDelta,
+  SESSION_COOKIE_NAME,
+} from '@/compartido/lib/session-cookie'
 
 const MODOS_VALIDOS: UserRole[] = ['TALLER', 'MARCA', 'ESTADO', 'ADMIN', 'CONTENIDO']
 
@@ -51,5 +57,14 @@ export const PATCH = apiHandler(async (req: NextRequest) => {
     data: { activeMode: modoSolicitado, role: modoSolicitado },
   })
 
-  return NextResponse.json({ activeMode: modoSolicitado })
+  // B-05: setear la cookie de sesion actualizada server-side, en la MISMA response,
+  // para que el nuevo activeMode no dependa del update() client-side (que una lectura
+  // concurrente del rolling JWT podia pisar). El update() del cliente queda como
+  // redundancia (propaga al SessionProvider/broadcast multi-tab).
+  const res = NextResponse.json({ activeMode: modoSolicitado })
+  const tokenActual = await decodeSessionToken(req.cookies.get(SESSION_COOKIE_NAME)?.value)
+  if (tokenActual) {
+    await setSessionCookie(res, mergeSessionDelta(tokenActual, { activeMode: modoSolicitado }))
+  }
+  return res
 })

--- a/src/app/api/usuarios/me/roles/route.ts
+++ b/src/app/api/usuarios/me/roles/route.ts
@@ -10,6 +10,12 @@ import {
   errorResponse,
 } from '@/compartido/lib/api-errors'
 import { rolesEfectivos } from '@/compartido/lib/roles'
+import {
+  decodeSessionToken,
+  setSessionCookie,
+  mergeSessionDelta,
+  SESSION_COOKIE_NAME,
+} from '@/compartido/lib/session-cookie'
 import { crearEntidadParaRol } from '@/compartido/lib/crear-entidad-rol'
 import {
   consultarPadron,
@@ -135,5 +141,14 @@ export const POST = apiHandler(async (req: NextRequest) => {
 
   logActividad('ROL_AGREGADO', user.id, { rol, entidadId: entidad.id })
 
-  return NextResponse.json({ rol, entidadId: entidad.id, roles: nuevosRoles, activeMode: rol })
+  // B-05: setear la cookie de sesion expandida server-side, en la MISMA response.
+  // Asi el roles[] nuevo + activeMode viajan en la cookie sin depender del update()
+  // client-side (que una lectura concurrente del rolling JWT podia pisar, dejando el
+  // JWT en single-rol y mandando a /unauthorized). El update() cliente queda redundante.
+  const res = NextResponse.json({ rol, entidadId: entidad.id, roles: nuevosRoles, activeMode: rol })
+  const tokenActual = await decodeSessionToken(req.cookies.get(SESSION_COOKIE_NAME)?.value)
+  if (tokenActual) {
+    await setSessionCookie(res, mergeSessionDelta(tokenActual, { roles: [rol], activeMode: rol }))
+  }
+  return res
 })

--- a/src/app/n/[token]/route.ts
+++ b/src/app/n/[token]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
-import { encode } from 'next-auth/jwt'
+import { setSessionCookie } from '@/compartido/lib/session-cookie'
 
 export async function GET(
   req: NextRequest,
@@ -32,37 +32,17 @@ export async function GET(
     data: { usadoEn: new Date() },
   })
 
-  // Nombre de cookie segun ambiente (debe coincidir con auth.config.ts)
-  const isProduction = process.env.NODE_ENV === 'production'
-  const cookieName = isProduction
-    ? '__Secure-authjs.session-token'
-    : 'authjs.session-token'
-
-  // Crear sesion NextAuth manualmente
-  // El salt DEBE coincidir con el nombre de la cookie para que decode() funcione
-  const sessionToken = await encode({
-    token: {
-      sub: magicLink.user.id,
-      email: magicLink.user.email,
-      name: magicLink.user.name,
-      role: (magicLink.user as { role?: string }).role,
-      id: magicLink.user.id,
-      registroCompleto: (magicLink.user as { registroCompleto?: boolean }).registroCompleto ?? true,
-    },
-    secret: process.env.NEXTAUTH_SECRET!,
-    salt: cookieName,
-  })
-
-  // Setear cookie de sesion y redirigir al destino
+  // Crear sesion NextAuth manualmente y setear la cookie via el helper unico
+  // (mismo encode + salt = nombre de cookie que usa el login normal). Ver
+  // session-cookie.ts.
   const response = NextResponse.redirect(new URL(magicLink.destino, req.url))
-  response.cookies.set({
-    name: cookieName,
-    value: sessionToken,
-    httpOnly: true,
-    secure: isProduction,
-    sameSite: 'lax',
-    path: '/',
-    maxAge: 7 * 24 * 60 * 60, // 7 dias (igual que sesion normal)
+  await setSessionCookie(response, {
+    sub: magicLink.user.id,
+    email: magicLink.user.email,
+    name: magicLink.user.name,
+    role: (magicLink.user as { role?: string }).role,
+    id: magicLink.user.id,
+    registroCompleto: (magicLink.user as { registroCompleto?: boolean }).registroCompleto ?? true,
   })
 
   return response

--- a/src/compartido/lib/auth.config.ts
+++ b/src/compartido/lib/auth.config.ts
@@ -29,7 +29,11 @@ export default {
   session: {
     strategy: 'jwt',
     maxAge: 7 * 24 * 60 * 60,   // 7 dias
-    updateAge: 24 * 60 * 60,     // renueva cada 24h si hay actividad
+    // NOTA (B-05): bajo strategy 'jwt', Auth.js v5 re-firma y re-emite la cookie en
+    // CADA lectura de sesion (sliding window) e IGNORA updateAge — updateAge solo se
+    // respeta en la estrategia database-session (throttle de writes a DB). Queda aca
+    // como no-op documentado por si se migra a database-session en el futuro.
+    updateAge: 24 * 60 * 60,
   },
   cookies: {
     sessionToken: {

--- a/src/compartido/lib/session-cookie.ts
+++ b/src/compartido/lib/session-cookie.ts
@@ -1,0 +1,130 @@
+// Helper ÚNICO para leer/firmar/setear la cookie de sesión JWT de Auth.js v5.
+//
+// Por qué existe (B-05): bajo `strategy: 'jwt'`, Auth.js v5 re-firma y re-emite la
+// cookie en CADA lectura de sesión (el middleware era el escritor dominante). Una
+// navegación que transportaba la cookie vieja podía pisar una actualización
+// concurrente de `update()` (last-write-wins en el cookie jar) → el usuario quedaba
+// en el modo viejo hasta re-login. El fix mueve la escritura autoritativa al
+// servidor: los endpoints de mutación (active-mode, me/roles) setean la cookie ya
+// actualizada en la MISMA response, y el middleware pasa a leer sin re-emitir.
+//
+// Este módulo centraliza el patrón que antes vivía inline en `app/n/[token]/route.ts`
+// (encode + Set-Cookie) para que haya UNA sola implementación del firmado de cookie
+// en todo el repo. Es Edge-safe (encode/decode de next-auth/jwt usan jose) → lo puede
+// importar tanto el middleware (Edge) como las route handlers (Node).
+
+import { encode, decode } from 'next-auth/jwt'
+import type { UserRole } from '@prisma/client'
+
+const isProduction = process.env.NODE_ENV === 'production'
+
+// DEBE coincidir con `cookies.sessionToken.name` de auth.config.ts. Auth.js v5 usa
+// el nombre de la cookie como `salt` del cifrado (ver @auth/core session.js), así que
+// este valor es a la vez el nombre de la cookie y el salt de encode/decode.
+export const SESSION_COOKIE_NAME = isProduction
+  ? '__Secure-authjs.session-token'
+  : 'authjs.session-token'
+
+// 7 días: igual que `session.maxAge` de auth.config.ts.
+const SESSION_MAX_AGE = 7 * 24 * 60 * 60
+
+// Roles que un usuario puede auto-asignarse vía cambio de sesión. Los de equipo
+// (ADMIN/ESTADO/CONTENIDO) NUNCA se suman desde un delta → anti-escalación.
+const ROLES_OPERATIVOS = ['TALLER', 'MARCA']
+
+function secret(): string {
+  return process.env.NEXTAUTH_SECRET as string
+}
+
+// Payload del token de sesión (lo que setea el callback jwt de auth.config.ts).
+export interface SessionTokenPayload {
+  [key: string]: unknown
+  id?: string
+  role?: string | null
+  roles?: string[] | null
+  activeMode?: string | null
+  registroCompleto?: boolean
+}
+
+// Delta autoritativo (ya confirmado en DB por el endpoint) a aplicar sobre el token.
+export interface CambioSesion {
+  activeMode?: string | null
+  /** Roles a SUMAR (union). Los no-operativos se filtran (anti-escalación). */
+  roles?: string[] | null
+}
+
+/** encode del token con el salt/secret/maxAge correctos. */
+export async function encodeSessionToken(token: SessionTokenPayload): Promise<string> {
+  return encode({ token, salt: SESSION_COOKIE_NAME, secret: secret(), maxAge: SESSION_MAX_AGE })
+}
+
+/** decode read-only de una cookie de sesión. Devuelve null si falta o es inválida. */
+export async function decodeSessionToken(
+  raw: string | undefined | null,
+): Promise<SessionTokenPayload | null> {
+  if (!raw) return null
+  try {
+    return (await decode({ token: raw, salt: SESSION_COOKIE_NAME, secret: secret() })) as
+      | SessionTokenPayload
+      | null
+  } catch {
+    // Token expirado / secret rotado / corrupto → tratar como no logueado.
+    return null
+  }
+}
+
+/**
+ * Construye el token nuevo desde el token ACTUAL + el delta confirmado en DB.
+ * MISMA semántica que la rama `trigger === 'update'` del callback jwt de
+ * auth.config.ts (incluido el filtro anti-escalación): los roles solo se EXPANDEN
+ * con roles operativos; el activeMode solo se acepta si pertenece a los roles
+ * resultantes; se preserva la invariante role == activeMode.
+ */
+export function mergeSessionDelta(
+  token: SessionTokenPayload,
+  delta: CambioSesion,
+): SessionTokenPayload {
+  const out: SessionTokenPayload = { ...token }
+
+  if (Array.isArray(delta.roles)) {
+    const previos = Array.isArray(out.roles) ? out.roles : []
+    out.roles = Array.from(
+      new Set([...previos, ...delta.roles.filter((r) => ROLES_OPERATIVOS.includes(r))]),
+    )
+  }
+
+  const nuevo = delta.activeMode
+  const rolesActuales = Array.isArray(out.roles) ? out.roles : []
+  if (nuevo && rolesActuales.includes(nuevo)) {
+    out.activeMode = nuevo
+    out.role = nuevo // invariante role == activeMode (back-compat U-03)
+  }
+
+  return out
+}
+
+const SESSION_COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: isProduction,
+  sameSite: 'lax' as const,
+  path: '/',
+  maxAge: SESSION_MAX_AGE,
+}
+
+// Tipo mínimo: cualquier respuesta con un cookie store estilo NextResponse.
+interface ConCookies {
+  cookies: { set: (opts: { name: string; value: string } & typeof SESSION_COOKIE_OPTIONS) => unknown }
+}
+
+/** Firma `token` y lo setea como cookie de sesión en `res` (mismo response). */
+export async function setSessionCookie<T extends ConCookies>(
+  res: T,
+  token: SessionTokenPayload,
+): Promise<T> {
+  const value = await encodeSessionToken(token)
+  res.cookies.set({ name: SESSION_COOKIE_NAME, value, ...SESSION_COOKIE_OPTIONS })
+  return res
+}
+
+// Re-export para callers que quieran el tipo de rol fuerte sin reimportar.
+export type { UserRole }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,15 +1,26 @@
-import NextAuth from 'next-auth'
-import { NextResponse } from 'next/server'
-import authConfig from '@/compartido/lib/auth.config'
+import { NextResponse, type NextRequest } from 'next/server'
 import { tieneAlgunRol, modoActivo, type FuenteRoles } from '@/compartido/lib/roles'
+import { decodeSessionToken, SESSION_COOKIE_NAME } from '@/compartido/lib/session-cookie'
 
-const { auth } = NextAuth(authConfig)
-
-export default auth((req) => {
+// B-05: el middleware lee el JWT READ-ONLY (decode), sin re-emitir Set-Cookie.
+// Antes envolvía con el wrapper `auth()`, que bajo strategy jwt re-firma y re-emite
+// la cookie en CADA navegación → una navegación con la cookie vieja pisaba la
+// actualización concurrente de un cambio de modo/rol (last-write-wins en el jar).
+// Ahora la escritura autoritativa de la cookie la hacen los endpoints server-side
+// (active-mode, me/roles); acá SOLO leemos. El sliding-expiry queda a cargo del
+// useSession (SessionProvider en el root layout + Header/FeedbackWidget global). El
+// gating es BYTE-IDÉNTICO al anterior: solo cambia de dónde sale la identidad.
+export default async function middleware(req: NextRequest) {
   const { nextUrl } = req
-  const isLoggedIn = !!req.auth
+
+  // Lectura pura del token desde la cookie. Edge-safe (decode usa jose). null si
+  // falta/expiró/es inválido → se trata como no logueado (igual que antes).
+  const token = await decodeSessionToken(req.cookies.get(SESSION_COOKIE_NAME)?.value)
+  const isLoggedIn = !!token
   // U-03: gating por MEMBRESÍA en roles[] (decisión D1/A), no por el escalar.
-  const sessionUser = req.auth?.user as FuenteRoles | undefined
+  const sessionUser = (token
+    ? { role: token.role, roles: token.roles, activeMode: token.activeMode }
+    : undefined) as FuenteRoles | undefined
 
   // Rutas públicas que no requieren autenticación
   const publicRoutes = [
@@ -68,7 +79,7 @@ export default auth((req) => {
 
   // Usuarios con registro incompleto (OAuth/magic link sin completar)
   const pathname = nextUrl.pathname
-  const registroCompleto = (req.auth?.user as { registroCompleto?: boolean })?.registroCompleto
+  const registroCompleto = (token as { registroCompleto?: boolean } | null)?.registroCompleto
   if (isLoggedIn && registroCompleto === false) {
     if (pathname === '/registro/completar' || pathname.startsWith('/api/')) {
       return NextResponse.next()
@@ -149,7 +160,7 @@ export default auth((req) => {
   }
 
   return NextResponse.next()
-})
+}
 
 export const config = {
   matcher: [

--- a/tests/e2e/u-04-toggle-multi-rol.spec.ts
+++ b/tests/e2e/u-04-toggle-multi-rol.spec.ts
@@ -58,17 +58,12 @@ test('cambiar a Marca redirige a /marca; volver a Taller redirige a /taller', as
   await expect(page).toHaveURL(/\/taller/)
 })
 
-// BLOQUEADO POR B-05 (clobbering de cookie en rolling JWT). El flujo es legítimo
-// —multi-rol cambia a Marca y navega a /— pero la cookie de sesión puede quedar
-// pisada en activeMode=TALLER aunque la DB tenga MARCA: una lectura de sesión
-// concurrente (rolling JWT re-emite Set-Cookie en cada GET) sobrescribe la cookie
-// actualizada con el estado previo. El hard-nav lee la cookie pisada → cae en
-// /taller. Determinístico 3/3 en CI (ver DEUDA_TECNICA.md B-05). page.tsx redirige
-// por el activeMode de la COOKIE, no de la DB, así que re-navegar NO recupera.
-// Des-fixmear cuando B-05 se arregle (spec propio: rediseño de sesión / no re-emitir
-// Set-Cookie en lecturas planas / set de cookie server-side). ESTE test es la
-// validación del fix de B-05.
-test.fixme('el modo activo persiste: tras cambiar a Marca, ir a / redirige a /marca', async ({ page }) => {
+// FIX B-05 (PR fix(b-05)): el clobbering de cookie en rolling JWT está resuelto.
+// El middleware ahora lee el JWT read-only (no re-emite Set-Cookie en cada nav) y los
+// endpoints de modo/rol setean la cookie actualizada server-side en la misma response,
+// así que ninguna lectura concurrente la pisa. ESTE test es la validación del fix:
+// cambiar a Marca y hard-navegar a / debe redirigir a /marca (la cookie refleja la DB).
+test('el modo activo persiste: tras cambiar a Marca, ir a / redirige a /marca', async ({ page }) => {
   await ensureNotProduction(page)
   await loginAs(page, 'dual')
 
@@ -79,6 +74,38 @@ test.fixme('el modo activo persiste: tras cambiar a Marca, ir a / redirige a /ma
   // El middleware redirige la raíz al dashboard del activeMode persistido en DB.
   await page.goto('/')
   await expect(page).toHaveURL(/\/marca/)
+})
+
+// FIX B-05 — validación MULTI-TAB (decisión 4). Dos pestañas comparten el cookie jar.
+// Tab 1 cambia a Marca; tab 2 venía con la sesión montada haciendo lecturas/navegación
+// (la presión concurrente que ANTES pisaba la cookie: el middleware re-emitía el token
+// viejo en cada nav). Con el middleware read-only + cookie server-side, la cookie
+// compartida refleja MARCA y ninguna lectura de tab 2 la revierte. SERIAL + mismo
+// afterEach de reset(julieta) que el resto del archivo.
+test('multi-tab: cambiar a Marca en una pestaña persiste pese a lecturas de otra', async ({ page }) => {
+  await ensureNotProduction(page)
+  await loginAs(page, 'dual')
+  await expect(page).toHaveURL(/\/taller/)
+
+  // Tab 2: misma sesión (cookie jar compartido). Monta la app y navega → lecturas.
+  const tab2 = await page.context().newPage()
+  await tab2.goto('/taller')
+  await expect(tab2).toHaveURL(/\/taller/)
+
+  // Tab 1: cambiar a Marca. La cookie se setea server-side en la response del toggle.
+  await abrirMenuUsuario(page)
+  await page.getByTestId('modo-toggle-option-MARCA').click()
+  await expect(page).toHaveURL(/\/marca/)
+
+  // Tab 2: hard-nav a / — la cookie compartida ya refleja MARCA → cae en /marca.
+  await tab2.goto('/')
+  await expect(tab2).toHaveURL(/\/marca/)
+
+  // Tab 1: hard-nav a / — persiste en /marca (no fue pisada por las lecturas de tab 2).
+  await page.goto('/')
+  await expect(page).toHaveURL(/\/marca/)
+
+  await tab2.close()
 })
 
 test('single-role NO ve el toggle de modo', async ({ page }) => {


### PR DESCRIPTION
Fix A+B del race **B-05** (clobbering de cookie en rolling JWT) según `.claude/specs/v4-b-05-fix-race-sesion.md` + las 6 decisiones cerradas de Gerardo.

## Causa raíz (discovery, verificado en `@auth/core`)
Bajo `strategy: 'jwt'`, Auth.js v5 re-firma y re-emite la cookie en **cada** lectura de sesión (`updateAge` es inerte para jwt). El middleware era el escritor dominante: cada navegación re-emitía el token que su request transportó → pisaba la actualización concurrente de `update()` (last-write-wins en el cookie jar). Un multi-rol que cambiaba de modo y navegaba podía quedar en el modo viejo hasta re-login.

## Fix
- **A — middleware read-only:** lee el JWT con `decode` (sin re-emitir Set-Cookie). Gating **byte-idéntico**; solo cambia de dónde sale la identidad. Sliding-expiry queda a cargo del `useSession` (verificado: toda ruta autenticada lo monta vía `SessionProvider` global + `FeedbackWidget` + `Header`).
- **B — cookie server-side:** `active-mode` y `me/roles` setean la cookie actualizada en la **misma** response, vía helper único `session-cookie.ts` (reusado por `n/[token]`, mismo filtro anti-escalación que el callback jwt). El `update()` cliente queda redundante (broadcast multi-tab); su remoción es follow-up.
- **C —** corregido el comentario engañoso de `updateAge` en `auth.config.ts`.

## Tests
- Des-fixmeado `u-04 'el modo activo persiste'` (criterio de éxito de B-05).
- Nuevo test **multi-tab** (validación de B).
- Unit test del helper (round-trip encode→decode + anti-escalación `roles=[ADMIN]` no pasa).

## AUTH — requiere smoke manual post-merge
Es código de sesión. Verificar tras merge: login/logout de los 4 roles, toggle de modo persiste, agregar rol, magic-link (`n/[token]`), expiración.

🤖 Generated with [Claude Code](https://claude.com/claude-code)