### PR TITLE
fix(niveles): cierre Nivel 5 - fuga F-1 + skill

### DIFF
--- a/.claude/skills/niveles-formalizacion/SKILL.md
+++ b/.claude/skills/niveles-formalizacion/SKILL.md
@@ -2,6 +2,35 @@
 
 Reglas de negocio para los niveles de formalizacion de talleres textiles en la Plataforma Digital Textil.
 
+> ## ⚠️ REGLA DE PRESENTACION (leer antes de tocar cualquier UI)
+>
+> Los niveles **BRONCE / PLATA / ORO son INTERNOS** — solo viven en la DB, en la
+> logica de recalculo y en las vistas de **ESTADO / ADMIN / OIT** (analitica).
+>
+> **NUNCA se muestran los nombres crudos del enum al TALLER ni a la MARCA.** Al
+> usuario se le muestra siempre la **etapa** via el helper
+> `nivelAEtapa()` (`src/compartido/lib/formalizacion.ts`):
+>
+> | Nivel interno (DB) | Etapa visible al usuario |
+> |---|---|
+> | `BRONCE` | **Etapa inicial** |
+> | `PLATA`  | **En proceso de formalización** |
+> | `ORO`    | **Formalización consolidada** |
+>
+> - **Sin badges de medallas** (bronce/plata/oro) al usuario. Sin lenguaje de
+>   ranking ("subí de nivel", "ganá puntos", "sin verificar").
+> - La formalizacion es un **recorrido / acompañamiento**, no un ranking — los
+>   requisitos son logros, no obligaciones (master 3.7).
+> - Cualquier render directo de `taller.nivel`, `nivelAnterior`, `nivelNuevo` (o
+>   los strings `BRONCE`/`PLATA`/`ORO`) en una superficie de TALLER o MARCA = **fuga**.
+>   Envolver con `nivelAEtapa()`.
+> - **Fuente:** master V4 decisiones **3.7-3.10**, Narrativa V4
+>   (`narrativa-V4-consolidado-niveles-1-a-4.md`), discovery
+>   `.claude/specs/v4-x-07-08-09-discovery.md` (cierre niveles, F-1).
+>
+> Las **condiciones de cada nivel y el recalculo** (abajo) siguen siendo logica
+> interna valida — eso NO cambia. Lo que cambia es **como se presenta**.
+
 ## Niveles
 
 ### BRONCE
@@ -17,7 +46,7 @@ Requisitos minimos para operar en la plataforma.
   - Responsable/titular
   - Al menos 1 proceso productivo declarado
 
-**Permisos:** puede recibir pedidos basicos, aparecer en directorio con badge "Bronce"
+**Permisos:** puede recibir pedidos basicos, aparecer en directorio (etapa visible: "Etapa inicial", sin badge de medalla)
 
 ### PLATA
 
@@ -29,7 +58,7 @@ Nivel intermedio que demuestra cumplimiento laboral y capacitacion.
 - Al menos 1 capacitacion completada (tabla `ProgresoCapacitacion` con `completado: true` para algun video/coleccion)
 - Sin denuncias abiertas con estado `PENDIENTE` o `EN_INVESTIGACION`
 
-**Permisos:** puede recibir pedidos de marcas verificadas, prioridad en directorio, badge "Plata"
+**Permisos:** puede recibir pedidos de marcas verificadas, prioridad en directorio (etapa visible: "En proceso de formalización", sin badge de medalla)
 
 ### ORO
 
@@ -46,7 +75,7 @@ Nivel maximo de formalizacion y calidad.
   - Certificacion vinculada a un `Certificado` valido (no vencido)
 - Evaluacion positiva: promedio >= 4.0 en tabla `Evaluacion`
 
-**Permisos:** acceso completo, puede participar en licitaciones, badge "Oro", destacado en directorio
+**Permisos:** acceso completo, puede participar en licitaciones, destacado en directorio (etapa visible: "Formalización consolidada", sin badge de medalla)
 
 ## Recalculo del nivel
 
