### PR TITLE
chore: observabilidad del piloto + copy narrativa Etapas 2-3

### DIFF
--- a/.claude/BITACORA_PROD.md
+++ b/.claude/BITACORA_PROD.md
@@ -1,0 +1,63 @@
+# Bitácora de Producción — PDT
+
+Registro cronológico de **deploys, incidentes y aprendizajes** de producción.
+Es la lectura previa de la **revisión semanal** del piloto (pedido de Sergio:
+"si algo se rompe en el piloto necesito poder verlo").
+
+- Una entrada por **deploy a prod** o por **incidente** (caída, error de runtime,
+  bug reportado por un taller, alerta de uptime).
+- Lo táctico/granular (cada commit) vive en `DAILY.md`. Acá va lo que importa para
+  operar el piloto: qué cambió en prod, qué se rompió, cómo se resolvió, qué se
+  aprendió.
+- La observabilidad que alimenta esta bitácora (uptime, alertas, health-check)
+  está documentada en `.claude/specs/RUNBOOK_OBSERVABILIDAD.md`.
+
+## Severidades
+
+| Sev | Significado | Ejemplo |
+|-----|-------------|---------|
+| **S1 — Crítico** | App caída o función core inutilizable para todos | login roto, 500 en home, DB caída |
+| **S2 — Alto** | Función importante rota para algunos | un rol no puede cotizar, email no sale |
+| **S3 — Medio** | Bug visible pero con workaround / no bloqueante | desborde mobile, label mal mapeado |
+| **S4 — Bajo** | Cosmético o interno | typo, log ruidoso |
+
+## Plantilla de entrada
+
+```
+## YYYY-MM-DD — <título corto>
+
+- **Tipo:** Deploy | Incidente
+- **Severidad:** S1 | S2 | S3 | S4 (N/A para deploys sin incidente)
+- **Qué pasó:** <descripción factual: qué se observó, dónde, desde cuándo>
+- **Detección:** <cómo nos enteramos: alerta de uptime / reporte de taller / CI / manual>
+- **Impacto:** <quién/qué se vio afectado y por cuánto tiempo>
+- **Cómo se resolvió:** <acción concreta + SHA/PR/deploy si aplica>
+- **Qué se aprendió / acción de seguimiento:** <prevención; link a DEUDA_TECNICA si abre deuda>
+```
+
+---
+
+## 2026-06-13 — Deploy a PROD (release mayor: develop → main)
+
+- **Tipo:** Deploy
+- **Severidad:** N/A (sin incidente)
+- **Qué pasó:** Primer release mayor a producción tras casi dos semanas. Merge
+  `develop` → `main` vía PR #422 (merge commit `3333016`, preserva historia).
+  Release de 105 commits; prod no se actualizaba desde el 01-jun. Deploy de Vercel
+  `plataforma-textil-rrld0fe3i` → ● Ready. Cambió la landing.
+- **Detección:** N/A (deploy planificado).
+- **Impacto:** Producción al día con `develop`. 4 migraciones pendientes aplicadas
+  en la DB durante el build (`agregar_imagen_coleccion`, `agregar_tipo_pedido`,
+  `k01_rls_revoke_anon`, `u05_backfill_roles_activemode`); las otras 2
+  (`multirol_y_arca`, `formulario_taller`) ya estaban en prod desde mayo →
+  `migrate deploy` solo aplicó las pendientes. "All migrations successfully
+  applied", sin error.
+- **Cómo se resolvió:** N/A — deploy exitoso. Detalle granular en `DAILY.md`
+  (sección 2026-06-13) y runbook en `.claude/specs/RUNBOOK_PROMOCION_PROD.md`.
+- **Qué se aprendió / acción de seguimiento:**
+  - Pendiente post-deploy (sin correr, requiere OK de Gerardo): crear cuenta de
+    Sergio en prod (faltan email + rol) + su smoke, y backfill de validaciones
+    D-02 con `--exclude <email-smoke>`.
+  - Este deploy es el motivo de montar observabilidad **antes** del piloto: con
+    105 commits acumulados, una caída habría sido difícil de diagnosticar sin
+    alertas. Ver `RUNBOOK_OBSERVABILIDAD.md`.

