### PR TITLE
docs: B-07 latente/baja — prod confirmado 0 certificados vigentes

### DIFF
--- a/.claude/DEUDA_TECNICA.md
+++ b/.claude/DEUDA_TECNICA.md
@@ -67,20 +67,22 @@ y prioridad sugerida.
   renderizar un objeto → error "Objects are not valid as a React child" (o muestra
   `[object Object]` según el path). El render correcto sería `resultado.taller.nombre`
   y `resultado.coleccion.titulo`.
-- **Por qué pasó desapercibido:** muy probablemente NO hay certificados emitidos aún
-  (la emisión requiere talleres pasando evaluaciones de academia), así que la rama de
-  éxito de la página nunca se ejercitó. **Pendiente confirmar el conteo en prod** (SQL
-  `SELECT count(*) FROM certificados;` — ver reporte de cierre del bloque K).
+- **Por qué pasó desapercibido:** NO hay certificados emitidos aún (la emisión requiere
+  talleres pasando evaluaciones de academia), así que la rama de éxito de la página nunca
+  se ejercitó. **Confirmado en prod (2026-06-13):** `SELECT count(*) FILTER (WHERE NOT
+  revocado) FROM certificados` → **0 vigentes**. → latente **sin impacto** hoy.
 - **Pre-existente:** sí — anterior a K-05. La Fase 1 de K-05 **preservó la forma exacta**
   de la respuesta (mismo sub-select de taller/coleccion), así que no introdujo ni agravó
   el bug; solo lo expuso al leer los callers.
-- **Impacto:** latente si hay 0 certificados; bug visible (página de verificación rota)
-  apenas exista 1 certificado emitido.
+- **Impacto:** ninguno mientras haya 0 certificados; la página de verificación se rompe
+  apenas exista **1** certificado emitido.
 - **Fix sugerido:** en `verificar/page.tsx`, tipar `taller`/`coleccion` como objetos y
   renderizar `.nombre`/`.titulo`. Fuera de scope de K-05 (es preexistente y de la página,
   no del endpoint).
-- **Prioridad:** media si prod tiene/tendrá certificados pronto; baja si el flujo de
-  academia no arranca en el piloto.
+- **Prioridad:** **baja** (latente, prod = 0 certificados vigentes confirmado).
+- **Trigger de arreglo:** cuando se construya/active el flujo de **emisión de certificados**,
+  arreglar `verificar/page.tsx` **ANTES de que existan filas** en `certificados` — apenas
+  se emita el primero, la página de verificación queda rota.
 
 ## Datos
 


### PR DESCRIPTION
Cierra el cabo suelto del bloque K: el conteo de certificados en prod.

**Confirmado en prod (2026-06-13):** 0 certificados vigentes → B-07 (bug latente de
`verificar/page.tsx`, tipa taller/coleccion como string pero recibe objeto) queda
**latente sin impacto / prioridad baja**, con trigger explícito: arreglar antes de
activar el flujo de emisión de certificados (apenas exista 1 fila, la página se rompe).

Solo toca `.claude/DEUDA_TECNICA.md`. No hay cambio de código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)