### PR TITLE
fix(k-01): cerrar 3 criticos C1/C2/C3 (PII + answer-key anonimos)

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-06-11
 
 ### Gerardo Breard
+- **13:00** `16334b1` — docs: D-03 reseed coordinado pendiente (cobertura test F-1)
+  - `.claude/DEUDA_TECNICA.md`
+
 - **12:02** `807d6de` — docs: B-05 a Resueltas + registrar B-06 (pill multi-tab stale)
   - `.claude/DEUDA_TECNICA.md`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,12 @@
 ## 2026-06-11
 
 ### Gerardo Breard
+- **14:56** `882090f` — fix(k-01): cerrar 3 criticos C1/C2/C3 (fugas anonimas de PII y answer-key)
+  - `src/__tests__/k-01-criticos.test.ts`
+  - `src/app/api/colecciones/[id]/route.ts`
+  - `src/app/api/marcas/[id]/route.ts`
+  - `src/app/api/talleres/[id]/route.ts`
+
 - **13:00** `16334b1` — docs: D-03 reseed coordinado pendiente (cobertura test F-1)
   - `.claude/DEUDA_TECNICA.md`
 

--- a/src/__tests__/k-01-criticos.test.ts
+++ b/src/__tests__/k-01-criticos.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// ─── K-01 — Hotfix de los 3 criticos C1/C2/C3 ────────────────────────────────
+// Fugas anonimas que cerramos:
+//   C1  GET /api/marcas/[id]      — PII (email/telefono/CUIT) + pedidos sin auth
+//   C2  GET /api/talleres/[id]    — PII del dueño sin auth
+//   C3  GET /api/colecciones/[id] — answer-key (evaluacion.preguntas[].correcta)
+// Estos tests son el embrion del patron K-02 (matriz 401/403/200 + no-leak).
+
+const mockAuth = vi.fn()
+vi.mock('@/compartido/lib/auth', () => ({ auth: () => mockAuth() }))
+
+const mockPrisma = {
+  marca: { findUnique: vi.fn() },
+  taller: { findUnique: vi.fn() },
+  coleccion: { findUnique: vi.fn() },
+}
+vi.mock('@/compartido/lib/prisma', () => ({ prisma: mockPrisma }))
+
+function getReq(url: string) {
+  return new NextRequest(new URL(url, 'http://localhost'), { method: 'GET' })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+// ─── C1 — GET /api/marcas/[id] ───────────────────────────────────────────────
+
+describe('C1 — GET /api/marcas/[id]: cierra fuga de PII anonima', () => {
+  const marca = {
+    id: 'm1', userId: 'mu1', nombre: 'Marca X', cuit: '30700000001',
+    user: { email: 'dueno@marca.com', name: 'Dueño', phone: '+5491100000000', avatar: null },
+    pedidos: [],
+  }
+
+  it('anonimo → 401 y el body no filtra PII', async () => {
+    mockAuth.mockResolvedValue(null)
+    const { GET } = await import('@/app/api/marcas/[id]/route')
+    const res = await GET(getReq('http://localhost/api/marcas/m1'), { params: Promise.resolve({ id: 'm1' }) })
+    const body = await res.json()
+    expect(res.status).toBe(401)
+    expect(JSON.stringify(body)).not.toContain('30700000001')
+    expect(JSON.stringify(body)).not.toContain('dueno@marca.com')
+  })
+
+  it('usuario logueado que NO es dueño ni supervision → 403, sin PII', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'otro', role: 'TALLER' } })
+    mockPrisma.marca.findUnique.mockResolvedValue(marca)
+    const { GET } = await import('@/app/api/marcas/[id]/route')
+    const res = await GET(getReq('http://localhost/api/marcas/m1'), { params: Promise.resolve({ id: 'm1' }) })
+    const body = await res.json()
+    expect(res.status).toBe(403)
+    expect(JSON.stringify(body)).not.toContain('30700000001')
+    expect(JSON.stringify(body)).not.toContain('dueno@marca.com')
+  })
+
+  it('dueño de la marca → 200', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'mu1', role: 'MARCA' } })
+    mockPrisma.marca.findUnique.mockResolvedValue(marca)
+    const { GET } = await import('@/app/api/marcas/[id]/route')
+    const res = await GET(getReq('http://localhost/api/marcas/m1'), { params: Promise.resolve({ id: 'm1' }) })
+    expect(res.status).toBe(200)
+  })
+
+  it('ADMIN → 200 (supervision)', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'admin1', role: 'ADMIN' } })
+    mockPrisma.marca.findUnique.mockResolvedValue(marca)
+    const { GET } = await import('@/app/api/marcas/[id]/route')
+    const res = await GET(getReq('http://localhost/api/marcas/m1'), { params: Promise.resolve({ id: 'm1' }) })
+    expect(res.status).toBe(200)
+  })
+})
+
+// ─── C2 — GET /api/talleres/[id] ─────────────────────────────────────────────
+
+describe('C2 — GET /api/talleres/[id]: cierra fuga de PII anonima', () => {
+  const taller = {
+    id: 't1', userId: 'tu1', nombre: 'Taller X',
+    user: { email: 'dueno@taller.com', phone: '+5491100000001', name: 'Titular' },
+    procesos: [], prendas: [], maquinaria: [], certificaciones: [], validaciones: [],
+  }
+
+  it('anonimo → 401 y el body no filtra PII', async () => {
+    mockAuth.mockResolvedValue(null)
+    const { GET } = await import('@/app/api/talleres/[id]/route')
+    const res = await GET(getReq('http://localhost/api/talleres/t1'), { params: Promise.resolve({ id: 't1' }) })
+    const body = await res.json()
+    expect(res.status).toBe(401)
+    expect(JSON.stringify(body)).not.toContain('dueno@taller.com')
+  })
+
+  it('usuario logueado que NO es dueño ni supervision → 403, sin PII', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'otro', role: 'MARCA' } })
+    mockPrisma.taller.findUnique.mockResolvedValue(taller)
+    const { GET } = await import('@/app/api/talleres/[id]/route')
+    const res = await GET(getReq('http://localhost/api/talleres/t1'), { params: Promise.resolve({ id: 't1' }) })
+    const body = await res.json()
+    expect(res.status).toBe(403)
+    expect(JSON.stringify(body)).not.toContain('dueno@taller.com')
+  })
+
+  it('dueño del taller → 200', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'tu1', role: 'TALLER' } })
+    mockPrisma.taller.findUnique.mockResolvedValue(taller)
+    const { GET } = await import('@/app/api/talleres/[id]/route')
+    const res = await GET(getReq('http://localhost/api/talleres/t1'), { params: Promise.resolve({ id: 't1' }) })
+    expect(res.status).toBe(200)
+  })
+
+  it('ESTADO → 200 (supervision)', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'estado1', role: 'ESTADO' } })
+    mockPrisma.taller.findUnique.mockResolvedValue(taller)
+    const { GET } = await import('@/app/api/talleres/[id]/route')
+    const res = await GET(getReq('http://localhost/api/talleres/t1'), { params: Promise.resolve({ id: 't1' }) })
+    expect(res.status).toBe(200)
+  })
+})
+
+// ─── C3 — GET /api/colecciones/[id] ──────────────────────────────────────────
+
+describe('C3 — GET /api/colecciones/[id]: cierra fuga del answer-key', () => {
+  const coleccion = {
+    id: 'c1', titulo: 'Curso', activa: true,
+    videos: [{ id: 'v1', titulo: 'Video', orden: 1 }],
+  }
+
+  it('anonimo → 401', async () => {
+    mockAuth.mockResolvedValue(null)
+    const { GET } = await import('@/app/api/colecciones/[id]/route')
+    const res = await GET(getReq('http://localhost/api/colecciones/c1'), { params: Promise.resolve({ id: 'c1' }) })
+    expect(res.status).toBe(401)
+  })
+
+  it('TALLER (sin rol de contenido) → 403', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'tu1', role: 'TALLER' } })
+    const { GET } = await import('@/app/api/colecciones/[id]/route')
+    const res = await GET(getReq('http://localhost/api/colecciones/c1'), { params: Promise.resolve({ id: 'c1' }) })
+    expect(res.status).toBe(403)
+    // No debe haber consultado la coleccion: el gate corta antes.
+    expect(mockPrisma.coleccion.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('ADMIN → 200 y el response NO incluye evaluacion (answer-key)', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'admin1', role: 'ADMIN' } })
+    mockPrisma.coleccion.findUnique.mockResolvedValue(coleccion)
+    const { GET } = await import('@/app/api/colecciones/[id]/route')
+    const res = await GET(getReq('http://localhost/api/colecciones/c1'), { params: Promise.resolve({ id: 'c1' }) })
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    // El include NO debe pedir evaluacion (de ahi salia preguntas[].correcta).
+    const includeArg = mockPrisma.coleccion.findUnique.mock.calls[0][0].include
+    expect(includeArg.evaluacion).toBeUndefined()
+    // Y el body no contiene ni la relacion ni el campo correcta.
+    expect(body.evaluacion).toBeUndefined()
+    expect(JSON.stringify(body)).not.toContain('correcta')
+  })
+
+  it('CONTENIDO → 200', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'cont1', role: 'CONTENIDO' } })
+    mockPrisma.coleccion.findUnique.mockResolvedValue(coleccion)
+    const { GET } = await import('@/app/api/colecciones/[id]/route')
+    const res = await GET(getReq('http://localhost/api/colecciones/c1'), { params: Promise.resolve({ id: 'c1' }) })
+    expect(res.status).toBe(200)
+  })
+})

