### PR TITLE
docs(k): squash SHA de C5 (#418) + estado final del bloque K

### DIFF
--- a/.claude/specs/v4-k-01-auditoria-endpoints.md
+++ b/.claude/specs/v4-k-01-auditoria-endpoints.md
@@ -342,7 +342,7 @@ Helper hermano `ownershipMatrix` (mismo archivo `_helpers/auth-matrix.ts`): para
 - **Archivo:** `src/app/api/upload/imagenes/route.ts` (rama `cotizacion`).
 - **Qué pasaba:** los contextos `portfolio` y `pedido` atan el `entityId` al caller. El contexto **`cotizacion` NO usaba `entityId`** — solo chequeaba `taller.findFirst({ where: { userId } })` ("¿el caller posee algún taller?"). Cualquier TALLER autenticado podía subir un objeto validado (imagen) a la ruta `cotizacion/<entityId-ajeno>/...` de cualquier pedido.
 - **Semántica del hallazgo (clave para el fix):** el `entityId` de este contexto es el **`pedidoId`** que el taller está cotizando (ver `src/taller/componentes/cotizar-form.tsx:32`), y la imagen se sube **antes** de crear la cotización. Por eso el gate correcto no es *ownership* de una cotización (no existe aún) sino **elegibilidad para cotizar el pedido**.
-- **✅ RESUELTO (diseño A — elegibilidad, decisión de Gerardo, PR (squash SHA al mergear)):** se extrajo el criterio de elegibilidad de `POST /api/cotizaciones` a `elegibilidadCotizar(callerUserId, tallerId, pedidoId)` en `src/compartido/lib/cotizaciones.ts` (pedido existe + no-propio + `PUBLICADO` + invitación si `INVITACION`). `POST /api/cotizaciones` ahora la usa (refactor sin cambio de comportamiento; sus tests `acceso-verificado.test.ts` siguen verdes sin tocarse). La rama `cotizacion` del upload resuelve `entityId` como pedidoId y aplica `elegibilidadCotizar` → no elegible **403**. Es **elegibilidad, no ownership** — el taller no posee el pedido.
+- **✅ RESUELTO (diseño A — elegibilidad, decisión de Gerardo, #418, `b1f58d8`):** se extrajo el criterio de elegibilidad de `POST /api/cotizaciones` a `elegibilidadCotizar(callerUserId, tallerId, pedidoId)` en `src/compartido/lib/cotizaciones.ts` (pedido existe + no-propio + `PUBLICADO` + invitación si `INVITACION`). `POST /api/cotizaciones` ahora la usa (refactor sin cambio de comportamiento; sus tests `acceso-verificado.test.ts` siguen verdes sin tocarse). La rama `cotizacion` del upload resuelve `entityId` como pedidoId y aplica `elegibilidadCotizar` → no elegible **403**. Es **elegibilidad, no ownership** — el taller no posee el pedido.
 - **Test:** `k-02-idor-matrix.test.ts` des-fotografiado: el caso no-elegible pasa de `200` a **403**; se sumó el caso positivo (taller elegible → **200**, flujo legítimo intacto). `cotizaciones-elegibilidad.test.ts` cubre el contrato de la función compartida.
 
 ---
@@ -383,9 +383,22 @@ Los 5 testigos conocidos fueron encontrados y clasificados correctamente:
 
 ## 8. Decisiones de Gerardo
 
+### Estado final del bloque K (2026-06-12)
+
+| Ítem | Estado | Ref |
+|---|---|---|
+| C1/C2/C3 (fugas anónimas PII + answer-key) | ✅ RESUELTO | #414 `0758fad` |
+| K-02 tanda 1 (matriz auth-por-rol, 401/403/200) | ✅ HECHA | #415 `39159eb` |
+| K-02 tanda 2 (matriz IDOR, ownership) | ✅ HECHA | #417 `cb731e8` |
+| C5 (IDOR escritura upload/imagenes cotizacion) | ✅ RESUELTO | #418 `b1f58d8` |
+| C4 (`/api/exportar` sin rate-limit) | ⏳ pendiente | barrido rate-limit |
+| K-05 (~17 selects explícitos de §4.1) | ⏳ pendiente | — |
+| Barrido rate-limit (C4 + faltantes §4.3) | ⏳ pendiente | — |
+| Decisión ADMIN/`configuracion-niveles` (§8.3.b) | ⏳ decisión Sergio/negocio | test fotografiado |
+
 1. **Hotfix de C1/C2/C3 — ✅ RESUELTO (#414, `0758fad`, 2026-06-11).** Se cerraron los 3 críticos con auth + select, scope quirúrgico, antes de K-02. La matriz 401/403/200 de K-02 ya parte del estado correcto (test de regresión `src/__tests__/k-01-criticos.test.ts`).
 2. **C4 (`/api/exportar` sin rate-limit) — ⏳ plan bloque K.** Queda para el barrido de rate-limit (§4.3): añadir `rateLimit('exportar')` + whitelist de `tipo`.
-2bis. **C5 (`/api/upload/imagenes` contexto `cotizacion`, IDOR de escritura) — ✅ RESUELTO (diseño A — elegibilidad, PR (squash SHA al mergear)).** Gate por `elegibilidadCotizar` (fuente única compartida con `POST /api/cotizaciones`). Ver §5.2.
+2bis. **C5 (`/api/upload/imagenes` contexto `cotizacion`, IDOR de escritura) — ✅ RESUELTO (diseño A — elegibilidad, #418, `b1f58d8`).** Gate por `elegibilidadCotizar` (fuente única compartida con `POST /api/cotizaciones`). Ver §5.2.
 3. **Confirmaciones de negocio (pendientes, no son bugs):** (a) ¿ESTADO debe ver PII de contacto (§4.4)? (b) ¿la exclusión de ADMIN en `configuracion-niveles/[id]`/`preview` es deliberada o un descuido? (c) ¿`CONTENIDO` con permisos de RAG y colecciones es intencional?
 
 > **TODO rastreable (ref §8.3.b + §5.1):** `PUT /api/estado/configuracion-niveles/[id]` y `POST .../preview` excluyen ADMIN (`requiereRolApi(['ESTADO'])`), a diferencia del resto de `/api/estado/*`. El test `src/__tests__/k-02-auth-matrix.test.ts` **fotografía** el comportamiento real (`ADMIN→403`) con comentario que apunta a esta sección. **Si la decisión es incluir ADMIN:** cambiar el endpoint y el test juntos (el test fallará y recordará actualizarlo). Decisión post-promoción.


### PR DESCRIPTION
Housekeeping post-merge de #418 (cierre de C5). **Doc-only.**

- Completa el squash SHA real de C5: **#418 `b1f58d8`** (reemplaza el marcador "squash SHA al mergear", igual que se hizo con C1/C2/C3).
- **§8 — tabla de estado final del bloque K:**
  - ✅ C1/C2/C3 (#414), K-02 tanda 1 (#415), K-02 tanda IDOR (#417), C5 (#418).
  - ⏳ Pendiente: K-05 (~17 selects de §4.1), barrido rate-limit (C4 + faltantes §4.3), decisión ADMIN/`configuracion-niveles` (negocio/Sergio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)