### PR TITLE
fix: M-03 mobile fixes del flujo critico del taller

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -47,7 +47,7 @@ function MagicLinkForm() {
   }
 
   return (
-    <form onSubmit={handleMagicLink} className="mt-3 flex gap-2">
+    <form onSubmit={handleMagicLink} className="mt-3 flex flex-col sm:flex-row gap-2">
       <input
         type="email"
         value={email}

--- a/src/app/(taller)/taller/page.tsx
+++ b/src/app/(taller)/taller/page.tsx
@@ -270,7 +270,7 @@ export default async function TallerDashboardPage() {
         </div>
 
         {/* Stats secundarios */}
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div className="bg-white rounded-card shadow-card p-5 border border-gray-100">
             <p className="text-xs uppercase text-gray-500 font-semibold mb-1">Formalización</p>
             <p className="text-3xl font-bold text-brand-blue">{completadas}/{totalValidaciones}</p>

--- a/src/app/(taller)/taller/perfil/completar/page.tsx
+++ b/src/app/(taller)/taller/perfil/completar/page.tsx
@@ -329,10 +329,10 @@ export default function WizardPage() {
         <div>
           <h2 className="font-serif font-bold text-xl text-brand-blue mb-4">Contanos sobre tu equipo de trabajo</h2>
           <p className="text-sm font-semibold mb-2">¿Cuántas personas trabajan en producción?</p>
-          <div className="flex gap-2 mb-4">
+          <div className="grid grid-cols-3 sm:grid-cols-5 gap-2 mb-4">
             {['1-2', '3-5', '6-10', '11-20', '+20'].map(v => (
               <button key={v} type="button" onClick={() => setTamanoEquipo(v)}
-                className={`flex-1 py-2 rounded-lg border text-sm font-semibold transition-colors ${tamanoEquipo === v ? 'bg-brand-blue text-white border-brand-blue' : 'bg-white border-gray-300 hover:border-brand-blue'}`}>
+                className={`py-2 rounded-lg border text-sm font-semibold transition-colors ${tamanoEquipo === v ? 'bg-brand-blue text-white border-brand-blue' : 'bg-white border-gray-300 hover:border-brand-blue'}`}>
                 {v}
               </button>
             ))}
@@ -703,7 +703,7 @@ export default function WizardPage() {
 
       {/* Navigation */}
       {step > 0 && step < 13 && (
-        <div className="flex justify-between mt-6">
+        <div className="flex justify-between mt-6 sticky bottom-0 -mx-4 px-4 py-3 bg-white/95 backdrop-blur border-t border-gray-100 sm:static sm:mx-0 sm:px-0 sm:py-0 sm:bg-transparent sm:backdrop-blur-none sm:border-0">
           <Button variant="secondary" onClick={prev} icon={<ArrowLeft className="w-4 h-4" />}>Atrás</Button>
           <Button onClick={next} icon={<ArrowRight className="w-4 h-4" />}>Siguiente</Button>
         </div>


### PR DESCRIPTION
## Qué hace

Fixes de **layout** para que el flujo que el taller usa **desde el celular** funcione bien en 320 / 375 / 414px. Bloque CRÍTICO del Bloque B (mobile), derivado del discovery (PR #430). **Sin tocar colores / tipografía / identidad visual** — eso es del rediseño futuro de OIT.

## Fixes

| # | Pantalla | Cambio |
|---|----------|--------|
| 1a | Wizard `perfil/completar` | Botones de tamaño de equipo (l.332): `flex` sin wrap → `grid grid-cols-3 sm:grid-cols-5`. Los 5 botones quedan legibles en mobile (2 filas), idénticos en ≥640px |
| 1b | Wizard `perfil/completar` | Nav Atrás/Siguiente (l.705): **sticky bottom en mobile**, estática en `sm+`. En pasos largos no hay que scrollear a buscarla |
| 2 | Dashboard taller | KPI grid (l.273): `grid-cols-2` → `grid-cols-1 sm:grid-cols-2`. Números `text-3xl` ya no apretados en pantallas chicas |
| 3 | Login | Form magic-link (l.50): `flex` → `flex-col sm:flex-row`. Input se apila sobre el botón en mobile |
| 4 | Crear cotización | **Verificada OK** — ya es responsive (`grid-cols-1 sm:grid-cols-2`, todo `w-full`). Sin cambios |

## Regla cumplida
Solo clases de layout (grid / flex / sticky / breakpoints). Desktop (≥640px) queda visualmente idéntico a antes en las 4 pantallas.

## Alcance
- E2E mobile (reactivar Playwright) va en un PR **posterior**, para no mezclar fixes con infraestructura de test.
- Verificación responsive: ver comentario del PR (viewports 320/375/414 sobre el preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)