--- a/src/app/api/colecciones/[id]/route.ts
+++ b/src/app/api/colecciones/[id]/route.ts
@@ -5,12 +5,19 @@ import { logAccionAdmin } from '@/compartido/lib/log'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
+    // K-01 C3: este GET, ademas de ser anonimo, incluia `evaluacion: true`, que
+    // filtra el answer-key (preguntas[].correcta). Gate a ADMIN/CONTENIDO (igual
+    // que PUT/DELETE de este archivo y su unico caller: el panel de contenido) y
+    // se elimina `evaluacion` del include. La correccion de la evaluacion ocurre
+    // server-side en POST .../evaluacion (el cliente nunca necesita `correcta`).
+    const sesion = await requiereRolApi(['ADMIN', 'CONTENIDO'])
+    if (sesion instanceof NextResponse) return sesion
+
     const { id } = await params
     const coleccion = await prisma.coleccion.findUnique({
       where: { id },
       include: {
         videos: { orderBy: { orden: 'asc' } },
-        evaluacion: true,
       },
     })
 

--- a/src/app/api/marcas/[id]/route.ts
+++ b/src/app/api/marcas/[id]/route.ts
@@ -5,11 +5,35 @@ import { modoActivo } from '@/compartido/lib/roles'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
+    // K-01 C1: este GET exponia PII (email/telefono/CUIT + pedidos) sin auth.
+    // Gate: mismo modelo que el PUT de este archivo (dueño o ADMIN) + ESTADO
+    // para lectura de supervision. El GET no tiene callers de fetch; las
+    // paginas publicas (perfil-marca/[id], directorio) leen Prisma directo.
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+    }
+
     const { id } = await params