--- a/.claude/specs/RUNBOOK_OBSERVABILIDAD.md
+++ b/.claude/specs/RUNBOOK_OBSERVABILIDAD.md
@@ -1,0 +1,151 @@
+# Runbook — Observabilidad del piloto
+
+Prerrequisito del deploy del piloto (pedido de Sergio: "si algo se rompe en el
+piloto necesito poder verlo"). Observabilidad **barata** para 4 talleres: detectar
+caídas y errores sin montar infraestructura pesada.
+
+Dos columnas de trabajo:
+- **Código/config (ya hecho, en este PR):** endpoint `/api/health`, bitácora.
+- **Cuentas externas (las hace Gerardo):** lo de abajo. Claude no puede crear
+  cuentas — esta es la guía paso a paso.
+
+Los incidentes que se detecten se registran en `.claude/BITACORA_PROD.md`.
+
+---
+
+## 0. Qué ya quedó montado en el repo (sin acción externa)
+
+| Pieza | Qué hace | Dónde |
+|-------|----------|-------|
+| `GET /api/health` | `SELECT 1` a la DB → `200 {status:ok,db:up}` o `503 {db:down}`. Lo pinguea la sonda de uptime. | `src/app/api/health/route.ts` |
+| `GET /api/health/version` | Reporta SHA/env/ref del deploy (no toca DB). Sirve para confirmar qué commit está en prod. | `src/app/api/health/version/route.ts` |
+| `.claude/BITACORA_PROD.md` | Registro de deploys/incidentes. Lectura previa de la revisión semanal. | `.claude/` |
+
+URL del health en prod (confirmar dominio canónico): **`https://plataformatextil.com.ar/api/health`**
+(si el canónico sigue siendo `plataforma-textil.vercel.app`, usar ese).
+
+---
+
+## 1. Alertas nativas de Vercel (las activa Gerardo en el dashboard)
+
+### Qué ofrece Vercel (y qué NO)
+
+| Capacidad | Disponible | Notas |
+|-----------|-----------|-------|
+| **Email de deploy fallido** | ✅ nativo, automático | Vercel manda email al owner del proyecto cuando un build falla. Solo hay que confirmar que las notificaciones están activas. |
+| **Notificación de deploy (éxito/fallo) a Slack** | ✅ integración | Vercel Slack app: postea estado de cada deploy en un canal. |
+| **Logs de runtime / function errors** | ✅ ver, ⚠️ alertar | En el plan Hobby/Pro se ven en la pestaña **Observability / Logs**, pero la retención es corta y **no hay alerta automática por error-rate** salvo en planes altos (Log Drains / Monitoring son Pro+/Enterprise). Esta es la brecha que tapan uptime + (opcional) Sentry. |
+| **Alerta por caída del sitio** | ❌ no nativo | Vercel no hace uptime monitoring. Por eso usamos UptimeRobot (sección 2). |
+
+### Pasos manuales para Gerardo
+
+1. **Confirmar email de deploy fallido**
+   - Vercel → avatar → **Account Settings → Notifications** (o **Project Settings →
+     Notifications**).
+   - Verificar que "Deployment failed" / "Deployment error" estén en ON para el
+     proyecto `plataforma-textil`.
+
+2. **(Opcional) Notificaciones de deploy a un canal**
+   - Vercel → **Integrations** → buscar **Slack** (o el canal elegido en §3) →
+     **Add Integration** → elegir el proyecto y el canal.
+   - Resultado: cada deploy a prod postea estado (Building → Ready / Error).
+
+3. **Saber dónde mirar los errores de runtime**
+   - Vercel → proyecto → pestaña **Observability** (o **Logs**) → filtrar por
+     `Production` + status `5xx`.
+   - Esto es **manual** (no alerta sola). El disparador real para venir a mirar acá
+     es la alerta de UptimeRobot (§2) o un reporte de taller.
+
+---
+
+## 2. Uptime monitoring — UptimeRobot (lo crea Gerardo)
+
+**Recomendación: UptimeRobot** (gratis, 50 monitores, intervalo 5 min en el plan
+free, integra Telegram/Slack/email/webhook). Alternativas equivalentes:
+Better Stack (ex Better Uptime) free, Pingdom (pago). Para el piloto, UptimeRobot
+free alcanza.
+
+### Pasos exactos
+
+1. Crear cuenta gratis en https://uptimerobot.com (con el email institucional).
+2. **+ Add New Monitor**:
+   - **Monitor Type:** `HTTP(s)` — o mejor **`Keyword`** (verifica contenido, no
+     solo el status).
+   - **URL:** `https://plataformatextil.com.ar/api/health`
+   - Si es tipo **Keyword:** Keyword = `"db":"up"`, Alert when = **Keyword Not
+     Exists**. Así una respuesta 503 (`db:down`) o un cuelgue dispara alerta
+     aunque el server conteste algo.
+   - **Monitoring Interval:** `5 minutes` (mínimo del plan free; suficiente para
+     4 talleres).
+   - **Monitor Timeout:** 30s.
+3. **Alert Contacts To Notify:** seleccionar el canal de §3 (Telegram/Slack) +
+   email de respaldo.
+4. (Opcional) Segundo monitor a la **home** `https://plataformatextil.com.ar/`
+   tipo HTTP(s) — confirma que el front carga, no solo la API.
+
+> Por qué `/api/health` y no la home: la home es un server component pesado y
+> cacheable; puede responder 200 con la DB caída. `/api/health` hace `SELECT 1`
+> real → caza caídas de DB, que es el modo de falla más probable (Supabase).
+
+---
+
+## 3. Canal de alertas — Telegram vs Slack (decide Gerardo/Sergio)
+
+**Recomendación: Telegram** — el más simple de montar gratis y al que tanto
+UptimeRobot como (opcional) los webhooks de Vercel se conectan sin fricción.
+Slack es igual de válido si el equipo ya lo usa a diario.
+
+### Opción A — Telegram (recomendada)
+
+1. En Telegram, hablar con **@BotFather** → `/newbot` → nombre + username →
+   guarda el **bot token**.
+2. Crear un grupo "PDT Alertas" y agregar el bot.
+3. En **UptimeRobot → My Settings → Add Alert Contact → Telegram** → seguir el
+   flujo (autoriza el bot al chat). Asignar ese contacto a los monitores de §2.
+4. (Opcional) Para mandar también los deploy de Vercel a Telegram: usar la
+   integración Slack de Vercel hacia un canal, o un webhook intermedio. Para el
+   piloto alcanza con el email de deploy fallido (§1) + uptime en Telegram.
+
+### Opción B — Slack
+
+1. Crear (o usar) un workspace + canal `#pdt-alertas`.
+2. **UptimeRobot → Add Alert Contact → Slack** → autorizar el canal.
+3. **Vercel → Integrations → Slack** → conectar el proyecto al mismo canal
+   (cubre los deploy; §1 paso 2).
+
+> Decisión pendiente de Gerardo/Sergio: qué canal. Todo lo demás (uptime, health,
+> deploy email) ya está listo para enchufarse a cualquiera de los dos.
+
+---
+
+## 4. Error tracking (Sentry) — evaluación honesta
+
+**Recomendación: NO montarlo ahora. Las alertas nativas de Vercel + uptime +
+`/api/health` alcanzan para un piloto de 4 talleres.**
+
+| | Sin Sentry (lo que tenemos) | Con Sentry |
+|---|---|---|
+| Caída del sitio / DB | ✅ UptimeRobot en ≤5 min | ✅ igual |
+| Deploy fallido | ✅ email Vercel | ✅ igual |
+| Error 500 puntual de un usuario | ⚠️ visible en logs Vercel (manual, retención corta) | ✅ stack trace + contexto + alerta automática |
+| Error de JS en el browser del taller | ❌ invisible | ✅ capturado |
+| Setup | 0 (ya hecho) | ~1h (`@sentry/nextjs` wizard) + 1 cuenta + 1 env var |
+
+**Cuándo sí montar Sentry:** si durante el piloto aparece un bug que un taller
+reporta pero que **no podemos reproducir ni encontrar en los logs de Vercel**
+(típico de errores de browser o intermitentes). Ahí el stack trace de Sentry paga
+su setup. Free tier: 5k errores/mes, suficiente.
+
+> No montarlo sin decisión explícita. Si se decide, es `npx @sentry/wizard@latest
+> -i nextjs` + agregar `SENTRY_DSN` a las env vars de Vercel — Claude lo puede
+> hacer en un PR aparte.
+
+---
+
+## Resumen — qué necesita decisión/acción de Gerardo antes del deploy
+
+1. **Confirmar dominio canónico de prod** para la URL del health (`plataformatextil.com.ar` vs `plataforma-textil.vercel.app`).
+2. **Activar/confirmar** notificaciones de deploy fallido en Vercel (§1).
+3. **Crear** el monitor de UptimeRobot apuntando a `/api/health` (§2).
+4. **Elegir canal** (Telegram recomendado) y conectarlo a UptimeRobot (§3).
+5. **Decidir** sobre Sentry — recomendación: diferir (§4).

--- a/.claude/specs/v4-narrativa-etapas-2-3-copy.md
+++ b/.claude/specs/v4-narrativa-etapas-2-3-copy.md
@@ -1,0 +1,299 @@
+# Copy de Narrativa V4 — Etapas 2 y 3
+
+> Fuente: entregable de Sergio, 18-jun-2026. Insumo de implementacion para Etapa 2 (narrativa core) y Etapa 3 (gobernanza / bloque V4.5).
+
+Copy de Narrativa V4 — Etapas 2 y 3
+Fecha: 18 de junio de 2026
+Para: Gerardo (implementación)
+Versión: preliminar — para validación
+Alcance: copy textual de las componentes de las Etapas 2 y 3 del plan de implementación de la Narrativa V4
+
+Cómo está organizado
+Cada sección lista los textos visibles a usuario para cada componente: títulos, subtítulos, ayudas contextuales, banners, mensajes de estado (vacío, cargando, error, éxito), textos de botones y confirmaciones. Lo que está entre corchetes [así] son variables dinámicas que la aplicación reemplaza por datos reales.
+Criterios narrativos transversales (aplican a todo el copy):
+- Tono de acompañamiento institucional, no de evaluación ni de puntaje.
+- Verbos de acción para botones, en infinitivo o imperativo personal (en segunda persona singular: "completá", "subí", "elegí").
+- En textos descriptivos, voz neutra, claridad sobre jerga técnica.
+- "Facilitador, no inspector" — sin lenguaje punitivo ni de auditoría rígida.
+- Etapas en lugar de niveles/puntajes (Inicial / En proceso / Consolidada).
+
+ETAPA 2 — Reestructuración (Mi taller + dimensiones + umbrales)
+2.1 Sub-tabs Mi taller
+Estructura visual
+El tab principal "Mi taller" se convierte en paraguas de dos sub-tabs. La cabecera común muestra el nombre del taller, su etapa actual y el ARCA verificado. Debajo, el toggle de sub-tabs:
+Mi vidriera   |   Mi gestión productiva
+Cabecera común (siempre visible arriba)
+
+Sub-tab "Mi vidriera"
+Texto del sub-tab: Mi vidriera
+Ícono auxiliar (opcional): ícono de vidriera/exhibición
+Banner contextual (sobre el contenido del sub-tab):
+"Esto es lo que ven las marcas cuando te encuentran en el directorio. Lo que mostrás acá es público — usá el botón Ver cómo me ve el directorio para revisarlo."
+Sub-tab "Mi gestión productiva"
+Texto del sub-tab: Mi gestión productiva
+Ícono auxiliar (opcional): ícono de gestión/herramienta
+Banner contextual:
+"Esto es solo tuyo. Tu equipo de acompañamiento puede verlo para ayudarte, pero ninguna marca tiene acceso. Es tu espacio de gestión interna."
+Mensajes de estado
+
+2.2 Tres dimensiones de la vidriera
+Estructura
+Mi vidriera se reorganiza en 3 bloques claros, cada uno con su propio título, ayuda contextual y contenido.
+Bloque 1 — Credenciales
+Título del bloque: Credenciales
+Subtítulo: Lo que confirma que tu taller cumple con los requisitos institucionales.
+Ayuda contextual (ícono "i" al lado del título):
+"Las credenciales son verificadas por la entidad de gobernanza. Mostrás tu etapa de formalización y la verificación de ARCA."
+Estados visuales en la vidriera pública:
+- Si tiene etapa Inicial: badge azul claro con "Etapa inicial"
+- Si tiene etapa En proceso: badge azul medio con "En proceso de formalización"
+- Si tiene etapa Consolidada: badge azul oscuro con "Formalización consolidada"
+- Si tiene ARCA verificado: badge verde con texto "ARCA verificado"
+Estado vacío: (no aplica — siempre se muestra al menos el dato de ARCA y la etapa, aunque sea inicial)
+Bloque 2 — Formación
+Título del bloque: Formación
+Subtítulo: Los cursos que completaste y que aportan a tu trayectoria profesional.
+Ayuda contextual:
+"Cada badge corresponde a un curso completado en la Academia. Podés elegir qué badges mostrar a las marcas desde la configuración de tu vidriera."
+Estado vacío: "Todavía no completaste ningún curso. Mirá la Academia para empezar tu primer trayecto formativo."
+CTA en estado vacío: Ir a la Academia
+Badges (texto sobre cada badge):
+- Nombre del curso
+- (opcional) Fecha de obtención
+Bloque 3 — Descripción
+Título del bloque: Descripción de mi taller
+Subtítulo: Lo que contás sobre cómo trabajás. Vos decidís qué hacer visible a las marcas.
+Ayuda contextual:
+"Esta sección incluye tu perfil productivo. Podés mostrar u ocultar bloques completos desde Configuración de visibilidad. La información que ocultes solo la verás vos en Mi gestión productiva."
+Sub-bloques del perfil productivo (cada uno con su propio título):
+- Mi equipo de trabajo
+- Mi espacio físico
+- Mi capacidad de producción
+- Cómo organizo el trabajo
+- Maquinaria
+Mensaje cuando un bloque está oculto a marcas (visible solo al taller en preview):
+"Este bloque no se muestra a las marcas. Cambialo desde Configuración de visibilidad si querés exponerlo."
+
+2.3 Tres umbrales escalonados
+Estructura
+La página "Mi recorrido" muestra los tres umbrales en orden y resalta el actual del taller. Cada umbral tiene su propio panel.
+Umbral 1 — Registrado
+Título: Registrado
+Subtítulo: Te diste de alta en la plataforma. Ya podés moverte por la Academia y los Recursos.
+Ayuda contextual:
+"Estás en período de bienvenida. Tenés 60 días para verificar tu CUIT y completar tu vidriera mínima. Mientras tanto, podés aprender en la Academia y conocer cómo funciona la plataforma."
+Lista de lo que se desbloquea:
+- Navegar la Academia
+- Consultar Recursos institucionales
+- Ver el directorio público
+Lista de lo que falta para pasar al siguiente umbral:
+- Verificar tu CUIT con ARCA
+- Completar descripción del taller (mínimo 50 caracteres)
+- Indicar tu ubicación
+- Declarar al menos un rubro o capacidad
+- Subir una foto de tu taller
+CTA principal: Completá tu vidriera mínima
+Mensaje cuando faltan días del período de gracia: "Te quedan [X] días del período de bienvenida."
+Mensaje cuando el período de gracia vence: "El período de bienvenida finalizó. Completá tu vidriera mínima para aparecer en el directorio."
+Umbral 2 — Visible en directorio
+Título: Visible en el directorio
+Subtítulo: Ya apareces en el directorio público. Las marcas pueden encontrarte y conocer tu taller.
+Ayuda contextual:
+"Tu vidriera mínima está lista. Las marcas pueden verte. El siguiente paso es habilitar la cotización de pedidos — para eso, avanzá en la etapa de formalización y completá tu perfil productivo."
+Lista de lo que se desbloquea:
+- Aparecer en el directorio público
+- Recibir mensajes de marcas
+- Ser incluido en búsquedas y filtros
+Lista de lo que falta para pasar al siguiente umbral:
+- Alcanzar al menos la etapa "En proceso" de formalización
+- Completar tu perfil productivo al 80%
+CTA principal: Ver mi recorrido de formalización
+Umbral 3 — Apto para cotizar
+Título: Apto para cotizar
+Subtítulo: Ya podés cotizar pedidos publicados por marcas. Es el último umbral del recorrido.
+Ayuda contextual:
+"Llegaste al umbral más alto. Tus capacidades están declaradas, tu formalización avanzó y las marcas pueden invitarte a cotizar. Seguí completando tu perfil para aparecer en más búsquedas."
+Lista de lo que se desbloquea:
+- Recibir invitaciones a cotizar
+- Aparecer en match calificado por capacidad
+- Habilitar tu vidriera completa (todas las dimensiones)
+Mensaje motivacional (opcional): "Tu recorrido en la PDT está completo. Seguí sumando capacidades y cursos para que más marcas te encuentren."
+Mensajes transversales del recorrido
+
+2.4 Filtros del directorio
+Estructura
+El directorio (vista de marca y vista pública) se simplifica a tres filtros.
+Título de la sección de filtros: Filtrar talleres
+Filtros:
+
+Texto debajo de los filtros (siempre visible):
+"Mostramos solo talleres con CUIT verificado por ARCA."
+Botones:
+- Aplicar filtros
+- Limpiar filtros
+Estado vacío (sin resultados):
+"No encontramos talleres con esos filtros. Probá quitando alguno o ampliando la ubicación."
+
+2.5 Renombre ESTADO → COORD
+Cambios de copy en pantallas existentes
+
+Texto en la página "Quién es quién" / Ayuda
+"El rol COORD agrupa a las personas responsables de la coordinación institucional de la plataforma. Es el equipo que verifica documentación, define las etapas de formalización y acompaña a los talleres en su recorrido."
+Texto de transición (notificación a usuarios actuales con rol ESTADO)
+"El rol que tenías como ESTADO pasa a llamarse COORD. Tu acceso y tus permisos son los mismos. El cambio es de nomenclatura, no funcional."
+
+ETAPA 3 — Gobernanza estructural + Academia para marcas
+3.1 Sub-perfil COORD POLÍTICO / OPERATIVO
+Estructura
+El rol COORD se desdobla en dos sub-perfiles con permisos diferenciados. La UI muestra un módulo común y módulos específicos según el sub-perfil.
+Cabecera común (visible para los dos sub-perfiles)
+Título principal: Coordinación · [Político / Operativo]
+Subtítulo: Acompañamiento institucional del sector textil
+Pill indicadora de sub-perfil:
+- Político (color: azul oscuro)
+- Operativo (color: verde institucional)
+Sub-perfil POLÍTICO
+Texto del módulo de inicio:
+"Tu rol es estratégico. Acá ves cómo evoluciona el sector, configurás las políticas de formalización y producís informes para la gobernanza."
+Secciones del menú del POLÍTICO:
+- Estado del sector
+- Configuración de etapas y umbrales
+- Catálogo de cursos de la Academia
+- Plantillas de respuesta
+- Reportes institucionales
+Texto de la sección "Configuración de etapas y umbrales":
+"Acá definís qué documentos y verificaciones requiere cada etapa de formalización. Los cambios afectan a todos los talleres a partir del próximo ciclo."
+Texto de ayuda en plantillas de respuesta:
+"Las plantillas se ofrecen al perfil Operativo cuando aprueba o rechaza documentación. Vos definís el lenguaje institucional; ellos lo usan o lo adaptan al caso."
+Mensaje cuando intenta acceder a un documento individual:
+"El acceso a documentos individuales es del perfil Operativo. Vos definís políticas y ves agregados; ellos trabajan los casos."
+Sub-perfil OPERATIVO
+Texto del módulo de inicio:
+"Tu rol es ejecutivo. Acá trabajás los casos individuales: revisás documentación, aprobás avances de etapa y dejás observaciones de campo."
+Secciones del menú del OPERATIVO:
+- Mi agenda
+- Cola de verificaciones
+- Talleres
+- Observaciones de campo
+Texto de la sección "Cola de verificaciones":
+"Acá están los documentos que esperan tu revisión. Aprobá, rechazá con motivo o pedí una aclaración al taller."
+Botones de acción sobre cada documento:
+- Aprobar
+- Rechazar
+- Pedir aclaración
+Confirmación al aprobar:
+"Aprobado. El taller fue notificado automáticamente."
+Modal al rechazar:
+- Título: Rechazar documento
+- Subtítulo: "Indicá el motivo del rechazo. El taller recibirá tu mensaje."
+- Campo: motivo (mínimo 50 caracteres)
+- Selector: usar plantilla / escribir libre
+- Botón confirmación: Rechazar y notificar
+- Botón cancelar: Cancelar
+Modal al pedir aclaración:
+- Título: Pedir aclaración
+- Subtítulo: "Hacele una pregunta al taller. Tendrá oportunidad de responder una vez."
+- Campo: pregunta (texto libre)
+- Botón confirmación: Enviar pregunta
+- Botón cancelar: Cancelar
+Mensaje al pedir aclaración (cuando ya hubo una):
+"Ya hiciste una aclaración sobre este documento. Si seguís con dudas, aprobá o rechazá con el motivo correspondiente."
+Mensaje cuando intenta acceder a configuración política:
+"La configuración de etapas y umbrales es del perfil Político. Vos trabajás los casos individuales."
+Texto de transición (notificación a usuarios migrados al sub-perfil OPERATIVO)
+"Tu rol COORD se especificó como Operativo. Trabajás los casos individuales (verificaciones, observaciones de campo). La configuración de políticas es del perfil Político."
+
+3.2 Plantillas de rechazo
+Estructura
+El POLÍTICO gestiona el catálogo de plantillas. El OPERATIVO las usa al rechazar.
+Vista del POLÍTICO — gestión del catálogo
+Título de la sección: Plantillas de respuesta
+Texto introductorio:
+"Las plantillas se ofrecen al perfil Operativo cuando aprueba o rechaza documentación. Cada plantilla tiene un nombre interno y un mensaje al taller. Mantenelas claras y constructivas."
+Botón para crear plantilla: Nueva plantilla
+Formulario de plantilla:
+- Campo 1 — Nombre interno: "Cómo identificás esta plantilla. Solo lo ve el equipo COORD."
+- Campo 2 — Mensaje al taller: "El texto que recibe el taller. Hablale de vos a vos, sé concreto sobre qué cambiar."
+- Campo 3 — Tipo: rechazo / pedido de aclaración
+- Botón confirmación: Guardar plantilla
+- Botón cancelar: Cancelar
+Confirmación al guardar: "Plantilla guardada. Ya está disponible para el equipo Operativo."
+Estado vacío: "Todavía no creaste plantillas. Las plantillas ayudan a mantener un lenguaje institucional consistente."
+Vista del OPERATIVO — uso de plantillas al rechazar
+En el modal de rechazo:
+- Selector: "Usar plantilla" / "Escribir libre"
+- Si elige "Usar plantilla": dropdown con las plantillas activas. Al seleccionar una, el campo de motivo se rellena automáticamente y queda editable.
+- Si elige "Escribir libre": el campo de motivo queda vacío para escribir desde cero.
+Texto auxiliar:
+"Podés usar una plantilla y adaptarla al caso concreto antes de enviar."
+
+3.3 Academia para marcas
+Estructura
+Se habilita el tab "Cursos" para el rol MARCA. La marca ve un catálogo curado de cursos pensados para su rol: gestión de proveedores, comercio justo, calidad textil, costos.
+Cabecera del tab Cursos en rol MARCA
+Título principal: Cursos
+Subtítulo: Aprender sobre el sector textil, los procesos productivos y la formalización de tus proveedores.
+Banner contextual:
+"Los cursos están pensados para ayudarte a entender cómo trabajan los talleres con los que conectás. Cada uno tiene su catálogo de requisitos asociados — al completar un curso, ves qué requisitos del recorrido del taller estás ayudando a apuntalar."
+Estructura del catálogo
+El catálogo se organiza en categorías. Cada curso tiene:
+- Título del curso
+- Descripción corta (1-2 líneas)
+- Tiempo estimado de cursada
+- Categoría
+- Badge (si ya lo completaste)
+Categorías iniciales para la marca:
+- Cómo elegir proveedores
+- Gestión de la cadena productiva
+- Comercio justo y trabajo decente
+- Calidad textil
+- Costos y precios justos
+Vista de curso individual
+Cabecera del curso:
+- Título del curso
+- Categoría
+- Tiempo estimado
+- Botón principal: Empezar curso / Continuar curso / Ver certificado
+Sección "Qué vas a aprender":
+[bullets con los aprendizajes específicos del curso]
+Sección "Requisitos del recorrido del taller que apoya este curso":
+"Al completar este curso, vas a entender mejor estos requisitos que los talleres necesitan cumplir:"
+- [requisito 1]
+- [requisito 2]
+- [requisito 3]
+Sección "Cursos relacionados":
+[listado de otros cursos]
+Lógica de linkeo curso ↔ requisito
+Desde un curso (vista de la marca):
+- "Este curso te ayuda a entender los siguientes requisitos del recorrido del taller: [lista]"
+Desde un requisito (vista del taller, en Mi recorrido):
+- "Cursos que profundizan este requisito: [lista]"
+Estados
+
+Notificaciones
+
+Decisiones abiertas que afectan al copy final
+Algunas decisiones institucionales pendientes pueden modificar fragmentos del copy de arriba. Las marco acá para que estén visibles:
+¿Los cursos cuentan en el cálculo del recorrido del taller?
+- Si la respuesta es sí, el copy del Umbral 3 y del Bloque de Formación cambia para reflejar que los cursos suman a la formalización.
+- Si la respuesta es no (status quo), el copy actual queda.
+¿El renombre COORD → GOBERNANZA está confirmado?
+- Si OIT confirma "GOBERNANZA" como nombre institucional, hay que reemplazar todas las menciones de "COORD" del copy de arriba.
+¿Quién carga el contenido de cursos en producción? (O-05)
+- Si la respuesta involucra a INTI, las descripciones de la Academia pueden mencionar la cocreación.
+¿La validación sectorial del perfil del taller (G-18) ya se hizo?
+- Si se hizo, el copy de los bloques de la vidriera puede mencionarlo como referencia ("validado con el sector").
+¿Los textos legales (política de privacidad y términos) ya están ampliados?
+- Si están ampliados, los enlaces en el flujo de registro pueden referenciarlos directamente.
+
+Pendientes para Nivel 5 — copy fino
+Lo siguiente queda para un trabajo posterior dedicado al lenguaje (no es parte de las Etapas 2 y 3):
+- Mensajes de error específicos (validaciones de formulario, errores de API)
+- Emails transaccionales (asunto + cuerpo de los 10-15 emails operativos)
+- Notificaciones push (cuando se habilite mobile)
+- Lenguaje del onboarding inicial (primera vez que el usuario entra)
+- Footer institucional ampliado y leyendas legales
+- Textos de los formularios completos del perfil productivo (W-A)
+- Tooltips de cada campo del wizard
+
+Documento preliminar para validación con el equipo. Ajustes y sugerencias son bienvenidos antes de pasar a implementación.

--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,12 @@
 # Daily Log
 
+## 2026-06-21
+
+### Gerardo Breard
+- **15:43** `ee10ad9` — docs(narrativa): guardar copy de Etapas 2-3 como spec de referencia
+  - `.claude/specs/v4-narrativa-etapas-2-3-copy.md`
+
+
 ## 2026-06-19
 
 ### Gerardo Breard

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,10 @@
 ## 2026-06-21
 
 ### Gerardo Breard
+- **15:56** `7e30efd` — docs(observabilidad): bitacora de prod + runbook de observabilidad
+  - `.claude/BITACORA_PROD.md`
+  - `.claude/specs/RUNBOOK_OBSERVABILIDAD.md`
+
 - **15:54** `fcc260e` — feat(health): endpoint /api/health con check de DB para sondas externas
   - `src/app/api/health/route.ts`
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-06-21
 
 ### Gerardo Breard
+- **15:54** `fcc260e` — feat(health): endpoint /api/health con check de DB para sondas externas
+  - `src/app/api/health/route.ts`
+
 - **15:43** `ee10ad9` — docs(narrativa): guardar copy de Etapas 2-3 como spec de referencia
   - `.claude/specs/v4-narrativa-etapas-2-3-copy.md`
 

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/compartido/lib/prisma'
+
+// Health-check liviano para sondas externas (UptimeRobot, etc.). Devuelve 200
+// si la app responde Y la DB contesta un SELECT 1; 503 si la DB falla. Es mejor
+// que pingear la home (server component pesado, cacheable) porque caza caidas de
+// DB que la home podria enmascarar. Distinto de /api/health/version (que solo
+// reporta SHA/env sin tocar la DB).
+export const runtime = 'nodejs' // Prisma necesita Node, no Edge.
+export const dynamic = 'force-dynamic' // nunca cachear el resultado del check.
+
+export async function GET() {
+  try {
+    await prisma.$queryRaw`SELECT 1`
+    return NextResponse.json(
+      { status: 'ok', db: 'up' },
+      { status: 200, headers: { 'Cache-Control': 'no-store' } },
+    )
+  } catch {
+    // Log generico (sin el error crudo: puede traer connection string) — queda
+    // en los runtime logs de Vercel para correlacionar con la alerta de uptime.
+    console.error('[health] DB check failed: SELECT 1 did not respond')
+    return NextResponse.json(
+      { status: 'error', db: 'down' },
+      { status: 503, headers: { 'Cache-Control': 'no-store' } },
+    )
+  }
+}


### PR DESCRIPTION
Prerrequisito del deploy del piloto (orden de Sergio: "si algo se rompe en el piloto necesito poder verlo") + guardado del copy de narrativa como spec de referencia. **No toca prod ni schema.**

## Qué incluye

### Copy de narrativa (referencia)
- `.claude/specs/v4-narrativa-etapas-2-3-copy.md` — copy de Etapas 2 (narrativa core) y 3 (gobernanza/V4.5). Insumo de implementación; **no se implementa nada del copy todavía**.

### Observabilidad — código/config
- **`src/app/api/health/route.ts`** (nuevo): `GET /api/health` hace `SELECT 1` vía Prisma → `200 {status:ok,db:up}` o `503 {db:down}`. Para sondas de uptime; caza caídas de DB que la home (server component pesado/cacheable) podría enmascarar. No filtra detalles del error de DB. Distinto de `/api/health/version` (solo SHA/env).
- **`.claude/BITACORA_PROD.md`** (nuevo): registro de deploys/incidentes con plantilla (tipo/severidad/qué pasó/detección/impacto/resolución/aprendizaje) + primera entrada (deploy a prod 13-jun, ref DAILY). Lectura previa de la revisión semanal.

### Observabilidad — guía para Gerardo (cuentas externas)
- **`.claude/specs/RUNBOOK_OBSERVABILIDAD.md`** (nuevo): pasos exactos para activar lo externo —
  - Alertas nativas de Vercel: qué hay (email de deploy fallido, Slack de deploy) y qué **no** (no hay alerta por error-rate en Hobby/Pro, no hay uptime) + pasos manuales.
  - Uptime con **UptimeRobot** (free) apuntando a `/api/health`, tipo Keyword `"db":"up"`, cada 5 min.
  - Canal de alertas: **Telegram** (recomendado) vs Slack.
  - **Sentry: recomendación honesta de diferir** para un piloto de 4 talleres (Vercel nativo + uptime + health alcanzan); montar solo si aparece un bug no reproducible/no visible en logs.

## Decisiones que necesitan a Gerardo antes del deploy
1. Confirmar dominio canónico de prod para la URL del health.
2. Activar/confirmar notificaciones de deploy fallido en Vercel.
3. Crear el monitor de UptimeRobot.
4. Elegir canal (Telegram recomendado).
5. Decidir sobre Sentry (recomendación: diferir).

## Notas
- Type-check local no corrió (toolchain TS roto en WSL `/mnt/d` — T-01 conocido); lo valida el build de Vercel.
- `/api/health` se smoke-testea contra el preview una vez que levante.

🤖 Generated with [Claude Code](https://claude.com/claude-code)