### PR TITLE
docs: cerrar Bloque B critico + hallazgo F-05 (desborde toasts 320px)

### DIFF
--- a/.claude/DEUDA_TECNICA.md
+++ b/.claude/DEUDA_TECNICA.md
@@ -18,6 +18,27 @@ y prioridad sugerida.
 - **Prioridad:** baja (backlog post-piloto, decisión de Gerardo)
 - **Estimación:** 3-4h
 
+### F-05: Desborde horizontal ~17px en /taller a 320px (contenedor de toasts)
+- **Detectado en:** Acción 3 del Bloque B / E2E mobile (#433, 2026-06-18),
+  al validar el flujo del taller en 320px con playwright-core.
+- **Descripción:** el dashboard del taller (`/taller`) produce ~17px de
+  scroll horizontal a 320px. La fuente es un contenedor `fixed bottom-4
+  right-4 ... flex flex-col` (viewport de toasts) que renderiza ~337px de
+  ancho (> viewport 320). NO es del flujo de contenido (login, wizard y
+  pedidos disponibles dan desborde 0 a 320px) ni del fix de #431 (el KPI
+  grid ya apila bien); es un contenedor accesorio.
+- **Pre-existente:** sí — anterior a #431/#433. Los fixes de #431 no lo
+  introdujeron ni lo tocan.
+- **Impacto:** cosmético (leve rubber-band horizontal en 320px). No afecta
+  funcionalidad ni el piloto.
+- **Por qué el e2e no lo cubre:** el test mobile del dashboard (#433) NO
+  assertea desborde de página en `/taller` por este hallazgo; sí cubre el
+  FIX 2 (#431) vía el stacking de KPIs. Login/wizard/disponibles sí
+  assertean desborde 0.
+- **Prioridad:** **baja** (solo 320px, contenedor accesorio).
+- **Follow-up:** revisar el `max-width`/`overflow` del contenedor de toasts
+  (ej. acotar a `max-w-[calc(100vw-2rem)]` o `inset-x` en mobile). PR chico.
+
 ## Backend / Arquitectura
 
 ### B-01: Tres paths de verificación de CUIT sin unificar

--- a/.claude/specs/v4-b-m03-mobile-fixes.md
+++ b/.claude/specs/v4-b-m03-mobile-fixes.md
@@ -7,7 +7,10 @@
 **Branch:** `feature/m03-mobile-flujo-taller`.
 
 > **ESTADO: ✅ HECHO — mergeado a `develop` en PR #431 (squash `bafcc2a`).** FIX 1a / 1b / 2 / 3 implementados; FIX 4 verificado sin cambios. Los 4 verificados visualmente en preview de Vercel (Playwright, viewports 320/375/414). Verde unit+e2e+Vercel.
-> **Pendiente del Bloque B:** Acción 3 (reactivar E2E mobile, PR aparte) + opcionales post-MVP (header-public hamburguesa, data-table cards).
+>
+> **🟢 BLOQUE B CRÍTICO — CERRADO.** Fixes de layout (#431 `bafcc2a`) + red de seguridad E2E mobile (#433 `b834835`: projects `mobile-chrome` 393px + `mobile-small` 320px, 8 tests que protegen cada fix; desktop intacto en 134 tests). Verde unit+e2e+Vercel en develop.
+> **Pendiente del Bloque B = solo opcionales post-MVP:** header-public hamburguesa, data-table cards (vista mobile). NO bloquean el piloto.
+> **Hallazgo abierto (no #431):** ~17px de desborde horizontal en `/taller` a 320px (contenedor `fixed` de toasts) → ver `DEUDA_TECNICA.md` F-05.
 
 ---
 


### PR DESCRIPTION
Bookkeeping de cierre del **Bloque B crítico** (pedido por Gerardo):

- **Spec M-03**: Bloque B CRÍTICO marcado **🟢 CERRADO** — fixes de layout (#431 `bafcc2a`) + red de seguridad E2E mobile (#433 `b834835`). Pendiente del Bloque B = solo opcionales post-MVP (header-public hamburguesa, data-table cards), que NO bloquean el piloto.
- **DEUDA F-05**: anotado el hallazgo de los ~17px de desborde horizontal en `/taller` a 320px (contenedor `fixed` de toasts). Pre-existente, ajeno a #431, severidad **baja** (cosmético, solo 320px, contenedor accesorio). Follow-up: acotar `max-width`/`overflow` del contenedor de toasts.

Solo documentación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)