### PR TITLE
feat(backfill): --exclude para la cuenta de smoke (condicion de Sergio)

### DIFF
--- a/prisma/validaciones-helper.ts
+++ b/prisma/validaciones-helper.ts
@@ -31,3 +31,60 @@ export function buildValidacionesFaltantes(
       estado: 'NO_INICIADO' as const,
     }))
 }
+
+// ── Exclusión de talleres del backfill (condición de Sergio: cuenta de smoke intocable)
+
+// Parsea el flag --exclude del argv. Acepta forma repetible y CSV, con o sin '=':
+//   --exclude a@x.com --exclude b@y.com
+//   --exclude a@x.com,b@y.com
+//   --exclude=a@x.com,b@y.com
+// Normaliza a lowercase, trimea, descarta vacíos y deduplica.
+export function parseExcludeEmails(argv: string[]): string[] {
+  const out: string[] = []
+  const push = (csv: string) => {
+    for (const part of csv.split(',')) {
+      const email = part.trim().toLowerCase()
+      if (email) out.push(email)
+    }
+  }
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--exclude') {
+      const val = argv[i + 1]
+      if (val && !val.startsWith('--')) {
+        push(val)
+        i++ // consumir el valor
+      }
+    } else if (arg.startsWith('--exclude=')) {
+      push(arg.slice('--exclude='.length))
+    }
+  }
+  return [...new Set(out)]
+}
+
+export type TallerConEmail = { id: string; nombre: string; userEmail: string | null }
+
+// Particiona los talleres en incluidos (entran al backfill) y excluidos (cuenta de
+// smoke u otros), comparando el email del user dueño contra la lista de --exclude.
+// Comparación case-insensitive. Reporta también qué emails de la lista no matchearon
+// ningún taller (para detectar typos antes del --apply).
+export function particionarExcluidos(
+  talleres: TallerConEmail[],
+  excludeEmails: string[],
+): { incluidos: TallerConEmail[]; excluidos: TallerConEmail[]; sinMatch: string[] } {
+  const set = new Set(excludeEmails.map((e) => e.toLowerCase()))
+  const incluidos: TallerConEmail[] = []
+  const excluidos: TallerConEmail[] = []
+  const matcheados = new Set<string>()
+  for (const t of talleres) {
+    const email = t.userEmail?.toLowerCase() ?? null
+    if (email && set.has(email)) {
+      excluidos.push(t)
+      matcheados.add(email)
+    } else {
+      incluidos.push(t)
+    }
+  }
+  const sinMatch = [...set].filter((e) => !matcheados.has(e))
+  return { incluidos, excluidos, sinMatch }
+}

--- a/scripts/u05-backfill-validaciones.ts
+++ b/scripts/u05-backfill-validaciones.ts
@@ -21,9 +21,18 @@
 //   ALLOW_PROD=1 npx tsx scripts/u05-backfill-validaciones.ts            # dry-run contra prod (dimensionar)
 //   npx tsx scripts/u05-backfill-validaciones.ts --apply    # aplica en dev
 //   ALLOW_PROD=1 npx tsx scripts/u05-backfill-validaciones.ts --apply    # aplica en prod (deliberado)
+//
+// Exclusión (condición de Sergio: cuenta de smoke intocable). Repetible o CSV, en
+// dry-run y en --apply. Omite del backfill los talleres cuyo user tenga ese email:
+//   ...u05-backfill-validaciones.ts --exclude smoke@ejemplo.com
+//   ...u05-backfill-validaciones.ts --exclude a@x.com,b@y.com --apply
 
 import { PrismaClient } from '@prisma/client'
-import { buildValidacionesFaltantes } from '../prisma/validaciones-helper'
+import {
+  buildValidacionesFaltantes,
+  parseExcludeEmails,
+  particionarExcluidos,
+} from '../prisma/validaciones-helper'
 
 const PROD_REF = 'nefbhacmjrzynnhvgfnl' // ref de prod, ver scripts/check-db-ref.ts
 const dbUrl = process.env.DATABASE_URL ?? ''
