### PR TITLE
test(k-02): tanda 2 matriz IDOR (ownership) + hallazgo C5

### DIFF
--- a/.claude/specs/v4-k-01-auditoria-endpoints.md
+++ b/.claude/specs/v4-k-01-auditoria-endpoints.md
@@ -313,7 +313,37 @@ El helper `authMatrix` (en `src/__tests__/_helpers/auth-matrix.ts`) genera, por 
 | `/api/marcas/[id]` GET, `/api/talleres/[id]` GET, `/api/colecciones/[id]` GET | (los 🔴) | ✓ vía `k-01-criticos.test.ts` |
 | `/api/stats/public` GET, `/api/health/version` GET | público | ✓ (anónimo→200, sin gate) |
 
-**Hallazgo de K-02 (punto 4 del reporte):** ningún test reveló un crítico nuevo. La única discrepancia es la ya documentada en §5/§8.3(b): `configuracion-niveles/[id]` PUT (y `/preview`) excluyen ADMIN (`requiereRolApi(['ESTADO'])`), a diferencia del resto de `/api/estado/*`. El test **fotografía** el comportamiento real (`ADMIN→403`) en vez de corregirlo; cambiar el endpoint es decisión post-promoción. Resto de la matriz §5 sin cubrir aún: endpoints con ownership/scope (pedidos/[id], cotizaciones, ordenes, validaciones/[id]) — su 200 depende de pertenencia, no solo de rol; quedan para una segunda tanda de K-02 (matriz IDOR) o K-04.
+**Hallazgo de K-02 tanda 1 (punto 4 del reporte):** ningún test reveló un crítico nuevo. La única discrepancia es la ya documentada en §5/§8.3(b): `configuracion-niveles/[id]` PUT (y `/preview`) excluyen ADMIN (`requiereRolApi(['ESTADO'])`), a diferencia del resto de `/api/estado/*`. El test **fotografía** el comportamiento real (`ADMIN→403`) en vez de corregirlo; cambiar el endpoint es decisión post-promoción.
+
+### 5.2 Estado K-02 tanda 2 — matriz IDOR (`src/__tests__/k-02-idor-matrix.test.ts`)
+
+Helper hermano `ownershipMatrix` (mismo archivo `_helpers/auth-matrix.ts`): para cada recurso, `anónimo→401 / owner→2xx / no-owner mismo-rol→403|404 / transversal→no-403`. El recurso mockeado es el mismo; cambia la identidad de la sesión.
+
+| Endpoint (método) | Owner | Transversal | No-owner | IDOR |
+|---|---|---|---|---|
+| `/api/pedidos/[id]` GET | marca dueña / taller asignado | ADMIN | 403 | ✓ bloqueado |
+| `/api/pedidos/[id]` PUT | marca dueña | ADMIN | 403 | ✓ bloqueado |
+| `/api/cotizaciones/[id]` PUT ACEPTAR/RECHAZAR | marca dueña | ADMIN | 403 | ✓ bloqueado |
+| `/api/cotizaciones/[id]` PUT RETIRAR | taller dueño | ADMIN | 403 | ✓ bloqueado |
+| `/api/ordenes/[id]` PUT | taller asignado | ADMIN | 403 | ✓ bloqueado |
+| `/api/validaciones/[id]` PUT | taller dueño | **ESTADO (NO ADMIN)** | 403 | ✓ bloqueado |
+| `/api/validaciones/[id]/signed-url` GET | taller dueño | ADMIN, ESTADO | 403 | ✓ bloqueado |
+| `/api/validaciones/[id]/upload` POST | taller dueño | **ninguno (owner-only)** | 403 | ✓ bloqueado |
+| `/api/pedidos/[id]/invitaciones` POST | marca dueña | ADMIN | 403 | ✓ bloqueado |
+| `/api/notificaciones` PUT | dueño de la notif | ninguno | **403 (incl. inexistente)** | ✓ bloqueado |
+| `/api/upload/imagenes` POST `portfolio`/`pedido` | ata `entityId` al caller | — | 403 | ✓ bloqueado |
+| **`/api/upload/imagenes` POST `cotizacion`** | — | — | **200 ⚠** | **🔴 IDOR confirmado (C5)** |
+
+**Convención 403 vs 404 (fotografiada):** las rutas `[id]` de recurso (pedidos, cotizaciones, ordenes, validaciones, invitaciones) devuelven **404 si no existe** y **403 si existe pero no sos dueño** (revela existencia). `notificaciones` PUT devuelve **403 también para inexistente** (no revela). Inconsistencia menor; no es bug, se documenta.
+
+**Endpoints sin superficie IDOR (self-scoped, verificados):** `/api/colecciones/[id]/progreso` POST, `/api/colecciones/[id]/evaluacion` POST, `/api/auth/mi-cuenta`, `/api/cuenta`, `/api/usuarios/me/*` — el recurso se deriva de la sesión (`findFirst({ userId })`), no de un id del cliente → no hay IDOR posible. La lista `cotizaciones` GET / `pedidos` GET filtran por scope en el `where`, no por `[id]`.
+
+#### 🔴 C5 — `POST /api/upload/imagenes` contexto `cotizacion`: IDOR de escritura (confirmado)
+- **Archivo:** `src/app/api/upload/imagenes/route.ts:77-84`.
+- **Qué pasa:** los contextos `portfolio` y `pedido` atan el `entityId` al caller (`findFirst({ id: entityId, userId })`). El contexto **`cotizacion` NO usa `entityId`** — solo chequea `taller.findFirst({ where: { userId } })` ("¿el caller posee algún taller?"). Cualquier TALLER autenticado puede subir un objeto validado (imagen) a la ruta de almacenamiento `cotizacion/<entityId-ajeno>/...` de **cualquier** cotización.
+- **Escenario:** taller A (cualquiera) → `POST` con `contexto=cotizacion`, `entityId=<cotización de otra marca>`, archivo imagen válido → **200**, objeto escrito bajo el namespace ajeno.
+- **Severidad: MEDIA, no bloqueante de promoción por sí sola.** Requiere usuario TALLER autenticado (no anónimo); **no filtra PII** ni **muta el registro** de la cotización (solo escribe un objeto-imagen en storage bajo una carpeta adivinable; el `{url}` se devuelve al atacante, no se adjunta automáticamente a la cotización ajena). Impacto real = abuso de almacenamiento / inyección de imágenes en namespace ajeno. **Ya estaba documentado como excepción 🟡 en §6.3** — K-02 lo confirma y lo eleva a hallazgo nominado (C5).
+- **Test:** `k-02-idor-matrix.test.ts` **fotografía** el comportamiento actual (`200`) con comentario `[IDOR confirmado]`. **NO se corrigió de oficio.** Fix propuesto (decisión de Gerardo): en la rama `cotizacion`, resolver la cotización por `entityId` y verificar que su `taller.userId === session.user.id` (o que el caller sea la marca dueña del pedido), igual que hacen `portfolio`/`pedido`.
 
 ---
 
