### PR TITLE
fix: consistencia de labels W-A (escalabilidad + organizacion + registro)

### DIFF
--- a/.claude/DEUDA_TECNICA.md
+++ b/.claude/DEUDA_TECNICA.md
@@ -161,18 +161,22 @@ _D-01 y D-02 resueltos en U-05 (#410) — ver sección "Resueltas"._
   en la práctica
 - **Estimación:** 1-2h (el cleanup hook es lo más limpio)
 
-### T-06: Sin e2e de W-A2–W-A5 (formulario del taller refactorizado)
+### T-06: Sin e2e del FLUJO de W-A2–W-A5 (formulario del taller refactorizado)
 - **Detectado en:** discovery W-A (2026-06-13, `v4-w-a-discovery.md`).
 - **Descripción:** el refactor del formulario `/taller/perfil/completar` (W-A) está
-  implementado y deployado, pero solo **W-A1** tiene e2e dedicado
-  (`tests/e2e/desglose-plantilla.spec.ts`). **W-A2–W-A5 no tienen cobertura e2e:**
-  opción "Organización mixta" + campo abierto, "Sin registro sistemático",
-  desdoblamiento de capacidad en 2 preguntas (disponibilidad + escalabilidad), y los
-  10 roles funcionales. No hay test que recorra el wizard y verifique que esas opciones
-  existen y que el `PUT /api/talleres/[id]` las persiste.
-- **Impacto:** un cambio futuro al wizard podría romper estas opciones sin que CI lo note.
-- **Prioridad:** baja-media (la funcionalidad está en prod y funciona; es red de regresión).
-- **Estimación:** 2-3h (`tests/e2e/w-a-formulario.spec.ts` que recorra los pasos nuevos).
+  implementado y deployado. **Parcialmente cubierto ahora:**
+  - **W-A1** tiene e2e dedicado (`tests/e2e/desglose-plantilla.spec.ts`).
+  - La **consistencia de labels** de W-A2 (organizacion/mixta), W-A3 (registro/
+    sin-sistematico) y W-A4 (escalabilidad/turnos/maquinaria) quedó cubierta por
+    `src/__tests__/taller-formulario-labels.test.ts` (fix de consistencia, PR de labels)
+    — verifica que perfil y dashboard sectorial muestran los valores nuevos bien.
+- **Lo que QUEDA (no cubierto):** un e2e que **recorra el wizard** end-to-end y verifique
+  que las opciones nuevas se seleccionan y que el `PUT /api/talleres/[id]` las **persiste**
+  (incluye los 10 roles de W-A5 y la pregunta 1 de disponibilidad de W-A4, que no tienen
+  ningún test). Es cobertura de FLUJO, no de mapeo de labels.
+- **Impacto:** un cambio futuro al wizard podría romper la selección/persistencia sin que CI lo note.
+- **Prioridad:** baja (la funcionalidad está en prod y funciona; el mapeo de display ya tiene unit).
+- **Estimación:** 1.5-2h (`tests/e2e/w-a-formulario.spec.ts` que recorra los pasos nuevos y asserte persistencia).
 
 ## Producto
 

--- a/.claude/specs/v4-w-b-discovery.md
+++ b/.claude/specs/v4-w-b-discovery.md
@@ -7,6 +7,8 @@
 
 ---
 
+> **ACTUALIZACIÓN (2026-06-13, al implementar el fix):** el bug era **más amplio** que lo que este discovery detectó. Al editar los archivos se confirmó que **`organizacion` y `registroProduccion` tenían el mismo problema de labels viejos** (no solo `escalabilidad`): el dashboard sectorial no etiquetaba `mixta` y el perfil del taller mostraba `mixta` como "Prenda completa" y `sin-sistematico` como "Sin registro". El discovery los había marcado "new-aware" mirando solo las queries `groupBy` (correctas) y no los mapas de labels (incompletos). **Los 3 campos se corrigieron juntos** vía fuente única `src/compartido/lib/taller-formulario.ts`. La clasificación de §3 (bug de consistencia chico, ~1–2h) se mantiene; solo aumentó el alcance dentro de los mismos 2 archivos.
+
 ## 0. TL;DR
 
 **SÍ existe un reporte sectorial** (`(estado)/estado/sector/page.tsx`) que agrega los datos del formulario del taller. **Está casi todo new-aware**, salvo **un campo: `escalabilidad`**, cuyo mapeo de etiquetas quedó con los **valores VIEJOS**. Eso produce un **bug de consistencia chico y concreto** en dos lugares.

--- a/src/__tests__/taller-formulario-labels.test.ts
+++ b/src/__tests__/taller-formulario-labels.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import {
+  labelOrganizacion,
+  labelRegistro,
+  labelEscalabilidad,
+  ORGANIZACION_LABELS,
+  REGISTRO_LABELS,
+  ESCALABILIDAD_LABELS,
+} from '@/compartido/lib/taller-formulario'
+
+// Regresión de consistencia W-A: el formulario guarda valores nuevos, y tanto el perfil
+// del taller como el dashboard sectorial de ESTADO derivan sus labels de estas funciones
+// compartidas. Si el mapeo vuelve a quedar viejo, estos tests fallan en AMBOS consumidores
+// a la vez (los dos llaman a las mismas funciones).
+
+describe('W-A escalabilidad — valores nuevos del formulario muestran label correcto', () => {
+  // El form guarda turnos/contratar/tercerizar/maquinaria (step 10, P2).
+  it("'turnos' NO muestra 'Sin capacidad de escalar' (el bug)", () => {
+    expect(labelEscalabilidad('turnos')).toBe('Ampliando turnos u horas de trabajo')
+    expect(labelEscalabilidad('turnos')).not.toBe('Sin capacidad de escalar')
+  })
+  it("'maquinaria' tiene label (antes caía a 'Desconocido'/'Sin capacidad')", () => {
+    expect(labelEscalabilidad('maquinaria')).toBe('Invirtiendo en maquinaria/equipamiento')
+  })
+  it("'contratar' y 'tercerizar' siguen correctos", () => {
+    expect(labelEscalabilidad('contratar')).toBe('Contratando personal')
+    expect(labelEscalabilidad('tercerizar')).toBe('Tercerizando parte de la producción')
+  })
+  it('valores VIEJOS (turno/horas-extra/no) ya no están en el mapa → fallback', () => {
+    expect(ESCALABILIDAD_LABELS['turno']).toBeUndefined()
+    expect(ESCALABILIDAD_LABELS['horas-extra']).toBeUndefined()
+    expect(labelEscalabilidad('horas-extra')).toBe('Desconocido')
+    expect(labelEscalabilidad('horas-extra', 'horas-extra')).toBe('horas-extra')
+  })
+  it('null/undefined → fallback', () => {
+    expect(labelEscalabilidad(null)).toBe('Desconocido')
+    expect(labelEscalabilidad(undefined)).toBe('Desconocido')
+  })
+})
+
+describe('W-A organizacion — "mixta" muestra su propio label, no "Prenda completa"', () => {
+  it("'mixta' NO se muestra como 'Prenda completa' (el bug del else)", () => {
+    expect(labelOrganizacion('mixta')).toBe('Organización mixta')
+    expect(labelOrganizacion('mixta')).not.toBe('Prenda completa')
+  })
+  it('linea/modular/completa siguen correctos', () => {
+    expect(labelOrganizacion('linea')).toBe('En línea')
+    expect(labelOrganizacion('modular')).toBe('Modular')
+    expect(labelOrganizacion('completa')).toBe('Prenda completa')
+  })
+})
+
+describe('W-A registro — "no" y "sin-sistematico" son labels distintos', () => {
+  it("'no' y 'sin-sistematico' no se colapsan en el mismo texto (el bug del else)", () => {
+    expect(labelRegistro('no')).toBe('No llevan registro')
+    expect(labelRegistro('sin-sistematico')).toBe('Sin registro sistemático')
+    expect(labelRegistro('no')).not.toBe(labelRegistro('sin-sistematico'))
+  })
+  it('papel/excel/software correctos', () => {
+    expect(labelRegistro('papel')).toBe('Papel/cuaderno')
+    expect(labelRegistro('excel')).toBe('Excel/planilla')
+    expect(labelRegistro('software')).toBe('Sistema/software')
+  })
+  it("clave muerta 'ninguno' ya no existe en el mapa", () => {
+    expect(REGISTRO_LABELS['ninguno']).toBeUndefined()
+  })
+})

--- a/src/app/(estado)/estado/sector/page.tsx
+++ b/src/app/(estado)/estado/sector/page.tsx
@@ -4,33 +4,15 @@ import { auth } from '@/compartido/lib/auth'
 import { prisma } from '@/compartido/lib/prisma'
 import { redirect } from 'next/navigation'
 import { Card } from '@/compartido/componentes/ui/card'
+import { labelOrganizacion, labelRegistro, labelEscalabilidad } from '@/compartido/lib/taller-formulario'
 
-const orgLabels: Record<string, string> = {
-  linea: 'En línea',
-  modular: 'Modular',
-  completa: 'Prenda completa',
-}
-
+// W-A: organizacion/registro/escalabilidad usan la fuente unica compartida
+// (taller-formulario.ts). catLabels (plantilla) queda local — ya refleja el enum vigente.
 const catLabels: Record<string, string> = {
   APRENDIZ: 'Aprendices',
   MEDIO_OFICIAL: 'Medio oficial',
   OFICIAL: 'Oficial',
   OFICIAL_CALIFICADO: 'Oficial calificado',
-}
-
-const regLabels: Record<string, string> = {
-  software: 'Software',
-  excel: 'Excel/planilla',
-  papel: 'Papel',
-  ninguno: 'Sin registro',
-}
-
-const escLabels: Record<string, string> = {
-  turno: 'Segundo turno',
-  tercerizar: 'Tercerización',
-  contratar: 'Contratando personal',
-  'horas-extra': 'Horas extra',
-  no: 'Sin capacidad',
 }
 
 function BarChart({ items, total, unit = 'talleres' }: { items: { label: string; count: number }[]; total: number; unit?: string }) {
@@ -178,7 +160,7 @@ export default async function DiagnosticoSectorPage() {
       <Card title="Organización productiva">
         <BarChart
           items={distribucionOrganizacion.map(d => ({
-            label: orgLabels[d.organizacion ?? ''] ?? d.organizacion ?? 'Desconocido',
+            label: labelOrganizacion(d.organizacion, d.organizacion ?? 'Desconocido'),
             count: d._count._all,
           }))}
           total={totalConWizard}
@@ -189,7 +171,7 @@ export default async function DiagnosticoSectorPage() {
       <Card title="Gestión y registro">
         <BarChart
           items={distribucionRegistro.map(d => ({
-            label: regLabels[d.registroProduccion ?? ''] ?? d.registroProduccion ?? 'Desconocido',
+            label: labelRegistro(d.registroProduccion, d.registroProduccion ?? 'Desconocido'),
             count: d._count._all,
           }))}
           total={totalConWizard}
@@ -200,7 +182,7 @@ export default async function DiagnosticoSectorPage() {
       <Card title="Capacidad de escalar">
         <BarChart
           items={distribucionEscalabilidad.map(d => ({
-            label: escLabels[d.escalabilidad ?? ''] ?? d.escalabilidad ?? 'Desconocido',
+            label: labelEscalabilidad(d.escalabilidad, d.escalabilidad ?? 'Desconocido'),
             count: d._count._all,
           }))}
           total={totalConWizard}

--- a/src/app/(taller)/taller/perfil/page.tsx
+++ b/src/app/(taller)/taller/perfil/page.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/compartido/componentes/ui/button'
 import { ProgressRing } from '@/compartido/componentes/ui/progress-ring'
 import { Star, MapPin, Users, TrendingUp, Clock, Award, Download } from 'lucide-react'
 import { PortfolioManager } from '@/taller/componentes/portfolio-manager'
+import { labelOrganizacion, labelRegistro, labelEscalabilidad } from '@/compartido/lib/taller-formulario'
 import { nivelAEtapa } from '@/compartido/lib/formalizacion'
 
 export default async function TallerPerfilPage() {
@@ -179,9 +180,7 @@ export default async function TallerPerfilPage() {
             <div className="bg-gray-50 rounded-lg p-3">
               <p className="text-gray-500 text-xs mb-1">Organización</p>
               <p className="font-medium text-gray-800">
-                {taller.organizacion === 'linea' ? 'En línea'
-                 : taller.organizacion === 'modular' ? 'Modular'
-                 : 'Prenda completa'}
+                {labelOrganizacion(taller.organizacion)}
               </p>
             </div>
 
@@ -220,10 +219,7 @@ export default async function TallerPerfilPage() {
               <div className="bg-gray-50 rounded-lg p-3">
                 <p className="text-gray-500 text-xs mb-1">Registro de producción</p>
                 <p className="font-medium text-gray-800">
-                  {taller.registroProduccion === 'software' ? 'Software'
-                   : taller.registroProduccion === 'excel' ? 'Excel/planilla'
-                   : taller.registroProduccion === 'papel' ? 'Papel'
-                   : 'Sin registro'}
+                  {labelRegistro(taller.registroProduccion)}
                 </p>
               </div>
             )}
@@ -232,11 +228,7 @@ export default async function TallerPerfilPage() {
               <div className="bg-gray-50 rounded-lg p-3">
                 <p className="text-gray-500 text-xs mb-1">Puede escalar</p>
                 <p className="font-medium text-gray-800">
-                  {taller.escalabilidad === 'turno' ? 'Segundo turno'
-                   : taller.escalabilidad === 'tercerizar' ? 'Tercerización'
-                   : taller.escalabilidad === 'contratar' ? 'Contratando personal'
-                   : taller.escalabilidad === 'horas-extra' ? 'Horas extra'
-                   : 'Sin capacidad de escalar'}
+                  {labelEscalabilidad(taller.escalabilidad)}
                 </p>
               </div>
             )}

--- a/src/compartido/lib/taller-formulario.ts
+++ b/src/compartido/lib/taller-formulario.ts
@@ -1,0 +1,55 @@
+// Fuente única de la definición valor↔label de los campos del formulario del taller
+// (W-A). Evita que el perfil del taller (donde se muestran) y el dashboard sectorial de
+// ESTADO (donde se agregan) dupliquen y diverjan los labels respecto del wizard (donde
+// se cargan).
+//
+// Por qué existe: el refactor W-A cambió/agregó valores en varios campos, pero el perfil
+// y el dashboard seguían mapeando los viejos → datos mostrados mal:
+//   - escalabilidad: el form guarda 'turnos'/'maquinaria' pero ambos mostraban
+//     "Sin capacidad de escalar" / "Desconocido".
+//   - organizacion: el form agregó 'mixta' pero el perfil lo mostraba como
+//     "Prenda completa" (el `else` del ternario) y el dashboard como "Desconocido".
+//   - registroProduccion: el form usa 'no'/'sin-sistematico' pero el perfil los
+//     colapsaba en "Sin registro" y el dashboard tenía una clave muerta 'ninguno'.
+//
+// El copy es el del master (2.15–2.18) = el copy exacto de los RadioOption del wizard
+// (src/app/(taller)/taller/perfil/completar/page.tsx). Si el wizard cambia un valor o
+// label, se actualiza ACÁ y los tres lugares quedan consistentes.
+//
+// Nota: `disponibilidad` (W-A4 pregunta 1: sin-cambios/con-limites/baja/no-puede) NO se
+// muestra ni agrega en ningún reporte hoy, así que no tiene labels duplicados ni bug.
+// Cuando W-B la exponga, agregar su mapa acá.
+
+// W-A2 (issue #299) — "¿Cómo organizan el trabajo?" (campo `organizacion`)
+export const ORGANIZACION_LABELS: Record<string, string> = {
+  linea: 'En línea',
+  modular: 'Modular',
+  completa: 'Prenda completa',
+  mixta: 'Organización mixta',
+}
+
+// W-A3 (issue #300) — "¿Llevan registro de producción diaria?" (campo `registroProduccion`)
+export const REGISTRO_LABELS: Record<string, string> = {
+  no: 'No llevan registro',
+  'sin-sistematico': 'Sin registro sistemático',
+  papel: 'Papel/cuaderno',
+  excel: 'Excel/planilla',
+  software: 'Sistema/software',
+}
+
+// W-A4 (issue #303) — "¿Cómo podría aumentar su capacidad productiva?" (campo `escalabilidad`)
+export const ESCALABILIDAD_LABELS: Record<string, string> = {
+  turnos: 'Ampliando turnos u horas de trabajo',
+  contratar: 'Contratando personal',
+  tercerizar: 'Tercerizando parte de la producción',
+  maquinaria: 'Invirtiendo en maquinaria/equipamiento',
+}
+
+function label(map: Record<string, string>, valor: string | null | undefined, fallback: string): string {
+  if (!valor) return fallback
+  return map[valor] ?? fallback
+}
+
+export const labelOrganizacion = (v: string | null | undefined, fallback = 'Desconocido') => label(ORGANIZACION_LABELS, v, fallback)
+export const labelRegistro = (v: string | null | undefined, fallback = 'Desconocido') => label(REGISTRO_LABELS, v, fallback)
+export const labelEscalabilidad = (v: string | null | undefined, fallback = 'Desconocido') => label(ESCALABILIDAD_LABELS, v, fallback)


### PR DESCRIPTION
## Problema (vivo en prod desde el deploy de hoy)
El formulario W-A guarda valores nuevos pero el **perfil del taller** y el **dashboard sectorial de ESTADO** mapeaban labels viejos:
- **escalabilidad:** `turnos`/`maquinaria` → "Sin capacidad de escalar" / "Desconocido"
- **organizacion:** `mixta` → "Prenda completa" (perfil) / "Desconocido" (dashboard)
- **registroProduccion:** `sin-sistematico` → "Sin registro" (se colapsaba con `no`)

> El discovery W-B había detectado **solo escalabilidad**; al implementar se confirmó que `organizacion` y `registro` tenían el mismo bug (el discovery los marcó "new-aware" mirando solo las queries `groupBy`, correctas, y no los mapas de labels). **Los 3 se corrigen juntos.**

## Fix
- **Fuente única** `src/compartido/lib/taller-formulario.ts`: mapas valor↔label (copy del master = copy del wizard). Perfil y dashboard derivan de ahí → no vuelve a divergir.
- El form (donde se originan los valores) queda como está; oportunidad futura de que también renderice desde el módulo (lleva `desc`, refactor mayor — anotado).
- **disponibilidad:** verificado, NO tenía el bug (no se muestra/agrega en ningún reporte).

## Test
`src/__tests__/taller-formulario-labels.test.ts` — cubre los 3 campos (valores nuevos OK, viejos fuera del mapa → fallback). Verifica el mapeo que usan **ambos** consumidores (perfil + dashboard). T-06 reducido a e2e de flujo del wizard.

## Nota de deploy
Este bug está **vivo en prod**. Cuando cierre verde, evaluar si entra al próximo deploy o espera a acumular (decisión de Gerardo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)