@@ -36,6 +45,7 @@ if (isProd) console.warn('⚠️  ALLOW_PROD=1 — operando contra PROD delibera
 
 const prisma = new PrismaClient()
 const apply = process.argv.includes('--apply')
+const excludeEmails = parseExcludeEmails(process.argv)
 
 async function main() {
   const tiposActivos = await prisma.tipoDocumento.findMany({
@@ -44,16 +54,35 @@ async function main() {
   })
   console.log(`\n📋 U-05 backfill validaciones (${apply ? 'APPLY' : 'dry-run'}) — ${tiposActivos.length} tipos activos\n`)
 
-  const talleres = await prisma.taller.findMany({
-    select: { id: true, nombre: true, validaciones: { select: { tipo: true } } },
+  const talleresRaw = await prisma.taller.findMany({
+    select: {
+      id: true,
+      nombre: true,
+      user: { select: { email: true } },
+      validaciones: { select: { tipo: true } },
+    },
   })
+
+  // Aplicar exclusiones (cuenta de smoke u otras). Excluidos quedan fuera del universo
+  // tanto en dry-run como en --apply.
+  const { incluidos, excluidos, sinMatch } = particionarExcluidos(
+    talleresRaw.map((t) => ({ id: t.id, nombre: t.nombre, userEmail: t.user?.email ?? null })),
+    excludeEmails,
+  )
+  for (const ex of excluidos) console.log(`  EXCLUIDO: ${ex.userEmail} (${ex.nombre} / ${ex.id})`)
+  for (const e of sinMatch) console.warn(`  ⚠️  --exclude ${e}: ningún taller con ese email (¿typo?)`)
+  if (excludeEmails.length) console.log('')
+
+  const validacionesPorTaller = new Map(talleresRaw.map((t) => [t.id, t.validaciones]))
+  const talleres = incluidos
 
   let talleresTocados = 0
   let validacionesCreadas = 0
 
   for (const t of talleres) {
     // Misma definición que el seed (buildValidacionesFaltantes): dedupe por (tallerId, tipo).
-    const faltantes = buildValidacionesFaltantes(tiposActivos, new Set(t.validaciones.map((v) => v.tipo)), t.id)
+    const existentes = validacionesPorTaller.get(t.id) ?? []
+    const faltantes = buildValidacionesFaltantes(tiposActivos, new Set(existentes.map((v) => v.tipo)), t.id)
     if (!faltantes.length) continue
 
     talleresTocados++

--- a/src/__tests__/u05-exclude.test.ts
+++ b/src/__tests__/u05-exclude.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { parseExcludeEmails, particionarExcluidos, type TallerConEmail } from '../../prisma/validaciones-helper'
+
+describe('parseExcludeEmails — flag --exclude del backfill', () => {
+  it('forma repetible: --exclude a --exclude b', () => {
+    expect(parseExcludeEmails(['--exclude', 'a@x.com', '--exclude', 'b@y.com'])).toEqual([
+      'a@x.com',
+      'b@y.com',
+    ])
+  })
+
+  it('forma CSV: --exclude a,b', () => {
+    expect(parseExcludeEmails(['--exclude', 'a@x.com,b@y.com'])).toEqual(['a@x.com', 'b@y.com'])
+  })
+
+  it('forma con = : --exclude=a,b', () => {
+    expect(parseExcludeEmails(['--exclude=a@x.com,b@y.com'])).toEqual(['a@x.com', 'b@y.com'])
+  })
+
+  it('mezcla repetible + CSV + =', () => {
+    expect(
+      parseExcludeEmails(['--exclude', 'a@x.com', '--exclude=b@y.com,c@z.com']),
+    ).toEqual(['a@x.com', 'b@y.com', 'c@z.com'])
+  })
+
+  it('normaliza a lowercase y trimea', () => {
+    expect(parseExcludeEmails(['--exclude', '  A@X.COM , b@Y.com '])).toEqual([
+      'a@x.com',
+      'b@y.com',
+    ])
+  })
+
+  it('deduplica', () => {
+    expect(parseExcludeEmails(['--exclude', 'a@x.com', '--exclude', 'A@X.com'])).toEqual([
+      'a@x.com',
+    ])
+  })
+
+  it('convive con --apply sin tragárselo como valor', () => {
+    expect(parseExcludeEmails(['--apply', '--exclude', 'a@x.com'])).toEqual(['a@x.com'])
+    expect(parseExcludeEmails(['--exclude', '--apply'])).toEqual([])
+  })
+
+  it('sin flag o flag sin valor -> []', () => {
+    expect(parseExcludeEmails(['--apply'])).toEqual([])
+    expect(parseExcludeEmails(['--exclude'])).toEqual([])
+    expect(parseExcludeEmails([])).toEqual([])
+  })
+})
+
+describe('particionarExcluidos — saca los talleres de la cuenta de smoke', () => {
+  const talleres: TallerConEmail[] = [
+    { id: 't1', nombre: 'Taller Uno', userEmail: 'uno@x.com' },
+    { id: 't2', nombre: 'Taller Smoke', userEmail: 'smoke@sergio.com' },
+    { id: 't3', nombre: 'Sin Email', userEmail: null },
+  ]
+
+  it('excluye por email (case-insensitive) y deja el resto', () => {
+    const { incluidos, excluidos } = particionarExcluidos(talleres, ['SMOKE@sergio.com'])
+    expect(excluidos.map((t) => t.id)).toEqual(['t2'])
+    expect(incluidos.map((t) => t.id)).toEqual(['t1', 't3'])
+  })
+
+  it('userEmail null nunca se excluye', () => {
+    const { excluidos } = particionarExcluidos(talleres, ['uno@x.com'])
+    expect(excluidos.map((t) => t.id)).toEqual(['t1'])
+  })
+
+  it('sin exclusiones: todos incluidos', () => {
+    const { incluidos, excluidos, sinMatch } = particionarExcluidos(talleres, [])
+    expect(incluidos).toHaveLength(3)
+    expect(excluidos).toHaveLength(0)
+    expect(sinMatch).toEqual([])
+  })
+
+  it('reporta emails de --exclude que no matchean ningún taller (typo)', () => {
+    const { excluidos, sinMatch } = particionarExcluidos(talleres, [
+      'smoke@sergio.com',
+      'noexiste@x.com',
+    ])
+    expect(excluidos.map((t) => t.id)).toEqual(['t2'])
+    expect(sinMatch).toEqual(['noexiste@x.com'])
+  })
+})


### PR DESCRIPTION
Cierra la **decisión 1** del runbook de promoción (#420): el backfill de validaciones D-02 (`scripts/u05-backfill-validaciones.ts`) ahora puede **excluir la cuenta de smoke de Sergio** (y cualquier otra) del universo.

## Qué hace
- Flag `--exclude <email>` **repetible y CSV**, con o sin `=`: `--exclude a@x.com,b@y.com` o `--exclude a@x.com --exclude=b@y.com`.
- Aplica en **dry-run y en `--apply`**: los talleres de esos users quedan fuera del universo del backfill.
- Loguea `EXCLUIDO: <email>` por cada excluido y **avisa si un email no matchea** ningún taller (detecta typos antes del `--apply`).

## Cómo
- Helpers puros `parseExcludeEmails` / `particionarExcluidos` en `prisma/validaciones-helper.ts`.
- Unit test `src/__tests__/u05-exclude.test.ts` (parsing repetible/CSV/`=`/lowercase/dedupe/convivencia con `--apply`; partición case-insensitive, `userEmail` null nunca excluido, reporte de `sinMatch`).

Solo tooling de backfill. No toca prod ni el flujo de la app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)