@@ -85,28 +114,41 @@ funcion recalcularNivel(tallerId):
 - Cada cambio de nivel se registra en `LogActividad` con tipo `CAMBIO_NIVEL`
 - Se envia `Notificacion` al taller cuando cambia su nivel
 
-## Visualizacion en perfil
+## Visualizacion (post-narrativa V4 — leer la regla de presentacion de arriba)
 
-### Badge en el perfil del taller
+> **CAMBIO vs version anterior de esta skill:** antes esta seccion instruia mostrar
+> badges de medalla `bronze/silver/gold` al usuario en perfil/directorio/dashboard.
+> Eso quedo **OBSOLETO** por master 3.7/3.8 y Narrativa V4: al TALLER/MARCA se le
+> muestra siempre la **etapa** (via `nivelAEtapa()`), nunca el nivel crudo ni una medalla.
 
-- Mostrar en `src/app/(public)/perfil/[id]/page.tsx` y `src/app/(taller)/taller/perfil/page.tsx`
-- Usar componente `Badge` con variantes:
-  - BRONCE: `variant="bronze"` (color ambar/bronce)
-  - PLATA: `variant="silver"` (color gris plata)
-  - ORO: `variant="gold"` (color dorado)
-- Mostrar junto al nombre del taller en el directorio (`src/app/(public)/directorio/page.tsx`)
+### Superficies de TALLER / MARCA / PUBLICO (etapa, NO nivel)
 
