### PR TITLE
test(k-02): test pattern reutilizable de auth (matriz 401/403/200)

### DIFF
--- a/.claude/specs/v4-k-01-auditoria-endpoints.md
+++ b/.claude/specs/v4-k-01-auditoria-endpoints.md
@@ -284,6 +284,35 @@ Para cada endpoint protegido, el comportamiento esperado por rol que K-02 debe t
 
 **Endpoints que eran públicos pero NO debían (los 🔴 — RESUELTOS en #414):** `/api/marcas/[id]` GET, `/api/talleres/[id]` GET, `/api/colecciones/[id]` GET ahora exigen sesión. K-02 debe codificar el estado correcto: anónimo → **401**, rol sin permiso → **403**, rol correcto → **200** (ya cubierto por `src/__tests__/k-01-criticos.test.ts`, que es el embrión de esa matriz).
 
+### 5.1 Estado K-02 — cobertura del test pattern (`src/__tests__/k-02-auth-matrix.test.ts`)
+
+El helper `authMatrix` (en `src/__tests__/_helpers/auth-matrix.ts`) genera, por endpoint, los casos `anónimo→401 / rol-sin-permiso→403 / rol-ok→2xx`, mockeando `auth()` para ejercitar el gating real (`requiereRolApi → tieneAlgunRol`). Endpoints con ✓ ya están testeados sistemáticamente:
+
+| Endpoint (método) | Roles OK | K-02 |
+|---|---|---|
+| `/api/admin/stats` GET | ADMIN | ✓ |
+| `/api/admin/usuarios` GET | ADMIN | ✓ (no-leak PII) |
+| `/api/admin/usuarios-buscar` GET | ADMIN, ESTADO | ✓ |
+| `/api/admin/whatsapp` GET | ADMIN, ESTADO | ✓ |
+| `/api/admin/rag` GET | ADMIN, CONTENIDO | ✓ |
+| `/api/admin/config` GET | ADMIN | ✓ |
+| `/api/marcas` GET | ADMIN | ✓ (no-leak PII) |
+| `/api/talleres` GET | ADMIN, ESTADO, MARCA | ✓ |
+| `/api/validaciones` GET | ADMIN, ESTADO | ✓ |
+| `/api/validaciones` POST | ADMIN | ✓ (201) |
+| `/api/contenido/novedades` GET | CONTENIDO, ADMIN | ✓ |
+| `/api/colecciones/[id]/evaluacion` GET | ADMIN, CONTENIDO | ✓ (no-leak `correcta`) |
+| `/api/colecciones/[id]/evaluacion` POST | TALLER | ✓ (gate) |
+| `/api/auditorias` GET | ADMIN, ESTADO | ✓ |
+| `/api/estado/configuracion-niveles` GET | ESTADO, ADMIN | ✓ |
+| `/api/estado/configuracion-niveles/[id]` PUT | **ESTADO (ADMIN→403)** | ✓ ⚠ inconsistencia fotografiada |
+| `/api/estado/demanda-insatisfecha` GET | ESTADO, ADMIN | ✓ |
+| `/api/exportar` GET | ADMIN, ESTADO | ✓ (no-leak PII; C4 rate-limit sigue pendiente) |
+| `/api/marcas/[id]` GET, `/api/talleres/[id]` GET, `/api/colecciones/[id]` GET | (los 🔴) | ✓ vía `k-01-criticos.test.ts` |
+| `/api/stats/public` GET, `/api/health/version` GET | público | ✓ (anónimo→200, sin gate) |
+
+**Hallazgo de K-02 (punto 4 del reporte):** ningún test reveló un crítico nuevo. La única discrepancia es la ya documentada en §5/§8.3(b): `configuracion-niveles/[id]` PUT (y `/preview`) excluyen ADMIN (`requiereRolApi(['ESTADO'])`), a diferencia del resto de `/api/estado/*`. El test **fotografía** el comportamiento real (`ADMIN→403`) en vez de corregirlo; cambiar el endpoint es decisión post-promoción. Resto de la matriz §5 sin cubrir aún: endpoints con ownership/scope (pedidos/[id], cotizaciones, ordenes, validaciones/[id]) — su 200 depende de pertenencia, no solo de rol; quedan para una segunda tanda de K-02 (matriz IDOR) o K-04.
+
 ---
 
 ## 6. Patrones transversales y sus excepciones
@@ -327,7 +356,7 @@ Los 5 testigos conocidos fueron encontrados y clasificados correctamente:
 3. **Confirmaciones de negocio (pendientes, no son bugs):** (a) ¿ESTADO debe ver PII de contacto (§4.4)? (b) ¿la exclusión de ADMIN en `configuracion-niveles/[id]`/`preview` es deliberada o un descuido? (c) ¿`CONTENIDO` con permisos de RAG y colecciones es intencional?
 
 ### Plan restante del bloque K
-- **K-02:** test pattern de auth (matriz §5 — 401/403/200 sistemática). Embrión ya en `k-01-criticos.test.ts`.
+- **K-02:** test pattern de auth (matriz §5 — 401/403/200 sistemática). 🔵 **En progreso** — helper reutilizable `authMatrix` + 20 endpoints cubiertos (ver §5.1). Falta la segunda tanda (endpoints con ownership/scope → matriz IDOR).
 - **K-05:** `select` explícito en los ~17 endpoints de §4.1. **Reevaluar** ahí si los GET de `/api/marcas/[id]` y `/api/talleres/[id]` (código muerto, §6.8) se eliminan en vez de mantenerse protegidos.
 - **Barrido de rate-limit:** C4 + los faltantes de §4.3.
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,14 @@
 # Daily Log
 
+## 2026-06-12
+
+### Gerardo Breard
+- **13:13** `279d658` — test(k-02): test pattern reutilizable de auth (matriz 401/403/200)
+  - `.claude/specs/v4-k-01-auditoria-endpoints.md`
+  - `src/__tests__/_helpers/auth-matrix.ts`
+  - `src/__tests__/k-02-auth-matrix.test.ts`
+
+
 ## 2026-06-11
 
 ### Gerardo Breard

--- a/src/__tests__/_helpers/auth-matrix.ts
+++ b/src/__tests__/_helpers/auth-matrix.ts
@@ -1,0 +1,183 @@
+import { it, expect, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// ─── K-02 — Test pattern reutilizable de auth (matriz 401/403/200) ────────────
+//
+// Codifica la matriz §5 de la auditoria K-01
+// (.claude/specs/v4-k-01-auditoria-endpoints.md): para cada endpoint protegido,
+// que rol debe recibir 401 (anonimo), 403 (logueado sin el rol) y 200 (rol
+// correcto). El helper FOTOGRAFIA y VIGILA el comportamiento; NO lo corrige.
+//
+// Mockea al nivel de `auth()` (no de `requiereRolApi`) para ejercitar la logica
+// real de gating del proyecto: requiereRolApi -> tieneAlgunRol -> rolesEfectivos.
+// Asi un cambio que rompa la membresia hace fallar estos tests.
+
+export const ALL_ROLES = ['TALLER', 'MARCA', 'ESTADO', 'ADMIN', 'CONTENIDO'] as const
+export type Rol = (typeof ALL_ROLES)[number]
+
+/**
+ * Sesion minima para un rol. `tieneAlgunRol` usa `rolesEfectivos`, que cae a
+ * `[activeMode ?? role]` cuando no hay `roles[]` — por eso basta con `role`.
+ */
+export function makeSession(role: Rol, id = `${role.toLowerCase()}-1`, extra: Record<string, unknown> = {}) {
+  return { user: { id, role, ...extra } }
+}
+
+/**
+ * Mock de Prisma auto-vivificante: cualquier `prisma.<modelo>.<metodo>()` existe
+ * y resuelve a un valor neutro por defecto. Cada caso 200 sobreescribe lo que
+ * necesite via `setup`. Un default vacio (findMany -> [], count -> 0) alcanza
+ * para que la mayoria de los GET lleguen a 200 sin armar fixtures pesados.
+ */
+export function makePrismaMock() {
+  const cache = new Map<string, Record<string, ReturnType<typeof vi.fn>>>()
+  const makeModel = () => ({
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    findFirst: vi.fn().mockResolvedValue(null),
+    count: vi.fn().mockResolvedValue(0),
+    groupBy: vi.fn().mockResolvedValue([]),
+    aggregate: vi.fn().mockResolvedValue({}),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+    upsert: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+    createMany: vi.fn().mockResolvedValue({ count: 0 }),
+  })
+  const proxy: Record<string, unknown> = new Proxy(
+    {},
+    {
+      get(_t, prop: string) {
+        if (prop === '$transaction') {
+          return vi.fn(async (arg: unknown) =>
+            Array.isArray(arg) ? Promise.all(arg) : (arg as (tx: unknown) => unknown)(proxy)
+          )
+        }
+        if (prop === '$executeRaw' || prop === '$queryRaw' || prop === '$executeRawUnsafe' || prop === '$queryRawUnsafe') {
+          return vi.fn().mockResolvedValue([])
+        }
+        if (typeof prop !== 'string') return undefined
+        if (!cache.has(prop)) cache.set(prop, makeModel())
+        return cache.get(prop)
+      },
+    }
+  )
+  return proxy
+}
+
+export type SuccessMode = 'exact' | 'passes-auth'
+
+export interface AuthMatrixSpec {
+  /** Importer con literal estatico, p.ej. `() => import('@/app/api/admin/stats/route')`. */
+  importer: () => Promise<Record<string, unknown>>
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+  url: string
+  params?: Record<string, string>
+  body?: unknown
+  /** Roles que deben pasar el gate (200/2xx). */
+  allow: Rol[]
+  /** Roles que deben recibir 403. Por defecto: todos los que no estan en `allow`. */
+  deny?: Rol[]
+  /** Status de exito esperado (200 por defecto; 201 en algunos POST). */
+  successStatus?: number
+  /**
+   * 'exact' (default): el rol permitido recibe `successStatus`.
+   * 'passes-auth': solo verifica que NO es 401/403 (para handlers con deps
+   * pesadas donde montar el 200 exacto agrega ruido sin valor de seguridad).
+   */
+  successMode?: SuccessMode
+  /** Configura mocks por caso. `role` es null en el caso anonimo. */
+  setup?: (role: Rol | null) => void
+  /** Substrings que NO deben aparecer en el body de 401/403 (anti-leak de PII). */
+  noLeak?: string[]
+}
+
+interface HelperDeps {
+  setSession: (role: Rol | null) => void
+}
+
+function buildRequest(spec: AuthMatrixSpec): NextRequest {
+  const init: { method: string; body?: string; headers?: Record<string, string> } = { method: spec.method }
+  if (spec.body !== undefined) {
+    init.body = JSON.stringify(spec.body)
+    init.headers = { 'content-type': 'application/json' }
+  }
+  return new NextRequest(new URL(spec.url, 'http://localhost'), init)
+}
+
+async function invoke(spec: AuthMatrixSpec): Promise<Response> {
+  const mod = await spec.importer()
+  const handler = mod[spec.method] as (req: NextRequest, ctx: { params: Promise<Record<string, string>> }) => Promise<Response>
+  return handler(buildRequest(spec), { params: Promise.resolve(spec.params ?? {}) })
+}
+
+async function assertNoLeak(res: Response, noLeak?: string[]) {
+  if (!noLeak?.length) return
+  const text = JSON.stringify(await res.clone().json().catch(() => ({})))
+  for (const secret of noLeak) {
+    expect(text).not.toContain(secret)
+  }
+}
+
+/**
+ * Genera, para un endpoint, los casos de la matriz:
+ *   anonimo -> 401  |  cada rol en `deny` -> 403  |  cada rol en `allow` -> 2xx
+ * Debe llamarse DENTRO de un `describe(...)`.
+ */
+export function authMatrix(spec: AuthMatrixSpec, deps: HelperDeps) {
+  const deny = spec.deny ?? ALL_ROLES.filter((r) => !spec.allow.includes(r))
+  const successStatus = spec.successStatus ?? 200
+  const mode: SuccessMode = spec.successMode ?? 'exact'
+
+  it('anonimo -> 401', async () => {
+    deps.setSession(null)
+    spec.setup?.(null)
+    const res = await invoke(spec)
+    expect(res.status).toBe(401)
+    await assertNoLeak(res, spec.noLeak)
+  })
+
+  for (const role of deny) {
+    it(`${role} sin permiso -> 403`, async () => {
+      deps.setSession(role)
+      spec.setup?.(role)
+      const res = await invoke(spec)
+      expect(res.status).toBe(403)
+      await assertNoLeak(res, spec.noLeak)
+    })
+  }
+
+  for (const role of spec.allow) {
+    const labelExito = mode === 'exact' ? `${role} -> ${successStatus}` : `${role} pasa el gate (no 401/403)`
+    it(labelExito, async () => {
+      deps.setSession(role)
+      spec.setup?.(role)
+      const res = await invoke(spec)
+      if (mode === 'exact') {
+        expect(res.status).toBe(successStatus)
+      } else {
+        expect(res.status).not.toBe(401)
+        expect(res.status).not.toBe(403)
+      }
+    })
+  }
+}
+
+/**
+ * Endpoint publico: el anonimo NO debe recibir 401 (la auditoria §5 lista los
+ * que deben quedar abiertos). Verifica que el gate no se agrego por error.
+ */
+export function publicMatrix(
+  spec: Pick<AuthMatrixSpec, 'importer' | 'method' | 'url' | 'params' | 'body' | 'successStatus' | 'setup'>,
+  deps: HelperDeps
+) {
+  const successStatus = spec.successStatus ?? 200
+  it('anonimo -> 200 (sin auth, es publico)', async () => {
+    deps.setSession(null)
+    spec.setup?.(null)
+    const res = await invoke(spec as AuthMatrixSpec)
+    expect(res.status).toBe(successStatus)
+  })
+}

--- a/src/__tests__/k-02-auth-matrix.test.ts
+++ b/src/__tests__/k-02-auth-matrix.test.ts
@@ -1,0 +1,349 @@
+import { describe, beforeEach, vi } from 'vitest'
+import {
+  authMatrix,
+  publicMatrix,
+  makePrismaMock,
+  makeSession,
+  type Rol,
+} from './_helpers/auth-matrix'
+
+// ─── K-02 — Matriz de auth sistematica (401/403/200) ─────────────────────────
+//
+// Codifica la matriz §5 de la auditoria K-01 sobre endpoints reales del
+// proyecto. SOLO tests: ningun cambio de comportamiento. Cada describe = un
+// endpoint; el helper genera anonimo->401, rol-sin-permiso->403, rol-ok->2xx.
+//
+// Mockea `auth()` (no `requiereRolApi`) para ejercitar el gating real
+// (requiereRolApi -> tieneAlgunRol -> rolesEfectivos). Prisma y las libs con
+// efectos (log, nivel, demanda) se mockean para que el camino 200 no pegue a DB.
+
+const mockAuth = vi.fn()
+vi.mock('@/compartido/lib/auth', () => ({ auth: () => mockAuth() }))
+
+const mockPrisma = makePrismaMock()
+vi.mock('@/compartido/lib/prisma', () => ({ prisma: mockPrisma }))
+
+// Libs con efectos colaterales (escriben a DB / cache) — neutralizadas.
+vi.mock('@/compartido/lib/log', () => ({ logActividad: vi.fn(), logAccionAdmin: vi.fn() }))
+vi.mock('@/compartido/lib/nivel', () => ({ invalidarCacheNivel: vi.fn(), aplicarNivel: vi.fn() }))
+vi.mock('@/compartido/lib/demanda-insatisfecha', () => ({
+  calcularStatsAgregadas: vi.fn().mockResolvedValue({}),
+  generarRecomendaciones: vi.fn().mockResolvedValue([]),
+}))
+// Libs importadas a nivel de modulo por la ruta de evaluacion (no se ejercitan
+// en el camino de auth, pero se mockean para evitar dependencias de entorno).
+vi.mock('@/compartido/lib/email', () => ({ sendEmail: vi.fn(), buildCertificadoEmail: vi.fn(() => ({})) }))
+vi.mock('@/compartido/lib/qr', () => ({ generateQrBuffer: vi.fn() }))
+vi.mock('@/compartido/lib/storage', () => ({ uploadFile: vi.fn() }))
+
+function setSession(role: Rol | null) {
+  mockAuth.mockResolvedValue(role ? makeSession(role) : null)
+}
+const deps = { setSession }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+// Helpers de modelo del proxy (tipado laxo: es un mock auto-vivificante).
+const m = (modelo: string) => (mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>)[modelo]
+
+const PII = 'leak@pii.test'
+
+// ─── Admin (ADMIN, algunos +ESTADO / +CONTENIDO) ─────────────────────────────
+
+describe('GET /api/admin/stats — solo ADMIN', () => {
+  authMatrix(
+    {
+      importer: () => import('@/app/api/admin/stats/route'),
+      method: 'GET',
+      url: '/api/admin/stats',
+      allow: ['ADMIN'],
+    },
+    deps
+  )
+})
+
+describe('GET /api/admin/usuarios — solo ADMIN (PII: email/phone)', () => {
+  authMatrix(
+    {
+      importer: () => import('@/app/api/admin/usuarios/route'),
+      method: 'GET',
+      url: '/api/admin/usuarios',
+      allow: ['ADMIN'],
+      noLeak: [PII],
+      setup: () => {
+        m('user').findMany.mockResolvedValue([{ id: 'u1', email: PII, name: 'X', role: 'TALLER', phone: '123' }])
+        m('user').count.mockResolvedValue(1)
+      },
+    },
+    deps
+  )
+})
+
+describe('GET /api/admin/usuarios-buscar — ADMIN/ESTADO (PII)', () => {
+  authMatrix(
+    {
+      importer: () => import('@/app/api/admin/usuarios-buscar/route'),
+      method: 'GET',
+      url: '/api/admin/usuarios-buscar', // sin q -> {usuarios:[]} con 200
+      allow: ['ADMIN', 'ESTADO'],
+      noLeak: [PII],
+    },
+    deps
+  )
+})
+
+describe('GET /api/admin/whatsapp — ADMIN/ESTADO (PII: phone)', () => {
+  authMatrix(
+    {
+      importer: () => import('@/app/api/admin/whatsapp/route'),
+      method: 'GET',
+      url: '/api/admin/whatsapp',
+      allow: ['ADMIN', 'ESTADO'],
+    },
+    deps
+  )
+})
+
+describe('GET /api/admin/rag — ADMIN/CONTENIDO', () => {
+  authMatrix(
+    {
+      importer: () => import('@/app/api/admin/rag/route'),
+      method: 'GET',
+      url: '/api/admin/rag',
+      allow: ['ADMIN', 'CONTENIDO'],
+    },
+    deps
+  )
+})
+
+describe('GET /api/admin/config — solo ADMIN', () => {
+  authMatrix(
+    {
+      importer: () => import('@/app/api/admin/config/route'),
+      method: 'GET',
+      url: '/api/admin/config',
+      allow: ['ADMIN'],
+    },
+    deps
+  )
+})
+
+// ─── Marcas / Talleres (listados con PII) ────────────────────────────────────
+
+describe('GET /api/marcas — solo ADMIN (PII de marcas)', () => {
+  authMatrix(
+    {
+      importer: () => import('@/app/api/marcas/route'),
+      method: 'GET',
+      url: '/api/marcas',
+      allow: ['ADMIN'],
+      noLeak: [PII],
+      setup: () => {
+        m('marca').findMany.mockResolvedValue([{ id: 'm1', nombre: 'M', user: { email: PII, name: 'D', phone: '1', active: true } }])
+        m('marca').count.mockResolvedValue(1)
+      },
+    },
+    deps
+  )
+})
+
+describe('GET /api/talleres — ADMIN/ESTADO/MARCA (directorio)', () => {
+  authMatrix(
+    {
+      importer: () => import('@/app/api/talleres/route'),
+      method: 'GET',
+      url: '/api/talleres',
+      allow: ['ADMIN', 'ESTADO', 'MARCA'],
+      setup: () => {
+        m('taller').findMany.mockResolvedValue([])
+        m('taller').count.mockResolvedValue(0)
+      },
+    },
+    deps
+  )
+})
+
+// ─── Validaciones ────────────────────────────────────────────────────────────
+
+describe('GET /api/validaciones — ADMIN/ESTADO', () => {
+  authMatrix(
+    {
+      importer: () => import('@/app/api/validaciones/route'),
+      method: 'GET',
+      url: '/api/validaciones',
+      allow: ['ADMIN', 'ESTADO'],
+    },
+    deps
+  )
+})
+
+describe('POST /api/validaciones — solo ADMIN (crea, 201)', () => {
+  authMatrix(
+    {
+      importer: () => import('@/app/api/validaciones/route'),
+      method: 'POST',
+      url: '/api/validaciones',
+      body: { tallerId: 't1', tipo: 'HABILITACION', tipoDocumentoId: 'td1', estado: 'PENDIENTE' },
+      allow: ['ADMIN'],
+      successStatus: 201,
+      setup: () => {
+        m('validacion').create.mockResolvedValue({ id: 'val1' })
+      },
+    },
+    deps
+  )
+})
+
+// ─── Contenido / academia ────────────────────────────────────────────────────
+
+describe('GET /api/contenido/novedades — CONTENIDO/ADMIN', () => {
+  authMatrix(
+    {
+      importer: () => import('@/app/api/contenido/novedades/route'),
+      method: 'GET',
+      url: '/api/contenido/novedades',
+      allow: ['CONTENIDO', 'ADMIN'],
+    },
+    deps
+  )
+})
+
+describe('GET /api/colecciones/[id]/evaluacion — ADMIN/CONTENIDO (answer-key)', () => {
+  authMatrix(
+    {
+      importer: () => import('@/app/api/colecciones/[id]/evaluacion/route'),
+      method: 'GET',
+      url: '/api/colecciones/c1/evaluacion',
+      params: { id: 'c1' },
+      allow: ['ADMIN', 'CONTENIDO'],
+      noLeak: ['correcta'],
+    },
+    deps
+  )
+})
+
+describe('POST /api/colecciones/[id]/evaluacion — solo TALLER (rinde la evaluacion)', () => {
+  // El 200 real depende de tener taller + certificado + email; aca solo
+  // verificamos el gate: TALLER pasa, el resto recibe 403, anonimo 401.
+  authMatrix(
+    {
+      importer: () => import('@/app/api/colecciones/[id]/evaluacion/route'),
+      method: 'POST',
+      url: '/api/colecciones/c1/evaluacion',
+      params: { id: 'c1' },
+      body: { respuestas: [] },
+      allow: ['TALLER'],
+      successMode: 'passes-auth',
+    },
+    deps
+  )
+})
+
+describe('GET /api/auditorias — ADMIN/ESTADO', () => {
+  authMatrix(
+    {
+      importer: () => import('@/app/api/auditorias/route'),
+      method: 'GET',
+      url: '/api/auditorias',
+      allow: ['ADMIN', 'ESTADO'],
+    },
+    deps
+  )
+})
+
+// ─── Estado ──────────────────────────────────────────────────────────────────
+
+describe('GET /api/estado/configuracion-niveles — ESTADO/ADMIN', () => {
+  authMatrix(
+    {
+      importer: () => import('@/app/api/estado/configuracion-niveles/route'),
+      method: 'GET',
+      url: '/api/estado/configuracion-niveles',
+      allow: ['ESTADO', 'ADMIN'],
+    },
+    deps
+  )
+})
+
+describe('PUT /api/estado/configuracion-niveles/[id] — solo ESTADO', () => {
+  // INCONSISTENCIA DOCUMENTADA (auditoria §5 ⚠): a diferencia del resto de
+  // /api/estado/*, este PUT excluye ADMIN (requiereRolApi(['ESTADO'])). El test
+  // FOTOGRAFIA el comportamiento real (ADMIN -> 403) en vez de corregirlo.
+  // Si la decision de negocio es incluir ADMIN, cambiar el endpoint y este test
+  // juntos. Ref: .claude/specs/v4-k-01-auditoria-endpoints.md §5 / §8.3(b).
+  authMatrix(
+    {
+      importer: () => import('@/app/api/estado/configuracion-niveles/[id]/route'),
+      method: 'PUT',
+      url: '/api/estado/configuracion-niveles/r1',
+      params: { id: 'r1' },
+      body: { descripcion: 'editada' },
+      allow: ['ESTADO'], // ADMIN cae en deny -> 403 (comportamiento real)
+      setup: () => {
+        m('reglaNivel').findUnique.mockResolvedValue({
+          id: 'r1', nivel: 'PLATA', puntosMinimos: 10, requiereVerificadoAfip: false,
+          certificadosAcademiaMin: 0, descripcion: 'd', beneficios: [],
+        })
+        m('reglaNivel').update.mockResolvedValue({ id: 'r1' })
+      },
+    },
+    deps
+  )
+})
+
+describe('GET /api/estado/demanda-insatisfecha — ESTADO/ADMIN', () => {
+  authMatrix(
+    {
+      importer: () => import('@/app/api/estado/demanda-insatisfecha/route'),
+      method: 'GET',
+      url: '/api/estado/demanda-insatisfecha',
+      allow: ['ESTADO', 'ADMIN'],
+    },
+    deps
+  )
+})
+
+// ─── Exportacion (C4: PII masiva — aca cubrimos su auth-gate) ─────────────────
+
+describe('GET /api/exportar — ADMIN/ESTADO (CSV con PII)', () => {
+  authMatrix(
+    {
+      importer: () => import('@/app/api/exportar/route'),
+      method: 'GET',
+      url: '/api/exportar?tipo=talleres',
+      allow: ['ADMIN', 'ESTADO'],
+      noLeak: [PII],
+      setup: () => {
+        m('taller').findMany.mockResolvedValue([]) // CSV vacio -> 200 sin armar fixture pesado
+      },
+    },
+    deps
+  )
+})
+
+// ─── Publicos (la auditoria §5 exige que NO pidan auth) ──────────────────────
+
+describe('GET /api/stats/public — publico', () => {
+  publicMatrix(
+    {
+      importer: () => import('@/app/api/stats/public/route'),
+      method: 'GET',
+      url: '/api/stats/public',
+    },
+    deps
+  )
+})
+
+describe('GET /api/health/version — publico', () => {
+  publicMatrix(
+    {
+      importer: () => import('@/app/api/health/version/route'),
+      method: 'GET',
+      url: '/api/health/version',
+    },
+    deps
+  )
+})


### PR DESCRIPTION
## K-02 — Test pattern de auth sistemático (Bloque K, MVP)

Segunda acción del bloque K tras el hotfix #414. **SOLO tests: cero cambios de comportamiento en endpoints** (el paquete funcional de develop queda idéntico para el smoke de Sergio).

### Qué trae
- **Helper reutilizable** `src/__tests__/_helpers/auth-matrix.ts` → `authMatrix(spec, deps)`: dado un endpoint + roles esperados, genera los casos `anónimo→401 / rol-sin-permiso→403 / rol-ok→2xx` + asserts de no-leak de PII. Mockea `auth()` (no `requiereRolApi`) para ejercitar el **gating real** del proyecto (`requiereRolApi → tieneAlgunRol → rolesEfectivos`). Prisma se mockea con un proxy auto-vivificante. `publicMatrix` cubre el caso inverso (público → anónimo no recibe 401).
- **Cobertura:** 20 endpoints de la matriz §5 de la auditoría K-01 (admin, estado, validaciones, contenido, exportar + 2 públicos). Extiende el embrión `k-01-criticos.test.ts`.
- **Auditoría actualizada:** §5.1 con el estado de cobertura K-02 por endpoint.

### Hallazgo (punto 4 del reporte — NO es un crítico nuevo)
Ningún test reveló una fuga nueva. La única discrepancia es la **ya documentada**: `PUT /api/estado/configuracion-niveles/[id]` (y `/preview`) excluyen ADMIN (`requiereRolApi(['ESTADO'])`), a diferencia del resto de `/api/estado/*`. El test **fotografía** el comportamiento real (`ADMIN→403`) con un comentario + ref a la auditoría §5/§8.3(b); cambiar el endpoint es decisión post-promoción.

### Sin cubrir (segunda tanda)
Endpoints con ownership/scope (`pedidos/[id]`, `cotizaciones`, `ordenes`, `validaciones/[id]`): su 200 depende de pertenencia, no solo de rol → matriz IDOR aparte (K-02 tanda 2 / K-04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)