### PR TITLE
feat(registro): persistir consentimiento legal server-side (T&C + privacidad)

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,18 @@
 # Daily Log
 
+## 2026-06-15
+
+### Gerardo Breard
+- **21:54** `cac4574` — feat(registro): persistir consentimiento legal server-side (T&C + privacidad)
+  - `prisma/migrations/20260615120000_agregar_consentimiento_terminos/migration.sql`
+  - `prisma/schema.prisma`
+  - `src/__tests__/registro-consentimiento.test.ts`
+  - `src/__tests__/u-05-cierre-fuente.test.ts`
+  - `src/app/(auth)/registro/page.tsx`
+  - `src/app/api/auth/registro/route.ts`
+  - `src/compartido/lib/legal.ts`
+
+
 ## 2026-06-12
 
 ### Gerardo Breard

--- a/prisma/migrations/20260615120000_agregar_consentimiento_terminos/migration.sql
+++ b/prisma/migrations/20260615120000_agregar_consentimiento_terminos/migration.sql
@@ -1,0 +1,10 @@
+-- Consentimiento legal en el registro (deuda técnica de auditoría):
+-- el checkbox de T&C era solo client-side y no se persistía. Ahora el
+-- POST /api/auth/registro exige aceptación y guarda versión + timestamp.
+--
+-- Ambas columnas son NULLABLE: cuentas previas a esta migración y altas
+-- creadas por ADMIN (POST /api/admin/usuarios) no pasan por el flujo de
+-- auto-registro y, por tanto, no registran consentimiento.
+
+ALTER TABLE "users" ADD COLUMN "terminosAceptadosVersion" TEXT;
+ALTER TABLE "users" ADD COLUMN "terminosAceptadosEn" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -172,6 +172,11 @@ model User {
   empleadosRegistradosSipa     Int?
   empleadosSipaActualizadoAt   DateTime?
 
+  // Consentimiento legal (registro) — versión de T&C/privacidad aceptada y cuándo.
+  // Nullable: cuentas previas a esta migración y altas creadas por ADMIN no lo tienen.
+  terminosAceptadosVersion     String?
+  terminosAceptadosEn          DateTime?
+
   createdAt        DateTime  @default(now())
   updatedAt        DateTime  @updatedAt
 

--- a/src/__tests__/registro-consentimiento.test.ts
+++ b/src/__tests__/registro-consentimiento.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// Consentimiento legal en el registro: el checkbox de T&C / privacidad era solo
+// client-side y no se persistía (hallazgo de auditoría). Estos tests verifican el
+// gate SERVER-SIDE: sin `aceptaTerminos === true` el POST se rechaza (400), y con
+// aceptación se persiste versión + timestamp en user.create.
+
+vi.mock('@/compartido/lib/prisma', () => ({
+  prisma: {
+    user: { findUnique: vi.fn(), create: vi.fn() },
+    taller: { findUnique: vi.fn() },
+    tipoDocumento: { findMany: vi.fn().mockResolvedValue([]) },
+    validacion: { createMany: vi.fn() },
+  },
+}))
+vi.mock('@/compartido/lib/arca', () => ({
+  consultarPadron: vi.fn(),
+  errorBloqueaRegistro: vi.fn().mockReturnValue(false),
+  mensajeErrorArca: vi.fn().mockReturnValue('CUIT invalido'),
+}))
+vi.mock('@/compartido/lib/email', () => ({
+  sendEmail: vi.fn().mockResolvedValue(undefined),
+  buildBienvenidaEmail: vi.fn().mockReturnValue({ subject: 's', html: '<p>h</p>' }),
+}))
+vi.mock('@/compartido/lib/ratelimit', () => ({
+  rateLimit: vi.fn().mockResolvedValue(null),
+  getClientIp: vi.fn().mockReturnValue('1.1.1.1'),
+}))
+vi.mock('@/compartido/lib/log', () => ({ logActividad: vi.fn() }))
+vi.mock('bcryptjs', () => ({ default: { hash: vi.fn().mockResolvedValue('hashed') } }))
+
+import { prisma } from '@/compartido/lib/prisma'
+import { consultarPadron } from '@/compartido/lib/arca'
+import { TERMINOS_VERSION } from '@/compartido/lib/legal'
+import { POST as registroPOST } from '@/app/api/auth/registro/route'
+
+const mockUserFind = prisma.user.findUnique as ReturnType<typeof vi.fn>
+const mockUserCreate = prisma.user.create as ReturnType<typeof vi.fn>
+const mockTallerFind = prisma.taller.findUnique as ReturnType<typeof vi.fn>
+const mockPadron = consultarPadron as ReturnType<typeof vi.fn>
+
+const reqRegistro = (body: unknown) =>
+  registroPOST(
+    new NextRequest('http://localhost/api/auth/registro', { method: 'POST', body: JSON.stringify(body) }) as NextRequest,
+    {} as never,
+  )
+
+const baseMarca = {
+  email: 'm@x.com',
+  password: 'password123',
+  role: 'MARCA' as const,
+  marcaData: { nombre: 'Mi Marca', cuit: '27-99999999-1' },
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockPadron.mockResolvedValue({ exitosa: true, datos: { nombre: 'X' } })
+  mockUserFind.mockResolvedValue(null)
+  mockTallerFind.mockResolvedValue(null)
+  mockUserCreate.mockResolvedValue({ id: 'u1', email: 'm@x.com', name: null, role: 'MARCA' })
+})
+
+describe('Consentimiento legal — POST /api/auth/registro', () => {
+  it('rechaza con 400 si falta aceptaTerminos', async () => {
+    const res = await reqRegistro(baseMarca)
+    expect(res.status).toBe(400)
+    expect(mockUserCreate).not.toHaveBeenCalled()
+  })
+
+  it('rechaza con 400 si aceptaTerminos es false', async () => {
+    const res = await reqRegistro({ ...baseMarca, aceptaTerminos: false })
+    expect(res.status).toBe(400)
+    expect(mockUserCreate).not.toHaveBeenCalled()
+  })
+
+  it('acepta con aceptaTerminos:true y persiste version + timestamp', async () => {
+    const res = await reqRegistro({ ...baseMarca, aceptaTerminos: true })
+    expect(res.status).toBe(201)
+    const arg = mockUserCreate.mock.calls[0][0]
+    expect(arg.data.terminosAceptadosVersion).toBe(TERMINOS_VERSION)
+    expect(arg.data.terminosAceptadosEn).toBeInstanceOf(Date)
+  })
+})