+    const role = modoActivo(session.user)
 
     const marca = await prisma.marca.findUnique({
       where: { id },
-      include: {
+      select: {
+        id: true,
+        userId: true,
+        nombre: true,
+        cuit: true,
+        ubicacion: true,
+        tipo: true,
+        website: true,
+        volumenMensual: true,
+        frecuenciaCompra: true,
+        rating: true,
+        pedidosRealizados: true,
+        verificadoAfip: true,
+        createdAt: true,
+        updatedAt: true,
         user: { select: { email: true, name: true, phone: true, avatar: true } },
         pedidos: { select: { id: true, omId: true, estado: true, tipoPrenda: true, cantidad: true, fechaCreacion: true } },
       },
@@ -17,6 +41,12 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 
     if (!marca) {
       return NextResponse.json({ error: 'Marca no encontrada' }, { status: 404 })
+    }
+
+    const esDueno = marca.userId === session.user.id
+    const esSupervision = role === 'ADMIN' || role === 'ESTADO'
+    if (!esDueno && !esSupervision) {
+      return NextResponse.json({ error: 'Sin acceso a esta marca' }, { status: 403 })
     }
 
     return NextResponse.json(marca)

--- a/src/app/api/talleres/[id]/route.ts
+++ b/src/app/api/talleres/[id]/route.ts
@@ -6,7 +6,17 @@ import { logAccionAdmin } from '@/compartido/lib/log'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
+    // K-01 C2: este GET exponia PII del dueño (email/telefono/nombre) sin auth.
+    // Gate: mismo modelo que el PUT de este archivo (dueño o ADMIN) + ESTADO
+    // para lectura de supervision. El GET no tiene callers de fetch; la pagina
+    // publica perfil/[id] y el directorio leen Prisma directo (no esta ruta).
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+    }
+
     const { id } = await params
+    const role = modoActivo(session.user)
 
     const taller = await prisma.taller.findUnique({
       where: { id },
@@ -22,6 +32,12 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 
     if (!taller) {
       return NextResponse.json({ error: 'Taller no encontrado' }, { status: 404 })
+    }
+
+    const esDueno = taller.userId === session.user.id
+    const esSupervision = role === 'ADMIN' || role === 'ESTADO'
+    if (!esDueno && !esSupervision) {
+      return NextResponse.json({ error: 'Sin acceso a este taller' }, { status: 403 })
     }
 
     return NextResponse.json(taller)


### PR DESCRIPTION
Hotfix **quirúrgico** de los 3 críticos de la auditoría K-01. Scope: solo **auth + select** en 3 endpoints. C4 y los 🟡 quedan para el plan ordenado del bloque K. **No mergear hasta review de Gerardo** (hotfix de seguridad).

## Qué se cerró
| | Endpoint | Antes | Después |
|---|---|---|---|
| C1 | `GET /api/marcas/[id]` | Anónimo → PII (email/tel/CUIT) + pedidos de cualquier marca | Sesión + dueño-o-ADMIN/ESTADO + `select` explícito |
| C2 | `GET /api/talleres/[id]` | Anónimo → PII del dueño | Sesión + dueño-o-ADMIN/ESTADO (mismo modelo que su PUT) |
| C3 | `GET /api/colecciones/[id]` | Anónimo + `include: evaluacion` → answer-key (`preguntas[].correcta`) | Gate ADMIN/CONTENIDO + `evaluacion` removido del include |

## Por qué no rompe callers (re-verificado)
- **C1/C2**: los GET **no tienen callers de fetch** — solo se usa el PUT (contactar-taller, editor de perfil, portfolio). Confirmado leyendo cada caller.
- **C3**: el único caller del GET es el panel `(contenido)`, que consume solo escalares + `videos` (nunca `evaluacion`). La academia del taller usa los subpaths `/progreso` y `/evaluacion`.
- Las páginas públicas (`perfil/[id]`, `perfil-marca/[id]`, `directorio`) leen **Prisma directo**, no estos endpoints.
- La corrección de la evaluación es **100% server-side** (`POST .../evaluacion`: el cliente manda solo `respuestas: number[]`; el server compara contra `p.correcta`). El cliente nunca necesita `correcta`.

## Tests (embrión K-02)
`src/__tests__/k-01-criticos.test.ts` — por cada endpoint: **401** anónimo, **403** logueado-sin-rol, **200** rol correcto, + aserción de **no-leak** (sin PII en 401/403; sin `evaluacion`/`correcta` en el 200 de C3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)