-### Progreso hacia el siguiente nivel
+- `src/app/(taller)/taller/page.tsx` (dashboard), `taller/formalizacion/page.tsx`
+  (Mi recorrido), `src/app/(public)/perfil/[id]/page.tsx`, directorio publico y
+  vidriera: **siempre `nivelAEtapa(taller.nivel)`**, nunca el enum.
+- El historial de cambios que se muestra al taller usa
+  `nivelAEtapa(nivelAnterior) → nivelAEtapa(nivelNuevo)` (heading "Historial de tu
+  recorrido", **no** "Historial de nivel"). Ver F-1 del discovery.
+- **Sin** componente `Badge` con variantes `bronze/silver/gold` orientado al usuario.
+  Sin "X de 7 requisitos" en el directorio **publico** (eso queda solo privado, en
+  Mi recorrido — narrativa 3.10, resuelto en #403).
 
-En la vista del taller (`/taller/dashboard`), mostrar:
-- Nivel actual con badge
-- Lista de requisitos del siguiente nivel con checkmarks (cumplido/pendiente)
-- Porcentaje de progreso hacia el siguiente nivel
-- Acciones sugeridas para avanzar (ej: "Completa una capacitacion para alcanzar nivel Plata")
+### Progreso del recorrido (vista del taller)
 
-### En el panel admin
+En el dashboard del taller (`/taller`) y en Mi recorrido (`/taller/formalizacion`):
+- **Etapa actual** (texto via `nivelAEtapa`), nunca el nombre del nivel ni medalla.
+- Lista de requisitos del siguiente tramo con checkmarks (cumplido/pendiente).
+- Porcentaje de progreso (`ProgressRing`).
+- Acciones sugeridas para avanzar, en lenguaje de acompañamiento (ej:
+  "Completá una capacitación para seguir avanzando"), **sin** "subí de nivel a Plata".
 
-En `/admin/talleres/[id]`:
-- Nivel actual e historial de cambios de nivel
-- Boton para forzar recalculo manual
-- Boton para override de nivel (con justificacion obligatoria registrada en log)
+### Vistas internas de ESTADO / ADMIN / OIT (nivel permitido para analitica)
+
+En `/admin/talleres/[id]`, `/estado/talleres`, reportes, configuracion-niveles:
+- Estas son vistas de **staff/analitica**, no de usuario → pueden operar sobre los
+  niveles internos. Aun asi las pantallas ya migradas muestran las **etiquetas de
+  etapa** ("Etapa inicial / En proceso / Consolidada") para consistencia; el enum
+  crudo queda como `value=` de filtros y logica, no como texto visible al staff salvo
+  analitica explicita.
+- Recalculo manual, override de nivel (con justificacion registrada en `LogActividad`)
+  e historial de cambios: sin cambios — siguen siendo herramientas internas.

--- a/.claude/specs/v4-x-07-08-09-discovery.md
+++ b/.claude/specs/v4-x-07-08-09-discovery.md
@@ -1,7 +1,7 @@
 # DISCOVERY — Nivel 5 / X-07·X-08·X-09 (aplicación visual a dashboards, listados, detalle + Mi Formalización)
 
 > **Tipo:** discovery + reconciliación master ↔ narrativa V4. **NO implementa.**
-> **Fecha:** 2026-06-08 · **Autor:** Gerardo (vía Claude) · **Estado:** **CERRADO** — 5 decisiones de scope tomadas (§9). Trabajo restante definido.
+> **Fecha:** 2026-06-08 · **Autor:** Gerardo (vía Claude) · **Estado:** **EJECUTADO** — 5 decisiones de scope tomadas (§9) + cierre niveles implementado (§11). **Nivel 5 (X-07/X-09) archivado como cumplido.**
 > **Fuente autoritativa:** en copy/narrativa/formalización manda la **Narrativa V4** (`narrativa-V4-consolidado-niveles-1-a-4.md`). El **master** (`docs/Diseño/MASTER_V4.md-v2.pdf`, mayo 2026) manda en el **patrón visual** (paleta, componentes, tipografía) que la narrativa no toca.
 
 ---
@@ -177,3 +177,31 @@ Ver el resumen ejecutable en "Decisiones cerradas" (arriba). El próximo entrega
 ---
 
 **Fin del discovery.** No se tocó código ni schema. Decisiones §9 **cerradas**. Próximos entregables: (1) spec **"cierre niveles"** (F-1 + skill `niveles-formalizacion`, ~2h); (2) **§1.4** vitrina info marca (spec narrativa propio); (3) **F-04** cosmético en backlog post-piloto.
+
+---
+
+## 11. Cierre niveles — EJECUTADO (2026-06-11)
+
+Implementado en `fix/cierre-niveles-f1` (scope: SOLO F-1 + skill stale, según decisiones §9.2 y §9.5).
+
+- ✅ **F-1 arreglada:** `(taller)/taller/page.tsx`, bloque "Historial de nivel" → renombrado a
+  **"Historial de tu recorrido"**; `{nivelAnterior} → {nivelNuevo}` ahora envuelve ambos extremos con
+  **`nivelAEtapa()`**. El taller ya no ve "BRONCE → PLATA" crudo.
+- ✅ **Barrido de seguridad** (`grep BRONCE|PLATA|ORO` en `src/app` + componentes): **única fuga
+  user-facing era F-1.** El resto son: lógica interna (`taller.nivel ?? 'BRONCE'` → `nivelAEtapa`),
+  `value=` de filtros, vistas de ESTADO/ADMIN (analítica, decisión 3.8) y el propio helper. La vista de
+  detalle de ADMIN (`admin/talleres/[id]`) muestra el enum crudo en su log de actividad interna — es
+  **staff/analítica, no usuario**, por eso queda fuera del scope de F-1 (anotable como pulido interno).
+- ✅ **Skill `niveles-formalizacion` actualizada** (deuda C / decisión §9.5): banner de regla de
+  presentación arriba (niveles = internos; al usuario siempre etapa vía `nivelAEtapa`; sin badges de
+  medalla; sin lenguaje de ranking) + sección "Visualización" reescrita (antes instruía badges
+  bronze/silver/gold al usuario). Referencia a master 3.7-3.10 y Narrativa V4.
+- ✅ **Test de regresión:** `tests/e2e/cierre-niveles-f1.spec.ts` — el dashboard del taller no expone
+  `\b(BRONCE|PLATA|ORO)\b`. Seed: a `tallerOro` (Carlos Mendoza) se le añadió un 2º paso de recorrido
+  (BRONCE→PLATA→ORO) para que renderice el bloque "Historial de tu recorrido" (requiere `length > 1`) y
+  el test cubra la superficie exacta de F-1.
+
+**F-2 (prop muerta `userLevel` en `(taller)/layout.tsx` → `UserSidebar`):** sin fuga visible (no se
+renderiza). Fuera del scope acordado (SOLO F-1) → se deja como está. **X-07b cosmético = F-04 backlog.**
+**§1.4 vitrina info marca = spec narrativa propio.** Con esto **X-07/X-09 del master quedan archivados
+como cumplidos**; X-08 cubierto por §1.4.

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1228,6 +1228,11 @@ async function main() {
   await prisma.logActividad.createMany({
     data: [
       { userId: admin.id, accion: 'NIVEL_SUBIDO', detalles: { tallerId: tallerPlata.id, nivelAnterior: 'BRONCE', nivelNuevo: 'PLATA', taller: 'Cooperativa Hilos del Sur' } },
+      // tallerOro tiene DOS pasos de recorrido (BRONCE→PLATA→ORO) para que el dashboard
+      // renderice el bloque "Historial de tu recorrido" (requiere length > 1). Esto da
+      // cobertura real al test de regresión F-1 (cierre-niveles): que ese historial
+      // muestre etapas vía nivelAEtapa(), nunca el enum crudo BRONCE/PLATA/ORO.
+      { userId: admin.id, accion: 'NIVEL_SUBIDO', detalles: { tallerId: tallerOro.id, nivelAnterior: 'BRONCE', nivelNuevo: 'PLATA', taller: 'Corte Sur SRL' } },
       { userId: admin.id, accion: 'NIVEL_SUBIDO', detalles: { tallerId: tallerOro.id, nivelAnterior: 'PLATA', nivelNuevo: 'ORO', taller: 'Corte Sur SRL' } },
       { userId: admin.id, accion: 'VALIDACION_RECHAZADA', detalles: { taller: 'Taller La Aguja', tipo: 'Habilitacion municipal', motivo: 'Documento ilegible' } },
       { userId: admin.id, accion: 'DENUNCIA_RECIBIDA', detalles: { codigo: `DEN-2026-${String(denunciaCount + 1).padStart(5, '0')}`, tipo: 'Trabajo no registrado' } },
@@ -1239,7 +1244,7 @@ async function main() {
     data: { tallerId: tallerBronce.id, coleccionId: col3.id, porcentajeCompletado: 33, videosVistos: 1 },
   })
 
-  console.log('  ✓ 4 logs adicionales + progreso bronce')
+  console.log('  ✓ 5 logs adicionales + progreso bronce')
 
   // ============================================
   // NOVEDADES (contenido público para carrusel landing)

--- a/src/app/(taller)/taller/page.tsx
+++ b/src/app/(taller)/taller/page.tsx
@@ -292,10 +292,10 @@ export default async function TallerDashboardPage() {
         </div>
       </div>
 
-      {/* Historial de nivel */}
+      {/* Historial de tu recorrido (F-1: etapas, no niveles crudos) */}
       {historialNiveles.length > 1 && (
         <div className="bg-white rounded-card border border-gray-100 p-6">
-          <h2 className="font-serif font-bold text-gray-800 mb-4">Historial de nivel</h2>
+          <h2 className="font-serif font-bold text-gray-800 mb-4">Historial de tu recorrido</h2>
           <div className="space-y-2">
             {historialNiveles.map(log => {
               const detalles = log.detalles as { nivelAnterior?: string; nivelNuevo?: string }
@@ -310,7 +310,7 @@ export default async function TallerDashboardPage() {
                       {subio ? '↑' : '↓'}
                     </span>
                     <span className="text-gray-600">
-                      {detalles.nivelAnterior} → {detalles.nivelNuevo}
+                      {nivelAEtapa(detalles.nivelAnterior ?? 'BRONCE')} → {nivelAEtapa(detalles.nivelNuevo ?? 'BRONCE')}
                     </span>
                   </div>
                   <span className="text-gray-400 text-xs">

--- a/tests/e2e/cierre-niveles-f1.spec.ts
+++ b/tests/e2e/cierre-niveles-f1.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test'
+import { ensureNotProduction } from './_helpers/safety'
+import { loginAs } from './_helpers/auth-multirol'
+
+// CIERRE NIVELES — regresión de la fuga F-1.
+// Decisión 3.7/3.8 del master + Narrativa V4: los niveles internos BRONCE/PLATA/ORO
+// NUNCA se muestran crudos al TALLER — al usuario se le muestra la ETAPA vía
+// nivelAEtapa() (Etapa inicial / En proceso de formalización / Formalización
+// consolidada). F-1 era el bloque "Historial de nivel" del dashboard, que renderizaba
+// "BRONCE → PLATA" crudo. Ver .claude/specs/v4-x-07-08-09-discovery.md.
+//
+// Red de regresión: el dashboard del taller NO debe exponer los strings del enum.
+// Usamos taller_oro (Carlos Mendoza / Corte Sur SRL): el seed le da DOS pasos de
+// recorrido (BRONCE→PLATA→ORO), así que su dashboard renderiza el bloque
+// "Historial de tu recorrido" (requiere length > 1) — la superficie exacta de F-1.
+test('el dashboard del taller no expone los niveles crudos BRONCE/PLATA/ORO', async ({ page }) => {
+  await ensureNotProduction(page)
+  await loginAs(page, 'taller_oro')
+  await expect(page).toHaveURL(/\/taller/)
+
+  const main = page.locator('main')
+
+  // Las etapas (lenguaje de usuario) SÍ están presentes: confirma que la página
+  // de formalización cargó y que el copy es el correcto.
+  await expect(main).toContainText('Formalización consolidada')
+
+  // Ningún nombre crudo del enum debe ser visible en la superficie del taller
+  // (ni en el subtítulo, ni en el banner de cambio, ni en el "Historial de tu recorrido").
+  // Word-boundary + mayúsculas exactas: evita falsos positivos como "Plataforma"
+  // (no es \bPLATA\b) o palabras con "oro" en minúscula.
+  await expect(main).not.toContainText(/\b(BRONCE|PLATA|ORO)\b/)
+})


### PR DESCRIPTION
## Cierre niveles (X-07/08/09) — fuga F-1 + skill stale

Cierra el trabajo restante del Nivel 5 del master, re-scopeado en el discovery #406 (el 85-90% ya estaba hecho por #347/#358/#403). Scope acordado: **SOLO F-1 + skill stale** (decisiones §9.2 y §9.5).

### Cambios
- **F-1:** `(taller)/taller/page.tsx`, bloque "Historial de nivel" mostraba `BRONCE → PLATA` crudo al taller (viola 3.8). Ahora usa `nivelAEtapa()` en ambos extremos; heading → "Historial de tu recorrido".
- **Barrido de seguridad** (`grep BRONCE|PLATA|ORO` en `src/app` + componentes): F-1 era la única fuga user-facing. El log de actividad de `admin/talleres/[id]` muestra el enum crudo pero es **staff/analítica** (no usuario) → fuera de scope.
- **Skill `niveles-formalizacion`** actualizada: niveles = internos, al usuario siempre etapa vía `nivelAEtapa`, sin badges de medalla. Previene regresión.
- **Test de regresión:** `tests/e2e/cierre-niveles-f1.spec.ts` — el dashboard del taller no expone `\b(BRONCE|PLATA|ORO)\b`. Seed: `tallerOro` suma un 2º paso de recorrido para que renderice el bloque "Historial de tu recorrido" y el test cubra la superficie de F-1.

### Cierre del Nivel 5
X-07/X-09 del master **archivados como cumplidos**. X-08 = §1.4 (spec narrativa propio). X-07b = F-04 (backlog).

Refs: discovery #406, decisiones 3.7-3.10, F-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)