@@ -355,13 +385,14 @@ Los 5 testigos conocidos fueron encontrados y clasificados correctamente:
 
 1. **Hotfix de C1/C2/C3 — ✅ RESUELTO (#414, `0758fad`, 2026-06-11).** Se cerraron los 3 críticos con auth + select, scope quirúrgico, antes de K-02. La matriz 401/403/200 de K-02 ya parte del estado correcto (test de regresión `src/__tests__/k-01-criticos.test.ts`).
 2. **C4 (`/api/exportar` sin rate-limit) — ⏳ plan bloque K.** Queda para el barrido de rate-limit (§4.3): añadir `rateLimit('exportar')` + whitelist de `tipo`.
+2bis. **C5 (`/api/upload/imagenes` contexto `cotizacion`, IDOR de escritura) — ⏳ pendiente, descubierto en K-02 tanda 2 (§5.2).** MEDIA, no bloqueante de promoción (requiere TALLER autenticado, no filtra PII ni muta el registro). Fix propuesto en §5.2. **Decisión de Gerardo.**
 3. **Confirmaciones de negocio (pendientes, no son bugs):** (a) ¿ESTADO debe ver PII de contacto (§4.4)? (b) ¿la exclusión de ADMIN en `configuracion-niveles/[id]`/`preview` es deliberada o un descuido? (c) ¿`CONTENIDO` con permisos de RAG y colecciones es intencional?
 
 > **TODO rastreable (ref §8.3.b + §5.1):** `PUT /api/estado/configuracion-niveles/[id]` y `POST .../preview` excluyen ADMIN (`requiereRolApi(['ESTADO'])`), a diferencia del resto de `/api/estado/*`. El test `src/__tests__/k-02-auth-matrix.test.ts` **fotografía** el comportamiento real (`ADMIN→403`) con comentario que apunta a esta sección. **Si la decisión es incluir ADMIN:** cambiar el endpoint y el test juntos (el test fallará y recordará actualizarlo). Decisión post-promoción.
 
 ### Plan restante del bloque K
 - **K-02 tanda 1 — ✅ HECHA (#415, `39159eb`, 2026-06-12).** Helper reutilizable `authMatrix` (`src/__tests__/_helpers/auth-matrix.ts`) + 20 endpoints de auth-por-rol cubiertos, 110 tests (ver §5.1). CI verde. Sin cambios de comportamiento.
-- **K-02 tanda 2 — ⏳ pendiente (matriz IDOR).** Endpoints cuyo 200 depende de **pertenencia**, no solo de rol: `pedidos/[id]` (GET/PUT), `cotizaciones` (GET/PUT/`[id]`), `ordenes/[id]` (PUT), `validaciones/[id]` (PUT/signed-url/upload), `pedidos/[id]/invitaciones` (POST). Requieren matriz owner-vs-no-owner (no la matriz de rol de la tanda 1). Extender `authMatrix` o un helper hermano que parametrice ownership.
+- **K-02 tanda 2 — ✅ HECHA (matriz IDOR, §5.2).** Helper hermano `ownershipMatrix` + 12 recursos cubiertos. **Hallazgo: C5** (`upload/imagenes` contexto `cotizacion`, IDOR de escritura — ver §5.2). El resto de los recursos con ownership bloquean correctamente al no-owner (403). **NO se corrigió ningún endpoint.**
 - **K-05:** `select` explícito en los ~17 endpoints de §4.1. **Reevaluar** ahí si los GET de `/api/marcas/[id]` y `/api/talleres/[id]` (código muerto, §6.8) se eliminan en vez de mantenerse protegidos.
 - **Barrido de rate-limit:** C4 (`/api/exportar`) + los faltantes de §4.3.
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,11 @@
 ## 2026-06-12
 
 ### Gerardo Breard
+- **16:27** `9fe8b60` — test(k-02): tanda 2 matriz IDOR (ownership) + hallazgo C5
+  - `.claude/specs/v4-k-01-auditoria-endpoints.md`
+  - `src/__tests__/_helpers/auth-matrix.ts`
+  - `src/__tests__/k-02-idor-matrix.test.ts`
+
 - **15:14** `db4a619` — docs(k-02): tanda 1 hecha (#415); plan explicito de tanda 2 (matriz IDOR)
   - `.claude/specs/v4-k-01-auditoria-endpoints.md`
 

--- a/src/__tests__/_helpers/auth-matrix.ts
+++ b/src/__tests__/_helpers/auth-matrix.ts
@@ -181,3 +181,91 @@ export function publicMatrix(
     expect(res.status).toBe(successStatus)
   })
 }
+
+// ─── K-02 tanda 2 — matriz IDOR (ownership: owner vs no-owner) ────────────────
+//
+// El recurso es el MISMO en todos los casos; lo que cambia es la IDENTIDAD de
+// la sesion. El caso CRITICO es el "no-owner" (mismo rol, otra identidad): si
+// muta/lee el recurso ajeno, es IDOR. `ownershipMatrix` necesita inyectar
+// sesiones con id explicito (owner-1 vs intruder-1), por eso su `deps` recibe
+// `setSession(sessionObject | null)` (firma distinta a la de authMatrix).
+
+export type OwnerSuccess = number | 'passes-ownership'
+
+export interface OwnershipSpec {
+  importer: () => Promise<Record<string, unknown>>
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+  url: string
+  params?: Record<string, string>
+  body?: unknown
+  /** Rol del dueño legitimo del recurso. */
+  ownerRole: Rol
+  /** Id de usuario que figura como dueño en el recurso mockeado. */
+  ownerId: string
+  /** Rol del intruso (default = ownerRole: mismo rol, otra identidad). */
+  intruderRole?: Rol
+  /** Id del intruso (distinto de ownerId). */
+  intruderId?: string
+  /** Roles con acceso transversal legitimo (ADMIN/ESTADO segun el endpoint). */
+  transversal?: Rol[]
+  /** Status esperado para el intruso: 403 (revela existencia) o 404 (no la revela). */
+  nonOwnerStatus: 403 | 404
+  /** Exito del dueño: status exacto, o 'passes-ownership' (no 401/403) si el 200 exige fixtures pesados. */
+  ownerSuccess: OwnerSuccess
+  /** Monta el recurso en el proxy de prisma (mismo recurso para todos los casos). */
+  setup?: () => void
+}
+
+interface OwnershipDeps {
+  setSession: (session: { user: Record<string, unknown> } | null) => void
+}
+
+/**
+ * Genera la matriz IDOR de un endpoint:
+ *   anonimo -> 401
+ *   owner (rol correcto, su recurso) -> ownerSuccess
+ *   no-owner (mismo rol, otra identidad) -> nonOwnerStatus   ← el caso IDOR
+ *   transversal (ADMIN/ESTADO) -> NO 403
+ * Debe llamarse dentro de un `describe(...)`.
+ */
+export function ownershipMatrix(spec: OwnershipSpec, deps: OwnershipDeps) {
+  const intruderRole = spec.intruderRole ?? spec.ownerRole
+  const intruderId = spec.intruderId ?? 'intruder-1'
+  const transversal = spec.transversal ?? []
+
+  it('anonimo -> 401', async () => {
+    deps.setSession(null)
+    spec.setup?.()
+    const res = await invoke(spec as AuthMatrixSpec)
+    expect(res.status).toBe(401)
+  })
+
+  it(`owner (${spec.ownerRole}, su recurso) -> ${spec.ownerSuccess}`, async () => {
+    deps.setSession(makeSession(spec.ownerRole, spec.ownerId))
+    spec.setup?.()
+    const res = await invoke(spec as AuthMatrixSpec)
+    if (typeof spec.ownerSuccess === 'number') {
+      expect(res.status).toBe(spec.ownerSuccess)
+    } else {
+      expect(res.status).not.toBe(401)
+      expect(res.status).not.toBe(403)
+    }
+  })
+
+  it(`no-owner (${intruderRole}, recurso ajeno) -> ${spec.nonOwnerStatus} [IDOR]`, async () => {
+    deps.setSession(makeSession(intruderRole, intruderId))
+    spec.setup?.()
+    const res = await invoke(spec as AuthMatrixSpec)
+    expect(res.status).toBe(spec.nonOwnerStatus)
+  })
+
+  for (const role of transversal) {
+    it(`${role} transversal -> no 403`, async () => {
+      deps.setSession(makeSession(role, `${role.toLowerCase()}-x`))
+      spec.setup?.()
+      const res = await invoke(spec as AuthMatrixSpec)
+      expect(res.status).not.toBe(401)
+      expect(res.status).not.toBe(403)
+    })
+  }
+}

--- a/src/__tests__/k-02-idor-matrix.test.ts
+++ b/src/__tests__/k-02-idor-matrix.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { ownershipMatrix, makePrismaMock, makeSession, type Rol } from './_helpers/auth-matrix'
+
+// ─── K-02 tanda 2 — matriz IDOR (ownership: owner vs no-owner) ────────────────
+//
+// Para cada endpoint cuyo 200 depende de PERTENENCIA (no solo de rol), el caso
+// crítico es el "no-owner": un usuario del mismo rol que intenta leer/mutar el
+// recurso de otro. SOLO tests: cero cambios de comportamiento.
+//
+// Convención 403/404 del proyecto (fotografiada): la mayoría de las rutas `[id]`
+// devuelven 404 si el recurso no existe y 403 si existe pero no sos el dueño
+// (revela existencia). `notificaciones` PUT es la excepción: 403 también para
+// inexistente (no revela). Ver §5.1 de la auditoría.
+
+const mockAuth = vi.fn()
+vi.mock('@/compartido/lib/auth', () => ({ auth: () => mockAuth() }))
+
+const mockPrisma = makePrismaMock()
+vi.mock('@/compartido/lib/prisma', () => ({ prisma: mockPrisma }))
+
+vi.mock('@/compartido/lib/log', () => ({ logActividad: vi.fn(), logAccionAdmin: vi.fn() }))
+vi.mock('@/compartido/lib/nivel', () => ({ aplicarNivel: vi.fn(), invalidarCacheNivel: vi.fn() }))
+vi.mock('@/compartido/lib/storage', () => ({ uploadFile: vi.fn().mockResolvedValue('https://x/up.jpg'), getSignedUrl: vi.fn().mockResolvedValue('https://x/signed') }))
+vi.mock('@/compartido/lib/ratelimit', () => ({ rateLimit: vi.fn().mockResolvedValue(null) }))
+vi.mock('@/compartido/lib/file-validation', () => ({
+  validarArchivo: vi.fn().mockResolvedValue({ valid: true }),
+  sanitizarNombreArchivo: vi.fn((n: string) => n),
+}))
+vi.mock('@/compartido/lib/email', () => ({
+  sendEmail: vi.fn(), buildInvitacionCotizarEmail: vi.fn(() => ({})), buildCertificadoEmail: vi.fn(() => ({})),
+}))
+vi.mock('@/compartido/lib/notificaciones', () => ({
+  notificarTalleresCompatibles: vi.fn(), notificarCotizacion: vi.fn(),
+}))
+
+const deps = { setSession: (s: { user: Record<string, unknown> } | null) => mockAuth.mockResolvedValue(s) }
+const m = (modelo: string) => (mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>)[modelo]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+// ─── pedidos/[id] (dueño = marca; taller asignado también lee) ────────────────
+
+describe('GET /api/pedidos/[id] — owner marca / ADMIN transversal', () => {
+  ownershipMatrix(
+    {
+      importer: () => import('@/app/api/pedidos/[id]/route'),
+      method: 'GET',
+      url: '/api/pedidos/p1',
+      params: { id: 'p1' },
+      ownerRole: 'MARCA',
+      ownerId: 'marca-owner',
+      transversal: ['ADMIN'],
+      nonOwnerStatus: 403,
+      ownerSuccess: 200,
+      setup: () => {
+        m('pedido').findUnique.mockResolvedValue({
+          id: 'p1', marca: { id: 'm1', nombre: 'M', userId: 'marca-owner' }, ordenes: [],
+        })
+      },
+    },
+    deps
+  )
+})
+
+describe('PUT /api/pedidos/[id] — muta: no-owner es el IDOR clásico', () => {
+  ownershipMatrix(
+    {
+      importer: () => import('@/app/api/pedidos/[id]/route'),
+      method: 'PUT',
+      url: '/api/pedidos/p1',
+      params: { id: 'p1' },
+      body: {}, // sin estado: cae al update final
+      ownerRole: 'MARCA',
+      ownerId: 'marca-owner',
+      transversal: ['ADMIN'],
+      nonOwnerStatus: 403,
+      ownerSuccess: 200,
+      setup: () => {
+        m('pedido').findUnique.mockResolvedValue({ marca: { userId: 'marca-owner' } })
+        m('pedido').update.mockResolvedValue({ id: 'p1' })
+      },
+    },
+    deps
+  )
+})
+
+// ─── cotizaciones/[id] PUT — ownership por acción ─────────────────────────────
+
+describe('PUT /api/cotizaciones/[id] ACEPTAR — owner marca / ADMIN transversal', () => {
+  ownershipMatrix(
+    {
+      importer: () => import('@/app/api/cotizaciones/[id]/route'),
+      method: 'PUT',
+      url: '/api/cotizaciones/cot1',
+      params: { id: 'cot1' },
+      body: { accion: 'ACEPTAR' },
+      ownerRole: 'MARCA',
+      ownerId: 'marca-owner',
+      transversal: ['ADMIN'],
+      nonOwnerStatus: 403,
+      ownerSuccess: 'passes-ownership', // estado != ENVIADA -> 400 (pasó ownership)
+      setup: () => {
+        m('cotizacion').findUnique.mockResolvedValue({
+          id: 'cot1', estado: 'ACEPTADA', pedidoId: 'p1', venceEn: new Date(0),
+          pedido: { omId: 'OM1', marca: { userId: 'marca-owner', nombre: 'M' } },
+          taller: { id: 't1', userId: 'taller-owner', nombre: 'T' },
+        })
+      },
+    },
+    deps
+  )
+})
+
+describe('PUT /api/cotizaciones/[id] RETIRAR — owner taller', () => {
+  ownershipMatrix(
+    {
+      importer: () => import('@/app/api/cotizaciones/[id]/route'),
+      method: 'PUT',
+      url: '/api/cotizaciones/cot1',
+      params: { id: 'cot1' },
+      body: { accion: 'RETIRAR' },
+      ownerRole: 'TALLER',
+      ownerId: 'taller-owner',
+      intruderId: 'intruder-taller',
+      transversal: ['ADMIN'],
+      nonOwnerStatus: 403,
+      ownerSuccess: 'passes-ownership',
+      setup: () => {
+        m('cotizacion').findUnique.mockResolvedValue({
+          id: 'cot1', estado: 'ACEPTADA', pedidoId: 'p1', venceEn: new Date(0),
+          pedido: { omId: 'OM1', marca: { userId: 'marca-owner', nombre: 'M' } },
+          taller: { id: 't1', userId: 'taller-owner', nombre: 'T' },
+        })
+      },
+    },
+    deps
+  )
+})
+
+// ─── ordenes/[id] PUT — solo taller asignado o ADMIN ──────────────────────────
+
+describe('PUT /api/ordenes/[id] — owner taller asignado / ADMIN transversal', () => {
+  ownershipMatrix(
+    {
+      importer: () => import('@/app/api/ordenes/[id]/route'),
+      method: 'PUT',
+      url: '/api/ordenes/o1',
+      params: { id: 'o1' },
+      body: {},
+      ownerRole: 'TALLER',
+      ownerId: 'taller-owner',
+      intruderId: 'intruder-taller',
+      transversal: ['ADMIN'],
+      nonOwnerStatus: 403,
+      ownerSuccess: 200,
+      setup: () => {
+        m('ordenManufactura').findUnique.mockResolvedValue({ id: 'o1', estado: 'PENDIENTE', pedidoId: 'p1', taller: { userId: 'taller-owner' } })
+        m('ordenManufactura').update.mockResolvedValue({ id: 'o1' })
+        m('ordenManufactura').findMany.mockResolvedValue([])
+        m('pedido').update.mockResolvedValue({})
+      },
+    },
+    deps
+  )
+})
+
+// ─── validaciones/[id] PUT — transversal ESTADO (NO ADMIN) ────────────────────
+
+describe('PUT /api/validaciones/[id] — owner taller / transversal SOLO ESTADO', () => {
+  const setup = () => {
+    m('validacion').findUnique.mockResolvedValue({ id: 'v1', estado: 'NO_INICIADO', tallerId: 't1', taller: { userId: 'taller-owner' } })
+    m('validacion').update.mockResolvedValue({ id: 'v1' })
+  }
+  ownershipMatrix(
+    {
+      importer: () => import('@/app/api/validaciones/[id]/route'),
+      method: 'PUT',
+      url: '/api/validaciones/v1',
+      params: { id: 'v1' },
+      body: {},
+      ownerRole: 'TALLER',
+      ownerId: 'taller-owner',
+      intruderId: 'intruder-taller',
+      transversal: ['ESTADO'],
+      nonOwnerStatus: 403,
+      ownerSuccess: 200,
+      setup,
+    },
+    deps
+  )
+
+  // FOTOGRAFÍA: a diferencia de otras rutas, ADMIN NO es transversal aquí
+  // (solo ESTADO u owner). Un ADMIN que no es dueño recibe 403.
+  it('ADMIN no-owner -> 403 (ADMIN no es transversal en validaciones)', async () => {
+    deps.setSession(makeSession('ADMIN', 'admin-1'))
+    setup()
+    const { PUT } = await import('@/app/api/validaciones/[id]/route')
+    const res = await PUT(
+      new NextRequest(new URL('/api/validaciones/v1', 'http://localhost'), { method: 'PUT', body: '{}', headers: { 'content-type': 'application/json' } }),
+      { params: Promise.resolve({ id: 'v1' }) } as never
+    )
+    expect(res.status).toBe(403)
+  })
+})
+
+// ─── validaciones/[id]/signed-url GET — transversal ADMIN + ESTADO ────────────
+
+describe('GET /api/validaciones/[id]/signed-url — owner / ADMIN / ESTADO', () => {
+  ownershipMatrix(
+    {
+      importer: () => import('@/app/api/validaciones/[id]/signed-url/route'),
+      method: 'GET',
+      url: '/api/validaciones/v1/signed-url',
+      params: { id: 'v1' },
+      ownerRole: 'TALLER',
+      ownerId: 'taller-owner',
+      intruderId: 'intruder-taller',
+      transversal: ['ADMIN', 'ESTADO'],
+      nonOwnerStatus: 403,
+      ownerSuccess: 200,
+      setup: () => {
+        m('validacion').findUnique.mockResolvedValue({ id: 'v1', documentoUrl: 'https://x/doc.pdf', taller: { userId: 'taller-owner' } })
+      },
+    },
+    deps
+  )
+})
+
+// ─── validaciones/[id]/upload POST — owner ONLY (ni ADMIN ni ESTADO) ──────────
+
+describe('POST /api/validaciones/[id]/upload — solo owner (no transversal)', () => {
+  ownershipMatrix(
+    {
+      importer: () => import('@/app/api/validaciones/[id]/upload/route'),
+      method: 'POST',
+      url: '/api/validaciones/v1/upload',
+      params: { id: 'v1' },
+      body: {}, // sin file -> el owner pasa ownership y luego falla por archivo (no es 401/403)
+      ownerRole: 'TALLER',
+      ownerId: 'taller-owner',
+      intruderId: 'intruder-taller',
+      transversal: [],
+      nonOwnerStatus: 403,
+      ownerSuccess: 'passes-ownership',
+      setup: () => {
+        m('validacion').findUnique.mockResolvedValue({ id: 'v1', estado: 'NO_INICIADO', tallerId: 't1', taller: { userId: 'taller-owner' } })
+      },
+    },
+    deps
+  )
+})
+
+// ─── pedidos/[id]/invitaciones POST — owner marca / ADMIN transversal ─────────
+
+describe('POST /api/pedidos/[id]/invitaciones — owner marca / ADMIN', () => {
+  ownershipMatrix(
+    {
+      importer: () => import('@/app/api/pedidos/[id]/invitaciones/route'),
+      method: 'POST',
+      url: '/api/pedidos/p1/invitaciones',
+      params: { id: 'p1' },
+      body: { tallerIds: ['t1'] },
+      ownerRole: 'MARCA',
+      ownerId: 'marca-owner',
+      transversal: ['ADMIN'],
+      nonOwnerStatus: 403,
+      ownerSuccess: 'passes-ownership', // estado PUBLICADO != BORRADOR -> 400 (pasó ownership)
+      setup: () => {
+        m('pedido').findUnique.mockResolvedValue({ id: 'p1', estado: 'PUBLICADO', tipoPrenda: 'X', cantidad: 1, marca: { userId: 'marca-owner', nombre: 'M' } })
+      },
+    },
+    deps
+  )
+})
+
+// ─── notificaciones PUT — IDOR de notificación; convención 403-para-inexistente
+
+describe('PUT /api/notificaciones — owner / no-owner (403 incluso si no existe)', () => {
+  const setup = () => {
+    m('notificacion').findUnique.mockResolvedValue({ userId: 'notif-owner' })
+    m('notificacion').update.mockResolvedValue({ id: 'n1', leida: true })
+  }
+  ownershipMatrix(
+    {
+      importer: () => import('@/app/api/notificaciones/route'),
+      method: 'PUT',
+      url: '/api/notificaciones',
+      body: { id: 'n1' },
+      ownerRole: 'TALLER',
+      ownerId: 'notif-owner',
+      intruderId: 'intruder-1',
+      transversal: [], // ni ADMIN: cualquiera solo toca sus propias notificaciones
+      nonOwnerStatus: 403,
+      ownerSuccess: 200,
+      setup,
+    },
+    deps
+  )
+
+  // FOTOGRAFÍA de convención: notificación inexistente -> 403 (no revela existencia),
+  // a diferencia de pedidos/cotizaciones/validaciones que dan 404.
+  it('notificación inexistente -> 403 (no 404: no revela existencia)', async () => {
+    deps.setSession(makeSession('TALLER', 'cualquiera'))
+    m('notificacion').findUnique.mockResolvedValue(null)
+    const { PUT } = await import('@/app/api/notificaciones/route')
+    const res = await PUT(
+      new NextRequest(new URL('/api/notificaciones', 'http://localhost'), { method: 'PUT', body: JSON.stringify({ id: 'no-existe' }), headers: { 'content-type': 'application/json' } })
+    )
+    expect(res.status).toBe(403)
+  })
+})
+
+// ─── upload/imagenes — LA excepción de la auditoría (§6.3): contexto cotizacion
+//     no ata entityId al caller. Tests bespoke (formData) que FOTOGRAFÍAN el gap.
+
+describe('POST /api/upload/imagenes — ownership por contexto', () => {
+  function uploadReq(contexto: string, entityId: string) {
+    const fd = new FormData()
+    fd.append('file', new File([new Uint8Array([0xff, 0xd8, 0xff])], 'x.jpg', { type: 'image/jpeg' }))
+    fd.append('contexto', contexto)
+    fd.append('entityId', entityId)
+    return new NextRequest(new URL('/api/upload/imagenes', 'http://localhost'), { method: 'POST', body: fd })
+  }
+  async function post(req: NextRequest) {
+    const { POST } = await import('@/app/api/upload/imagenes/route')
+    return POST(req)
+  }
+
+  it('anónimo -> 401', async () => {
+    deps.setSession(null)
+    expect((await post(uploadReq('portfolio', 'taller-x'))).status).toBe(401)
+  })
+
+  it('portfolio: entityId NO propio -> 403 (patrón seguro, ata entityId al caller)', async () => {
+    deps.setSession(makeSession('TALLER', 'attacker'))
+    m('taller').findFirst.mockResolvedValue(null) // no hay taller {id:entityId, userId:attacker}
+    const res = await post(uploadReq('portfolio', 'victim-taller'))
+    expect(res.status).toBe(403)
+  })
+
+  it('portfolio: entityId propio -> 200 (dueño legítimo)', async () => {
+    deps.setSession(makeSession('TALLER', 'owner'))
+    m('taller').findFirst.mockResolvedValue({ id: 'mi-taller', userId: 'owner' })
+    const res = await post(uploadReq('portfolio', 'mi-taller'))
+    expect(res.status).toBe(200)
+  })
+
+  // ⚠⚠ HALLAZGO IDOR (auditoría §6.3, confirmado): el contexto 'cotizacion' NO
+  // usa entityId — solo chequea que el caller posea ALGÚN taller. Un taller
+  // cualquiera puede escribir un objeto bajo la carpeta de una cotización ajena.
+  // El test FOTOGRAFÍA el comportamiento ACTUAL (200). El comportamiento SEGURO
+  // sería 403 si entityId no pertenece al caller. NO se corrige de oficio:
+  // reportado para decisión (ver §5.1 / hallazgo K-02-IDOR).
+  it('cotizacion: entityId AJENO -> 200 [IDOR confirmado: entityId no atado al caller]', async () => {
+    deps.setSession(makeSession('TALLER', 'attacker'))
+    m('taller').findFirst.mockResolvedValue({ id: 'attacker-taller', userId: 'attacker' }) // posee SU taller
+    const res = await post(uploadReq('cotizacion', 'cotizacion-de-otra-marca'))
+    // Comportamiento actual = 200 (vulnerable). Si se arregla a 403, actualizar este test.
+    expect(res.status).toBe(200)
+  })
+})


### PR DESCRIPTION
## K-02 tanda 2 — matriz IDOR (Bloque K, MVP)

Segunda tanda de K-02: ownership (owner vs no-owner) sobre los endpoints cuyo 200 depende de **pertenencia**, no solo de rol. **SOLO tests: cero cambios de comportamiento** (paquete funcional de develop idéntico para el smoke de Sergio).

### Qué trae
- **Helper hermano** `ownershipMatrix` (en `_helpers/auth-matrix.ts`): por recurso genera `anónimo→401 / owner→2xx / no-owner mismo-rol→403|404 / transversal→no-403`. El recurso mockeado es el mismo; cambia la identidad de la sesión.
- **12 recursos cubiertos:** `pedidos/[id]` GET+PUT, `cotizaciones/[id]` PUT (ACEPTAR/RETIRAR), `ordenes/[id]` PUT, `validaciones/[id]` PUT+signed-url+upload, `pedidos/[id]/invitaciones` POST, `notificaciones` PUT, `upload/imagenes` (portfolio/pedido/cotizacion).
- **Auditoría §5.2** con la matriz, la convención 403/404 y el hallazgo.

### ⚠ Hallazgo C5 (el punto importante)
**`POST /api/upload/imagenes` contexto `cotizacion` es un IDOR de escritura confirmado.** Los contextos `portfolio`/`pedido` atan `entityId` al caller; `cotizacion` (route.ts:77-84) solo chequea "¿el caller posee algún taller?" y **nunca usa `entityId`** → cualquier TALLER autenticado puede escribir un objeto bajo el namespace de una cotización ajena.

- **Severidad MEDIA, no bloqueante de promoción por sí sola:** requiere TALLER autenticado (no anónimo), **no filtra PII** ni **muta el registro** de la cotización (solo escribe un objeto-imagen validado en storage; el `{url}` vuelve al atacante, no se adjunta a la cotización ajena). Impacto = abuso de almacenamiento / inyección en namespace ajeno.
- **Ya estaba documentado** como excepción 🟡 en §6.3; K-02 lo confirma y lo eleva a **C5**.
- El test **fotografía** el `200` actual con comentario `[IDOR confirmado]`. **NO se corrigió de oficio** — fix propuesto en §5.2, decisión de Gerardo.

El resto de los recursos con ownership **bloquean correctamente** al no-owner (403). Convención 403/404 fotografiada en §5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)