### PR TITLE
feat: Etapa 2.2 visibilidad vidriera — fundacional (schema + helper + filtro)

### DIFF
--- a/.claude/specs/v4-etapa2-visibilidad-schema-propuesta.md
+++ b/.claude/specs/v4-etapa2-visibilidad-schema-propuesta.md
@@ -5,6 +5,8 @@
 > **Insumos:** copy `v4-narrativa-etapas-2-3-copy.md` §2.2 · master `narrativa-V4-consolidado-niveles-1-a-4.md` §1.3 + §4.5 (Modelo B) · `prisma/schema.prisma` (model Taller) · `src/app/(public)/perfil/[id]/page.tsx`.
 > **Decisión previa de Gerardo:** toggle **por bloque, NO granular** por ahora.
 
+> ✅ **EJECUTADO (fundacional) — rama `feature/etapa2-visibilidad-schema`.** Gerardo aprobó las 6 decisiones (Opción A JSONB; Formación on/off bloque; SAM siempre privado; visibilidad de marca diferida; 6 bloques + Credenciales fijo; Gerardo modela/migra). Este PR trae **solo lo fundacional**: campo `visibilidadVidriera Json?` + migración aditiva `20260621120000_agregar_visibilidad_vidriera` (aplicada a DEV), helper `src/compartido/lib/visibilidad-vidriera.ts` + tests, y el filtro en el render público. **Behavior-preserving:** todos los talleres actuales tienen `null` ⇒ todo visible ⇒ sin cambio percibido hasta que exista la UI de toggle. **NO incluye** (PRs siguientes): UI "Configuración de visibilidad", sub-tabs (2.1), "Mi gestión productiva", endpoint de escritura.
+
 Es el **cuello de botella técnico de la Etapa 2**: lo usan los 3 bloques de la vidriera y no depende de decisiones de producto. Una vez resuelto, desbloquea 2.1 (sub-tabs), 2.2 (reorg + Formación) y el botón "Ver cómo me ve el directorio".
 
 ---