--- a/src/__tests__/u-05-cierre-fuente.test.ts
+++ b/src/__tests__/u-05-cierre-fuente.test.ts
@@ -78,6 +78,7 @@ describe('U-05 cierre de fuente — POST /api/auth/registro', () => {
       email: 'm@x.com',
       password: 'password123',
       role: 'MARCA',
+      aceptaTerminos: true,
       marcaData: { nombre: 'Mi Marca', cuit: '27-99999999-1' },
     })
 
@@ -97,6 +98,7 @@ describe('U-05 cierre de fuente — POST /api/auth/registro', () => {
       email: 't@x.com',
       password: 'password123',
       role: 'TALLER',
+      aceptaTerminos: true,
       tallerData: { nombre: 'Mi Taller', cuit: '20-12345678-9' },
     })
 
@@ -110,7 +112,7 @@ describe('U-05 cierre de fuente — POST /api/auth/registro', () => {
   it('invariante: roles contiene siempre al role y activeMode == role', async () => {
     mockUserFind.mockResolvedValue(null)
     mockUserCreate.mockResolvedValue({ id: 'u3', email: 'm2@x.com', name: null, role: 'MARCA' })
-    await reqRegistro({ email: 'm2@x.com', password: 'password123', role: 'MARCA', marcaData: { nombre: 'M', cuit: '27-1-1' } })
+    await reqRegistro({ email: 'm2@x.com', password: 'password123', role: 'MARCA', aceptaTerminos: true, marcaData: { nombre: 'M', cuit: '27-1-1' } })
     const { role, roles, activeMode } = mockUserCreate.mock.calls[0][0].data
     expect(roles).toContain(role)
     expect(activeMode).toBe(role)

--- a/src/app/(auth)/registro/page.tsx
+++ b/src/app/(auth)/registro/page.tsx
@@ -40,7 +40,7 @@ const personalInfoSchema = z
     password: z.string().min(8, 'La contrasena debe tener al menos 8 caracteres'),
     confirmPassword: z.string().min(1, 'Confirma tu contrasena'),
     phone: z.string().optional(),
-    terminos: z.boolean().refine(v => v === true, 'Debes aceptar los terminos y condiciones'),
+    terminos: z.boolean().refine(v => v === true, 'Debes aceptar los terminos y condiciones y la politica de privacidad'),
   })
   .refine((data) => data.password === data.confirmPassword, {
     message: 'Las contrasenas no coinciden',
@@ -186,6 +186,8 @@ function StepPersonalInfo({
           <span className="text-sm text-gray-600">
             Acepto los{' '}
             <a href="/terminos" target="_blank" className="text-brand-blue font-semibold hover:underline">terminos y condiciones</a>
+            {' '}y la{' '}
+            <a href="/privacidad" target="_blank" className="text-brand-blue font-semibold hover:underline">politica de privacidad</a>
             {' '}de la Plataforma Digital Textil
           </span>
         </label>
@@ -404,6 +406,7 @@ function RegistroContent() {
           password: personalInfo.password,
           phone: personalInfo.phone || undefined,
           role,
+          aceptaTerminos: personalInfo.terminos,
           ...(role === 'TALLER' ? { tallerData: entidadPayload } : { marcaData: entidadPayload }),
         }),
       })

--- a/src/app/api/auth/registro/route.ts
+++ b/src/app/api/auth/registro/route.ts
@@ -4,6 +4,7 @@ import { Prisma } from '@prisma/client'
 import { logActividad } from '@/compartido/lib/log'
 import { consultarPadron, errorBloqueaRegistro, mensajeErrorArca, type DatosArca } from '@/compartido/lib/arca'
 import { sendEmail, buildBienvenidaEmail } from '@/compartido/lib/email'
+import { TERMINOS_VERSION } from '@/compartido/lib/legal'
 import { rateLimit, getClientIp } from '@/compartido/lib/ratelimit'
 import { apiHandler, errorResponse, errorConflict } from '@/compartido/lib/api-errors'
 import bcrypt from 'bcryptjs'
@@ -16,6 +17,11 @@ const registerSchema = z.object({
   name: z.string().trim().min(1).optional(),
   nombre: z.string().trim().min(1).optional(),
   phone: z.string().trim().optional(),
+  // Consentimiento legal obligatorio (T&C + privacidad). Validación server-side:
+  // sin `aceptaTerminos === true` el registro se rechaza con 400, no solo el zod del form.
+  aceptaTerminos: z.literal(true, {
+    errorMap: () => ({ message: 'Debes aceptar los terminos y condiciones y la politica de privacidad' }),
+  }),
   tallerData: z.object({
     nombre: z.string().trim().min(1, 'Nombre de taller requerido'),
     cuit: z.string().trim().min(1, 'CUIT requerido'),
@@ -94,6 +100,9 @@ export const POST = apiHandler(async (req: NextRequest) => {
         // el dato no se desincronice (ver spec v4-u-05). NO usar push: setear el array.
         roles: [data.role],
         activeMode: data.role,
+        // Consentimiento legal: prueba auditable de versión aceptada + cuándo.
+        terminosAceptadosVersion: TERMINOS_VERSION,
+        terminosAceptadosEn: new Date(),
         // MITIGACION #307 (temporal): marcar emailVerified al crear la cuenta para
         // no bloquear el onboarding. El paso "Verificar email" del checklist
         // (onboarding.ts) gatea con !!user.emailVerified y, sin flujo de verificacion

--- a/src/compartido/lib/legal.ts
+++ b/src/compartido/lib/legal.ts
@@ -1,0 +1,10 @@
+// Versión vigente de los Términos y Condiciones y la Política de Privacidad.
+//
+// Se persiste en `User.terminosAceptadosVersion` al momento del registro para
+// dejar prueba auditable de QUÉ versión aceptó cada usuario y CUÁNDO
+// (`User.terminosAceptadosEn`). Si en el futuro cambia el texto legal, subir
+// esta constante (y, si corresponde, forzar re-aceptación).
+//
+// El valor corresponde a la fecha de alta de `/terminos` y `/privacidad`
+// (commit c7eaa9f, 2026-02-11). Formato YYYY-MM-DD.
+export const TERMINOS_VERSION = '2026-02-11'


### PR DESCRIPTION
## Contexto
Hallazgo de auditoría: el checkbox de términos en `/registro` era **solo client-side** y **no se persistía**. Un `POST` directo a `/api/auth/registro` (saltando el form) creaba la cuenta sin ninguna prueba de aceptación, ni versión ni timestamp. Gap de compliance para un piloto con PII (OIT).

## Qué hace
1. **Schema + migración** — `User.terminosAceptadosVersion` (TEXT) y `User.terminosAceptadosEn` (TIMESTAMP). Nullable: cuentas previas y altas creadas por ADMIN (`/api/admin/usuarios`, otro path) no pasan por el auto-registro.
2. **Validación server-side** — `registerSchema` ahora exige `aceptaTerminos === true` (`z.literal(true)`). Sin aceptación → **400**, no solo el zod del form. Persiste `TERMINOS_VERSION` (`2026-02-11`, fecha de alta de `/terminos` y `/privacidad`) + `new Date()`.
3. **Formulario** — agrega link a **`/privacidad`** (antes solo linkeaba `/terminos`) y envía `aceptaTerminos` en el payload.

## Tests
- `src/__tests__/registro-consentimiento.test.ts` (nuevo): 400 sin `aceptaTerminos`, 400 con `false`, 201 + persiste versión/timestamp con `true`.
- `src/__tests__/u-05-cierre-fuente.test.ts`: actualizado con `aceptaTerminos: true` en sus 3 bodies.

## Verificación local
- ✅ `tsc --noEmit` limpio.
- ✅ `prisma generate` (v6.19.2) OK.
- ⚠️ Suite **vitest no ejecutada localmente**: el `node_modules` de este checkout está incompleto en el mount WSL (paquete `vitest` sin materializar; `npm install` falla en el postinstall de `@prisma/engines`). **CI corre los tests en este PR.**

## Pendiente / fuera de scope
- Re-aceptación forzada si cambian los T&C (hoy solo se versiona; bastaría subir `TERMINOS_VERSION` y gatear en login).
- Backfill de las cuentas existentes en prod (4) quedan con consentimiento `null` — decidir si se las marca o se ignora.

🤖 Generated with [Claude Code](https://claude.com/claude-code)