@@ -136,6 +138,8 @@ model Taller {
 - §1.3 también incluía **1.4 (vitrina con info de marca en cada pedido)** — no es visibilidad de perfil, fuera de alcance.
 
 **Conclusión:** cubre el **núcleo taller de §1.3 Modelo B completo**, salvo la pieza simétrica de marca y la granularidad por-badge (ambas explícitamente fuera del alcance "por bloque, taller").
+
+> ✅ **El núcleo taller de §1.3 (datos + helper + filtro) queda cubierto por el PR `feature/etapa2-visibilidad-schema`.** Pendiente sobre esta base (PRs siguientes): UI de toggles, botón "Ver cómo me ve el directorio", "Mi gestión productiva". Diferido: visibilidad de marca y Formación por-badge.
 
 ---
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-06-21
 
 ### Gerardo Breard
+- **17:48** `66676ab` — docs(spec): propuesta schema visibilidad vidriera (Etapa 2.2 / Modelo B)
+  - `.claude/specs/v4-etapa2-visibilidad-schema-propuesta.md`
+
 - **16:50** `4cbe96b` — docs(spec): discovery Etapa 2 narrativa V4 (relevamiento, no implementa)
   - `.claude/specs/v4-narrativa-etapa-2-discovery.md`
 

--- a/prisma/migrations/20260621120000_agregar_visibilidad_vidriera/migration.sql
+++ b/prisma/migrations/20260621120000_agregar_visibilidad_vidriera/migration.sql
@@ -1,0 +1,4 @@
+-- Etapa 2.2 / Modelo B (§1.3): visibilidad por bloque de la vidriera del taller.
+-- Aditiva pura: columna nullable, sin default, sin backfill. Filas existentes -> NULL = todo visible.
+-- AlterTable
+ALTER TABLE "talleres" ADD COLUMN "visibilidadVidriera" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -291,6 +291,12 @@ model Taller {
   paradasFrecuencia    String?
   rolesFuncionales     Json?      // W-A5: roles funcionales del taller
 
+  // Etapa 2.2 / Modelo B (§1.3): visibilidad por bloque de la vidriera.
+  // Objeto { formacion?, equipo?, espacio?, capacidad?, organizacion?, maquinaria? } (bool).
+  // null o key ausente = visible (default behavior-preserving). Solo `false` explicito oculta.
+  // Credenciales (etapa + ARCA) nunca se oculta; SAM nunca se expone en publico.
+  visibilidadVidriera  Json?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/src/__tests__/visibilidad-vidriera.test.ts
+++ b/src/__tests__/visibilidad-vidriera.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import {
+  BLOQUES_VIDRIERA,
+  bloqueVisible,
+  normalizarVisibilidad,
+  samVisible,
+  type BloqueVidriera,
+} from '@/compartido/lib/visibilidad-vidriera'
+
+describe('visibilidad-vidriera', () => {
+  describe('default = todo visible (behavior-preserving)', () => {
+    it('null => todos los bloques visibles', () => {
+      for (const b of BLOQUES_VIDRIERA) {
+        expect(bloqueVisible({ visibilidadVidriera: null }, b)).toBe(true)
+      }
+    })
+
+    it('campo ausente (undefined) => todos visibles', () => {
+      for (const b of BLOQUES_VIDRIERA) {
+        expect(bloqueVisible({}, b)).toBe(true)
+      }
+    })
+
+    it('objeto vacio {} => todos visibles', () => {
+      const norm = normalizarVisibilidad({})
+      for (const b of BLOQUES_VIDRIERA) expect(norm[b]).toBe(true)
+    })
+
+    it('key ausente dentro del objeto => ese bloque visible', () => {
+      // solo declara maquinaria; el resto debe quedar visible
+      const taller = { visibilidadVidriera: { maquinaria: true } }
+      expect(bloqueVisible(taller, 'equipo')).toBe(true)
+      expect(bloqueVisible(taller, 'formacion')).toBe(true)
+    })
+  })
+
+  describe('solo false explicito oculta', () => {
+    it('flag en false => bloque oculto', () => {
+      const taller = { visibilidadVidriera: { maquinaria: false } }
+      expect(bloqueVisible(taller, 'maquinaria')).toBe(false)
+    })
+
+    it('flag en true => bloque visible', () => {
+      const taller = { visibilidadVidriera: { formacion: true } }
+      expect(bloqueVisible(taller, 'formacion')).toBe(true)
+    })
+
+    it('oculta solo el bloque marcado, el resto sigue visible', () => {
+      const taller = { visibilidadVidriera: { espacio: false } }
+      expect(bloqueVisible(taller, 'espacio')).toBe(false)
+      expect(bloqueVisible(taller, 'capacidad')).toBe(true)
+      expect(bloqueVisible(taller, 'organizacion')).toBe(true)
+    })
+  })
+
+  describe('JSON invalido / defensivo => visible', () => {
+    it('valor no-booleano (string "false") no oculta', () => {
+      const taller = { visibilidadVidriera: { maquinaria: 'false' } }
+      expect(bloqueVisible(taller, 'maquinaria')).toBe(true)
+    })
+
+    it('array u otros tipos => todo visible', () => {
+      expect(bloqueVisible({ visibilidadVidriera: [] }, 'equipo')).toBe(true)
+      expect(bloqueVisible({ visibilidadVidriera: 'x' }, 'equipo')).toBe(true)
+      expect(bloqueVisible({ visibilidadVidriera: 42 }, 'equipo')).toBe(true)
+    })
+
+    it('0 / null por bloque no cuentan como false explicito => visible', () => {
+      const taller = { visibilidadVidriera: { equipo: 0, espacio: null } }
+      expect(bloqueVisible(taller, 'equipo')).toBe(true)
+      expect(bloqueVisible(taller, 'espacio')).toBe(true)
+    })
+  })
+
+  describe('invariante Credenciales: nunca toggleable', () => {
+    it('credenciales no esta en la lista de bloques toggleables', () => {
+      expect((BLOQUES_VIDRIERA as readonly string[]).includes('credenciales')).toBe(false)
+    })
+
+    it('una key "credenciales: false" en el JSON no afecta a ningun bloque real', () => {
+      const taller = { visibilidadVidriera: { credenciales: false } as Record<string, unknown> }
+      for (const b of BLOQUES_VIDRIERA) {
+        expect(bloqueVisible(taller, b as BloqueVidriera)).toBe(true)
+      }
+    })
+  })
+
+  describe('invariante SAM: nunca publico', () => {
+    it('SAM no es visible en contexto publico', () => {
+      expect(samVisible('publico')).toBe(false)
+    })
+
+    it('SAM si es visible en contexto privado', () => {
+      expect(samVisible('privado')).toBe(true)
+    })
+
+    it('SAM publico es false aunque el bloque capacidad este visible', () => {
+      const taller = { visibilidadVidriera: { capacidad: true } }
+      expect(bloqueVisible(taller, 'capacidad')).toBe(true)
+      expect(samVisible('publico')).toBe(false)
+    })
+  })
+})

--- a/src/app/(public)/perfil/[id]/page.tsx
+++ b/src/app/(public)/perfil/[id]/page.tsx
@@ -7,6 +7,7 @@ import { Card } from '@/compartido/componentes/ui/card'
 import { Star, MapPin, Users, TrendingUp, Clock, Award, ShieldCheck } from 'lucide-react'
 import { GaleriaFotos } from '@/taller/componentes/galeria-fotos'
 import { BadgeArca } from '@/compartido/componentes/badge-arca'
+import { bloqueVisible } from '@/compartido/lib/visibilidad-vidriera'
 
 export default async function PerfilPublicoPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -109,7 +110,7 @@ export default async function PerfilPublicoPage({ params }: { params: Promise<{ 
         </Card>
       )}
 
-      {taller.maquinaria.length > 0 && (
+      {taller.maquinaria.length > 0 && bloqueVisible(taller, 'maquinaria') && (
         <Card title="Maquinaria" className="mb-4">
           <ul className="space-y-1 text-sm">
             {taller.maquinaria.map((m: { id: string; nombre: string; cantidad: number }) => (
@@ -134,7 +135,7 @@ export default async function PerfilPublicoPage({ params }: { params: Promise<{ 
         </Card>
       )}
 
-      {taller.certificados.length > 0 && (
+      {taller.certificados.length > 0 && bloqueVisible(taller, 'formacion') && (
         <Card title="Capacitaciones certificadas">
           <div className="space-y-2">
             {taller.certificados.map((cert: { id: string; codigo: string; coleccion: { titulo: string; institucion: string | null } }) => (

--- a/src/compartido/lib/visibilidad-vidriera.ts
+++ b/src/compartido/lib/visibilidad-vidriera.ts
@@ -1,0 +1,75 @@
+// Visibilidad por bloque de la vidriera del taller (Etapa 2.2 / Modelo B, §1.3).
+//
+// El taller puede ocultar bloques completos de su vidriera publica desde
+// "Configuracion de visibilidad" (UI de un PR posterior). Este modulo es la base:
+// el tipo, el normalizador y el helper de consulta que usa el render publico.
+//
+// Reglas (invariantes del Modelo B):
+// - Default = TODO VISIBLE. `visibilidadVidriera` null/ausente, o una key faltante,
+//   significa visible. Solo `false` explicito oculta un bloque. Esto hace que el
+//   comportamiento actual (todos los talleres con el campo en null) sea identico.
+// - Credenciales (etapa + ARCA) NUNCA se oculta: no es un bloque toggleable.
+// - SAM NUNCA se expone en la vidriera publica, sin importar el toggle de `capacidad`.
+
+/** Bloques de la vidriera que el taller puede mostrar/ocultar a las marcas. */
+export type BloqueVidriera =
+  | 'formacion'
+  | 'equipo'
+  | 'espacio'
+  | 'capacidad'
+  | 'organizacion'
+  | 'maquinaria'
+
+/** Lista canonica de bloques toggleables (Credenciales no esta: es fijo). */
+export const BLOQUES_VIDRIERA: readonly BloqueVidriera[] = [
+  'formacion',
+  'equipo',
+  'espacio',
+  'capacidad',
+  'organizacion',
+  'maquinaria',
+] as const
+
+/** Forma persistida en `Taller.visibilidadVidriera` (todas las keys opcionales). */
+export type VisibilidadVidriera = Partial<Record<BloqueVidriera, boolean>>
+
+/**
+ * Normaliza el JSON crudo del campo a forma canonica: devuelve TODOS los bloques
+ * con un booleano explicito. Convencion: solo `false` oculta; cualquier otra cosa
+ * (ausente, null, no-booleano, JSON invalido) = visible.
+ */
+export function normalizarVisibilidad(
+  raw: unknown,
+): Record<BloqueVidriera, boolean> {
+  const obj =
+    raw && typeof raw === 'object' && !Array.isArray(raw)
+      ? (raw as Record<string, unknown>)
+      : {}
+  const out = {} as Record<BloqueVidriera, boolean>
+  for (const bloque of BLOQUES_VIDRIERA) {
+    // Solo el valor `false` explicito oculta; todo lo demas queda visible.
+    out[bloque] = obj[bloque] !== false
+  }
+  return out
+}
+
+/**
+ * ¿Se muestra este bloque en la vidriera publica?
+ * Credenciales no se consulta aca (siempre visible). SAM es un invariante de
+ * render aparte (ver `samVisible`), no un bloque.
+ */
+export function bloqueVisible(
+  taller: { visibilidadVidriera?: unknown },
+  bloque: BloqueVidriera,
+): boolean {
+  return normalizarVisibilidad(taller?.visibilidadVidriera)[bloque]
+}
+
+/**
+ * Invariante SAM: el SAM (minutos estandar) solo es visible en contexto privado
+ * ("Mi gestion productiva"). NUNCA en la vidriera publica, aunque el bloque
+ * `capacidad` este visible. Protege la cotizacion del taller (§4.5).
+ */
+export function samVisible(contexto: 'publico' | 'privado'): boolean {
+  return contexto === 'privado'
+}


### PR DESCRIPTION
## Qué es

Base del mecanismo de **visibilidad por bloque de la vidriera** (Etapa 2.2 del copy / §1.3 Modelo B del master). Es el cuello de botella técnico de la Etapa 2. Aprobado por Gerardo (6 decisiones, ver `.claude/specs/v4-etapa2-visibilidad-schema-propuesta.md`).

**Solo lo fundacional.** La UI de "Configuración de visibilidad", los sub-tabs (2.1), "Mi gestión productiva" y el endpoint de escritura son **PRs siguientes**. Este PR deja campo + helper + filtro listos.

## Behavior-preserving ⚠️

Todos los talleres actuales tienen `visibilidadVidriera = null` ⇒ **todo visible** ⇒ la página `/perfil/[id]` renderiza **exactamente lo de hoy**. Nadie ve un cambio hasta que exista la UI para togglear.

## Cambios

- **Schema:** `Taller.visibilidadVidriera Json?` (nullable, `null` = todo visible).
- **Migración aditiva** `20260621120000_agregar_visibilidad_vidriera` — `ADD COLUMN ... JSONB` nullable, **sin backfill, sin default**. Aplicada a DEV vía `migrate deploy`. Filas existentes → `null` (garantía Postgres: columna nullable sin default no reescribe).
- **Helper** `src/compartido/lib/visibilidad-vidriera.ts`: `type BloqueVidriera` (6), `BLOQUES_VIDRIERA`, `normalizarVisibilidad()` (ausente/no-bool = visible; solo `false` oculta), `bloqueVisible(taller, bloque)`, `samVisible(contexto)`.
  - Invariante **Credenciales**: nunca toggleable (siempre visible).
  - Invariante **SAM**: nunca público, aunque `capacidad` esté visible.
- **Tests unitarios** del helper: default visible, `false` oculta, defensivo (JSON inválido/array/no-bool), Credenciales fijo, SAM nunca público.
- **Render público** `(public)/perfil/[id]/page.tsx`: filtro `bloqueVisible()` en **Maquinaria** y **Formación** (los únicos bloques toggleables que hoy se renderizan en esa página). Credenciales (header/ARCA/etapa) sin filtro.

## Notas

- **SAM ya no se exponía** en `/perfil/[id]` (solo aparece `capacidadMensual` como contador resumen, nunca SAM). Este PR preserva ese estado y deja el invariante `samVisible()` listo para cuando el reorg (2.2) sume el bloque capacidad a la vista pública.
- Los otros 4 bloques toggleables (equipo, espacio, capacidad-detalle, organización) **aún no se renderizan** en la vista pública; se gatearán con el mismo helper cuando el reorg de 2.2 los agregue.
- **Toolchain (T-01):** `vitest`/`prisma`/`tsc` locales no corren en /mnt/d (node_modules bin rotos). Migración aplicada con `prisma@6.19.2` vía npx; lógica del helper sanity-checada con tsx (11/11); el type-check y los unit tests corren en CI/Vercel.

## Fuera de alcance (PRs siguientes)
UI "Configuración de visibilidad" · sub-tabs "Mi taller" (2.1) · "Mi gestión productiva" · botón "Ver cómo me ve el directorio" · endpoint de escritura · visibilidad simétrica de marca (diferida) · Formación por-badge (diferida).

🤖 Generated with [Claude Code](https://claude.com/claude-code)