### PR TITLE
feat: Etapa 2.1 — sub-tabs "Mi taller" (vidriera | gestión productiva)

### DIFF
--- a/src/app/(public)/perfil/[id]/page.tsx
+++ b/src/app/(public)/perfil/[id]/page.tsx
@@ -2,12 +2,7 @@ export const dynamic = 'force-dynamic'
 
 import { notFound } from 'next/navigation'
 import { prisma } from '@/compartido/lib/prisma'
-import { Badge } from '@/compartido/componentes/ui/badge'
-import { Card } from '@/compartido/componentes/ui/card'
-import { MapPin, Award, ShieldCheck } from 'lucide-react'
-import { GaleriaFotos } from '@/taller/componentes/galeria-fotos'
-import { BadgeArca } from '@/compartido/componentes/badge-arca'
-import { bloqueVisible } from '@/compartido/lib/visibilidad-vidriera'
+import { VidrieraPublicaContenido } from '@/taller/componentes/vidriera-publica-contenido'
 
 export default async function PerfilPublicoPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -40,103 +35,7 @@ export default async function PerfilPublicoPage({ params }: { params: Promise<{ 
         </a>
       </div>
 
-      <div className="mb-6">
-        <h1 className="font-overpass font-bold text-3xl text-brand-blue mb-2">{taller.nombre}</h1>
-        {(taller.verificadoAfip || taller.validaciones.length > 0) && (
-          <div className="flex flex-wrap items-center gap-2 mb-2">
-            {taller.verificadoAfip && <BadgeArca verificado={true} />}
-            {taller.validaciones.map((v: { tipoDocumento: { nombre: string } }, i: number) => (
-              <Badge key={i} variant="success"><ShieldCheck className="w-3 h-3 mr-1" />{v.tipoDocumento.nombre}</Badge>
-            ))}
-          </div>
-        )}
-        {taller.provincia && (
-          <p className="flex items-center gap-1 text-gray-600">
-            <MapPin className="w-4 h-4" /> {taller.provincia}{taller.partido ? `, ${taller.partido}` : ''}
-            {taller.ubicacionDetalle && <span className="text-gray-400"> · {taller.ubicacionDetalle}</span>}
-          </p>
-        )}
-        {taller.descripcion && (
-          <p className="text-gray-600 text-sm italic mt-2">&quot;{taller.descripcion}&quot;</p>
-        )}
-      </div>
-
-      {/* Cleanup re-QA: tarjetas de marketplace eliminadas de la vista PÚBLICA
-          (mismo criterio que "Mi vidriera"). Rating / On-time = fuera total
-          (no aplican al modelo PDT). Trabajadores / Cap. mensual = su lugar
-          final es el bloque "capacidad" (toggleable) de la Etapa 2.2. */}
-
-      {taller.procesos.length > 0 && (
-        <Card title="Procesos" className="mb-4">
-          <div className="flex flex-wrap gap-2">
-            {taller.procesos.map((tp: { id: string; proceso: { nombre: string } }) => (
-              <Badge key={tp.id} variant="outline">{tp.proceso.nombre}</Badge>
-            ))}
-          </div>
-        </Card>
-      )}
-
-      {taller.prendas.length > 0 && (
-        <Card title="Tipos de prenda" className="mb-4">
-          <div className="flex flex-wrap gap-2">
-            {taller.prendas.map((tp: { id: string; prenda: { nombre: string } }) => (
-              <Badge key={tp.id} variant="outline">{tp.prenda.nombre}</Badge>
-            ))}
-          </div>
-        </Card>
-      )}
-
-      {taller.portfolioFotos.length > 0 && (
-        <Card title="Trabajos realizados" className="mb-4">
-          <GaleriaFotos fotos={taller.portfolioFotos} />
-        </Card>
-      )}
-
-      {taller.maquinaria.length > 0 && bloqueVisible(taller, 'maquinaria') && (
-        <Card title="Maquinaria" className="mb-4">
-          <ul className="space-y-1 text-sm">
-            {taller.maquinaria.map((m: { id: string; nombre: string; cantidad: number }) => (
-              <li key={m.id} className="flex justify-between">
-                <span>{m.nombre}</span>
-                <span className="text-gray-500">x{m.cantidad}</span>
-              </li>
-            ))}
-          </ul>
-        </Card>
-      )}
-
-      {taller.certificaciones.length > 0 && (
-        <Card title="Certificaciones" className="mb-4">
-          <div className="flex flex-wrap gap-2">
-            {taller.certificaciones.map((c: { id: string; nombre: string }) => (
-              <Badge key={c.id} variant="success">
-                <Award className="w-3 h-3 mr-1" />{c.nombre}
-              </Badge>
-            ))}
-          </div>
-        </Card>
-      )}
-
-      {taller.certificados.length > 0 && bloqueVisible(taller, 'formacion') && (
-        <Card title="Capacitaciones certificadas">
-          <div className="space-y-2">
-            {taller.certificados.map((cert: { id: string; codigo: string; coleccion: { titulo: string; institucion: string | null } }) => (
-              <div key={cert.id} className="flex items-center justify-between text-sm">
-                <div>
-                  <span className="font-medium">{cert.coleccion.titulo}</span>
-                  {cert.coleccion.institucion && (
-                    <span className="text-gray-500 ml-2">· {cert.coleccion.institucion}</span>
-                  )}
-                </div>
-                <a href={`/verificar?code=${cert.codigo}`}
-                  className="text-brand-blue underline text-xs">
-                  Verificar
-                </a>
-              </div>
-            ))}
-          </div>
-        </Card>
-      )}
+      <VidrieraPublicaContenido taller={taller} />
     </div>
   )
 }

--- a/src/app/(public)/perfil/[id]/page.tsx
+++ b/src/app/(public)/perfil/[id]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from 'next/navigation'
 import { prisma } from '@/compartido/lib/prisma'
 import { Badge } from '@/compartido/componentes/ui/badge'
 import { Card } from '@/compartido/componentes/ui/card'
-import { Star, MapPin, Users, TrendingUp, Clock, Award, ShieldCheck } from 'lucide-react'
+import { MapPin, Award, ShieldCheck } from 'lucide-react'
 import { GaleriaFotos } from '@/taller/componentes/galeria-fotos'
 import { BadgeArca } from '@/compartido/componentes/badge-arca'
 import { bloqueVisible } from '@/compartido/lib/visibilidad-vidriera'
@@ -61,28 +61,10 @@ export default async function PerfilPublicoPage({ params }: { params: Promise<{ 
         )}
       </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-        <Card className="text-center p-4">
-          <Star className="w-5 h-5 text-yellow-500 mx-auto mb-1" />
-          <p className="font-overpass font-bold text-2xl text-brand-blue">{taller.rating.toFixed(1)}</p>
-          <p className="text-xs text-gray-500">Rating</p>
-        </Card>
-        <Card className="text-center p-4">
-          <Users className="w-5 h-5 text-brand-blue mx-auto mb-1" />
-          <p className="font-overpass font-bold text-2xl text-brand-blue">{taller.trabajadoresRegistrados}</p>
-          <p className="text-xs text-gray-500">Trabajadores</p>
-        </Card>
-        <Card className="text-center p-4">
-          <TrendingUp className="w-5 h-5 text-green-600 mx-auto mb-1" />
-          <p className="font-overpass font-bold text-2xl text-brand-blue">{taller.capacidadMensual.toLocaleString()}</p>
-          <p className="text-xs text-gray-500">Cap. mensual</p>
-        </Card>
-        <Card className="text-center p-4">
-          <Clock className="w-5 h-5 text-blue-500 mx-auto mb-1" />
-          <p className="font-overpass font-bold text-2xl text-brand-blue">{taller.ontimeRate}%</p>
-          <p className="text-xs text-gray-500">On-time</p>
-        </Card>
-      </div>
+      {/* Cleanup re-QA: tarjetas de marketplace eliminadas de la vista PÚBLICA
+          (mismo criterio que "Mi vidriera"). Rating / On-time = fuera total
+          (no aplican al modelo PDT). Trabajadores / Cap. mensual = su lugar
+          final es el bloque "capacidad" (toggleable) de la Etapa 2.2. */}
 
       {taller.procesos.length > 0 && (
         <Card title="Procesos" className="mb-4">

--- a/src/app/(taller)/taller/perfil/completar/page.tsx
+++ b/src/app/(taller)/taller/perfil/completar/page.tsx
@@ -7,6 +7,7 @@ import { Card } from '@/compartido/componentes/ui/card'
 import { Button } from '@/compartido/componentes/ui/button'
 import { Input } from '@/compartido/componentes/ui/input'
 import { Badge } from '@/compartido/componentes/ui/badge'
+import { Breadcrumbs } from '@/compartido/componentes/ui/breadcrumbs'
 import { useToast } from '@/compartido/componentes/ui/toast'
 
 const STEPS = [
@@ -243,6 +244,13 @@ export default function WizardPage() {
 
   return (
     <div className="max-w-3xl mx-auto py-6 px-4">
+      {/* Salida del wizard: el taller no queda "atrapado" en el flujo de pasos. */}
+      <Breadcrumbs items={[
+        { label: 'Mi taller', href: '/taller/perfil' },
+        { label: 'Mi gestión productiva', href: '/taller/perfil/gestion' },
+        { label: 'Completar perfil productivo' },
+      ]} />
+
       {/* Progress bar */}
       <div className="mb-2 flex items-center gap-2">
         <div className="flex-1 h-2 bg-gray-200 rounded-full overflow-hidden">

--- a/src/app/(taller)/taller/perfil/completar/page.tsx
+++ b/src/app/(taller)/taller/perfil/completar/page.tsx
@@ -711,10 +711,24 @@ export default function WizardPage() {
 
       {/* Navigation */}
       {step > 0 && step < 13 && (
-        <div className="flex justify-between mt-6 sticky bottom-0 -mx-4 px-4 py-3 bg-white/95 backdrop-blur border-t border-gray-100 sm:static sm:mx-0 sm:px-0 sm:py-0 sm:bg-transparent sm:backdrop-blur-none sm:border-0">
-          <Button variant="secondary" onClick={prev} icon={<ArrowLeft className="w-4 h-4" />}>Atrás</Button>
-          <Button onClick={next} icon={<ArrowRight className="w-4 h-4" />}>Siguiente</Button>
-        </div>
+        <>
+          <div className="flex justify-between mt-6 sticky bottom-0 -mx-4 px-4 py-3 bg-white/95 backdrop-blur border-t border-gray-100 sm:static sm:mx-0 sm:px-0 sm:py-0 sm:bg-transparent sm:backdrop-blur-none sm:border-0">
+            <Button variant="secondary" onClick={prev} icon={<ArrowLeft className="w-4 h-4" />}>Atrás</Button>
+            <Button onClick={next} icon={<ArrowRight className="w-4 h-4" />}>Siguiente</Button>
+          </div>
+          {/* Salida guardando progreso parcial desde cualquier paso intermedio.
+              Reusa handleSave (PUT con el estado actual) y vuelve a Mi gestión productiva. */}
+          <div className="text-center mt-3">
+            <button
+              type="button"
+              onClick={() => handleSave('/taller/perfil/gestion')}
+              disabled={saving}
+              className="text-sm text-gray-500 hover:underline disabled:opacity-50"
+            >
+              {saving ? 'Guardando...' : 'Guardar y completar después'}
+            </button>
+          </div>
+        </>
       )}
     </div>
   )

--- a/src/app/(taller)/taller/perfil/gestion/page.tsx
+++ b/src/app/(taller)/taller/perfil/gestion/page.tsx
@@ -6,6 +6,7 @@ import { redirect } from 'next/navigation'
 import Link from 'next/link'
 import { Card } from '@/compartido/componentes/ui/card'
 import { Button } from '@/compartido/componentes/ui/button'
+import { Lock } from 'lucide-react'
 import { labelOrganizacion, labelRegistro, labelEscalabilidad } from '@/compartido/lib/taller-formulario'
 
 // Etapa 2.1 — "Mi gestión productiva": datos privados del taller (solo el taller
@@ -19,6 +20,7 @@ export default async function TallerGestionPage() {
     where: { userId: session.user.id },
     include: {
       plantilla: { orderBy: { categoria: 'asc' } },
+      user: { select: { name: true, email: true, phone: true } },
     },
   })
 
@@ -35,6 +37,33 @@ export default async function TallerGestionPage() {
 
   return (
     <div className="space-y-6">
+      {/* Datos del responsable — PII privada, movida desde la cabecera común.
+          No visible para las marcas (minimización de datos, OIT IGDS 457). */}
+      <Card title="Datos del responsable">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+          {taller.user.name && (
+            <div>
+              <p className="text-gray-500">Responsable</p>
+              <p className="font-medium break-words">{taller.user.name}</p>
+            </div>
+          )}
+          <div>
+            <p className="text-gray-500">Email</p>
+            <p className="font-medium break-words">{taller.user.email}</p>
+          </div>
+          {taller.user.phone && (
+            <div>
+              <p className="text-gray-500">Teléfono</p>
+              <p className="font-medium break-words">{taller.user.phone}</p>
+            </div>
+          )}
+        </div>
+        <p className="flex items-center gap-1 text-xs text-gray-400 mt-4">
+          <Lock className="w-3 h-3 shrink-0" />
+          Esta información de contacto es privada. Las marcas no la ven en tu vidriera.
+        </p>
+      </Card>
+
       <Card title="Información General">
         <div className="grid grid-cols-2 gap-4 text-sm">
           <div>
@@ -131,6 +160,12 @@ export default async function TallerGestionPage() {
             Esta información es visible para el equipo de la plataforma y la Coordinación.
             No afecta tu recorrido de formalización.
           </p>
+
+          <div className="mt-4">
+            <Link href="/taller/perfil/completar">
+              <Button variant="secondary" size="sm">Actualizar perfil productivo</Button>
+            </Link>
+          </div>
         </Card>
       )}
 

--- a/src/app/(taller)/taller/perfil/gestion/page.tsx
+++ b/src/app/(taller)/taller/perfil/gestion/page.tsx
@@ -1,0 +1,149 @@
+export const dynamic = 'force-dynamic'
+
+import { auth } from '@/compartido/lib/auth'
+import { prisma } from '@/compartido/lib/prisma'
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { Card } from '@/compartido/componentes/ui/card'
+import { Button } from '@/compartido/componentes/ui/button'
+import { labelOrganizacion, labelRegistro, labelEscalabilidad } from '@/compartido/lib/taller-formulario'
+
+// Etapa 2.1 — "Mi gestión productiva": datos privados del taller (solo el taller
+// y el acompañamiento los ven; no aparecen en el directorio). Contenido repartido
+// desde la vista única anterior de perfil. El filtrado por visibilidad es 2.2.
+export default async function TallerGestionPage() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const taller = await prisma.taller.findFirst({
+    where: { userId: session.user.id },
+    include: {
+      plantilla: { orderBy: { categoria: 'asc' } },
+    },
+  })
+
+  if (!taller) {
+    return (
+      <Card className="text-center py-12">
+        <p className="text-gray-600 mb-4">Todavía no completaste tu perfil.</p>
+        <Link href="/taller/perfil/completar">
+          <Button>Completar Perfil</Button>
+        </Link>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card title="Información General">
+        <div className="grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <p className="text-gray-500">CUIT</p>
+            <p className="font-medium">{taller.cuit}</p>
+          </div>
+          {taller.fundado && (
+            <div>
+              <p className="text-gray-500">Fundado</p>
+              <p className="font-medium">{taller.fundado}</p>
+            </div>
+          )}
+          <div>
+            <p className="text-gray-500">Pedidos completados</p>
+            <p className="font-medium">{taller.pedidosCompletados}</p>
+          </div>
+          <div>
+            <p className="text-gray-500">Puntaje</p>
+            <p className="font-medium">{taller.puntaje} pts</p>
+          </div>
+        </div>
+      </Card>
+
+      {taller.organizacion && (
+        <Card title="Perfil productivo">
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4 text-sm">
+
+            <div className="bg-gray-50 rounded-lg p-3">
+              <p className="text-gray-500 text-xs mb-1">Organización</p>
+              <p className="font-medium text-gray-800">
+                {labelOrganizacion(taller.organizacion)}
+              </p>
+            </div>
+
+            {(taller.metrosCuadrados ?? 0) > 0 && (
+              <div className="bg-gray-50 rounded-lg p-3">
+                <p className="text-gray-500 text-xs mb-1">Espacio</p>
+                <p className="font-medium text-gray-800">{taller.metrosCuadrados} m²</p>
+              </div>
+            )}
+
+            {taller.plantilla.length > 0 && taller.plantilla.some(p => p.cantidad > 0) ? (
+              <div className="bg-gray-50 rounded-lg p-3">
+                <p className="text-gray-500 text-xs mb-1">Composición del equipo</p>
+                <div className="space-y-1">
+                  {taller.plantilla.filter(p => p.cantidad > 0).map(p => (
+                    <p key={p.categoria} className="font-medium text-gray-800 text-sm">
+                      {p.categoria === 'APRENDIZ' ? 'Aprendices'
+                       : p.categoria === 'MEDIO_OFICIAL' ? 'Medio oficial'
+                       : p.categoria === 'OFICIAL' ? 'Oficial'
+                       : 'Oficial calificado'}: {p.cantidad}
+                    </p>
+                  ))}
+                  <p className="text-xs text-gray-500 mt-1">
+                    Total: {taller.plantilla.reduce((sum, p) => sum + p.cantidad, 0)} personas
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="bg-gray-50 rounded-lg p-3">
+                <p className="text-gray-500 text-xs mb-1">Composición del equipo</p>
+                <p className="text-sm text-gray-400 italic">Pendiente de completar</p>
+              </div>
+            )}
+
+            {taller.registroProduccion && (
+              <div className="bg-gray-50 rounded-lg p-3">
+                <p className="text-gray-500 text-xs mb-1">Registro de producción</p>
+                <p className="font-medium text-gray-800">
+                  {labelRegistro(taller.registroProduccion)}
+                </p>
+              </div>
+            )}
+
+            {taller.escalabilidad && (
+              <div className="bg-gray-50 rounded-lg p-3">
+                <p className="text-gray-500 text-xs mb-1">Puede escalar</p>
+                <p className="font-medium text-gray-800">
+                  {labelEscalabilidad(taller.escalabilidad)}
+                </p>
+              </div>
+            )}
+
+            {(taller.sam ?? 0) > 0 && (
+              <div className="bg-gray-50 rounded-lg p-3">
+                <p className="text-gray-500 text-xs mb-1">Tiempo estándar ({taller.prendaPrincipal})</p>
+                <p className="font-medium text-gray-800">{taller.sam} min</p>
+              </div>
+            )}
+
+          </div>
+
+          <p className="text-xs text-gray-400 mt-4">
+            Esta información es visible para el equipo de la plataforma y la Coordinación.
+            No afecta tu recorrido de formalización.
+          </p>
+        </Card>
+      )}
+
+      {!taller.organizacion && (
+        <Card className="text-center py-10">
+          <p className="text-gray-600 mb-4">
+            Todavía no cargaste tu perfil productivo (organización, equipo, capacidad).
+          </p>
+          <Link href="/taller/perfil/completar">
+            <Button>Completar perfil productivo</Button>
+          </Link>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/src/app/(taller)/taller/perfil/gestion/page.tsx
+++ b/src/app/(taller)/taller/perfil/gestion/page.tsx
@@ -80,10 +80,7 @@ export default async function TallerGestionPage() {
             <p className="text-gray-500">Pedidos completados</p>
             <p className="font-medium">{taller.pedidosCompletados}</p>
           </div>
-          <div>
-            <p className="text-gray-500">Puntaje</p>
-            <p className="font-medium">{taller.puntaje} pts</p>
-          </div>
+          {/* "Puntaje" eliminado: la mecánica de scoring fue descartada en la V4. */}
         </div>
       </Card>
 

--- a/src/app/(taller)/taller/perfil/layout.tsx
+++ b/src/app/(taller)/taller/perfil/layout.tsx
@@ -1,0 +1,53 @@
+export const dynamic = 'force-dynamic'
+
+import { auth } from '@/compartido/lib/auth'
+import { prisma } from '@/compartido/lib/prisma'
+import { redirect } from 'next/navigation'
+import { nivelAEtapa } from '@/compartido/lib/formalizacion'
+import { PerfilHeaderTabs } from './perfil-header-tabs'
+
+// Etapa 2.1 — "Mi taller" se reparte en dos sub-tabs (Mi vidriera / Mi gestión
+// productiva). La cabecera común y las sub-tabs viven en este layout, sobre
+// ambas páginas. Los datos de cabecera (nombre + etapa + ARCA) se cargan acá
+// una sola vez; el cromo se oculta solo en editar/completar (lo decide el
+// componente cliente vía pathname).
+export default async function PerfilLayout({ children }: { children: React.ReactNode }) {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const taller = await prisma.taller.findFirst({
+    where: { userId: session.user.id },
+    select: {
+      id: true,
+      nombre: true,
+      nivel: true,
+      verificadoAfip: true,
+      provincia: true,
+      partido: true,
+      ubicacionDetalle: true,
+      sam: true,
+      user: { select: { email: true, phone: true } },
+    },
+  })
+
+  // Sin taller todavía: la página maneja el empty state ("Completar Perfil").
+  if (!taller) return <>{children}</>
+
+  return (
+    <div className="space-y-6">
+      <PerfilHeaderTabs
+        nombre={taller.nombre}
+        etapa={nivelAEtapa(taller.nivel)}
+        verificadoAfip={taller.verificadoAfip}
+        provincia={taller.provincia}
+        partido={taller.partido}
+        ubicacionDetalle={taller.ubicacionDetalle}
+        email={taller.user.email}
+        phone={taller.user.phone}
+        tallerId={taller.id}
+        samCompletado={Boolean(taller.sam)}
+      />
+      {children}
+    </div>
+  )
+}

--- a/src/app/(taller)/taller/perfil/layout.tsx
+++ b/src/app/(taller)/taller/perfil/layout.tsx
@@ -18,15 +18,12 @@ export default async function PerfilLayout({ children }: { children: React.React
   const taller = await prisma.taller.findFirst({
     where: { userId: session.user.id },
     select: {
-      id: true,
       nombre: true,
       nivel: true,
       verificadoAfip: true,
       provincia: true,
       partido: true,
       ubicacionDetalle: true,
-      sam: true,
-      user: { select: { email: true, phone: true } },
     },
   })
 
@@ -42,10 +39,6 @@ export default async function PerfilLayout({ children }: { children: React.React
         provincia={taller.provincia}
         partido={taller.partido}
         ubicacionDetalle={taller.ubicacionDetalle}
-        email={taller.user.email}
-        phone={taller.user.phone}
-        tallerId={taller.id}
-        samCompletado={Boolean(taller.sam)}
       />
       {children}
     </div>

--- a/src/app/(taller)/taller/perfil/page.tsx
+++ b/src/app/(taller)/taller/perfil/page.tsx
@@ -7,8 +7,10 @@ import Link from 'next/link'
 import { Badge } from '@/compartido/componentes/ui/badge'
 import { Card } from '@/compartido/componentes/ui/card'
 import { Button } from '@/compartido/componentes/ui/button'
-import { Award, Download, ExternalLink } from 'lucide-react'
+import { Award, Download } from 'lucide-react'
 import { PortfolioManager } from '@/taller/componentes/portfolio-manager'
+import { VerVidrieraModal } from '@/taller/componentes/ver-vidriera-modal'
+import { VidrieraPublicaContenido } from '@/taller/componentes/vidriera-publica-contenido'
 
 // Etapa 2.1 — "Mi vidriera": lo que ven las marcas en el directorio.
 // La cabecera común (nombre + etapa + ARCA) y las sub-tabs viven en el layout.
@@ -26,8 +28,12 @@ export default async function TallerVidrieraPage() {
       certificaciones: { where: { activa: true } },
       certificados: {
         where: { revocado: false },
-        include: { coleccion: { select: { titulo: true } } },
+        include: { coleccion: { select: { titulo: true, institucion: true } } },
         orderBy: { fecha: 'desc' },
+      },
+      validaciones: {
+        where: { estado: 'COMPLETADO' },
+        select: { tipoDocumento: { select: { nombre: true } } },
       },
     },
   })
@@ -45,14 +51,13 @@ export default async function TallerVidrieraPage() {
 
   return (
     <div className="space-y-6">
-      {/* "Ver cómo me ve el directorio": previsualizar la vidriera pública.
-          Movido acá desde la cabecera común (vive en la vidriera, no en la metadata global). */}
+      {/* "Ver cómo me ve el directorio": MODAL sobre Mi vidriera (no navega a la
+          página pública). El contenido es la vidriera pública filtrada por #437;
+          al cerrar, el taller queda en su contexto privado. */}
       <div className="flex justify-end">
-        <Link href={`/perfil/${taller.id}`} target="_blank" rel="noopener noreferrer">
-          <Button variant="secondary" size="sm" icon={<ExternalLink className="w-4 h-4" />}>
-            Ver cómo me ve el directorio
-          </Button>
-        </Link>
+        <VerVidrieraModal>
+          <VidrieraPublicaContenido taller={taller} />
+        </VerVidrieraModal>
       </div>
 
       {/* NOTA (2.2): "Trabajadores" y "Cap. mensual" salieron del grid destacado de

--- a/src/app/(taller)/taller/perfil/page.tsx
+++ b/src/app/(taller)/taller/perfil/page.tsx
@@ -7,8 +7,7 @@ import Link from 'next/link'
 import { Badge } from '@/compartido/componentes/ui/badge'
 import { Card } from '@/compartido/componentes/ui/card'
 import { Button } from '@/compartido/componentes/ui/button'
-import { ProgressRing } from '@/compartido/componentes/ui/progress-ring'
-import { Star, Users, TrendingUp, Clock, Award, Download } from 'lucide-react'
+import { Award, Download, ExternalLink } from 'lucide-react'
 import { PortfolioManager } from '@/taller/componentes/portfolio-manager'
 
 // Etapa 2.1 — "Mi vidriera": lo que ven las marcas en el directorio.
@@ -44,53 +43,22 @@ export default async function TallerVidrieraPage() {
     )
   }
 
-  const checks = ['nombre', 'cuit', 'descripcion', 'provincia', 'fundado'] as const
-  const campos = checks.length + 4
-  let completos = checks.filter(c => (taller as Record<string, unknown>)[c]).length
-  if (taller.capacidadMensual > 0) completos++
-  if (taller.trabajadoresRegistrados > 0) completos++
-  if (taller.procesos.length > 0) completos++
-  if (taller.maquinaria.length > 0) completos++
-  const completitud = Math.round((completos / campos) * 100)
-
   return (
     <div className="space-y-6">
-      <Card>
-        <div className="flex items-center gap-6">
-          <ProgressRing percentage={completitud} size={100} />
-          <div>
-            <p className="font-overpass font-bold text-brand-blue text-lg">Perfil {completitud}% completo</p>
-            <p className="text-sm text-gray-500">
-              {completitud < 100
-                ? 'Completá tu perfil para mejorar tu visibilidad en el directorio.'
-                : 'Tu perfil está completo. Las marcas pueden encontrarte fácilmente.'}
-            </p>
-          </div>
-        </div>
-      </Card>
-
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <Card className="text-center p-4">
-          <Star className="w-5 h-5 text-yellow-500 mx-auto mb-1" />
-          <p className="font-overpass font-bold text-2xl text-brand-blue">{taller.rating.toFixed(1)}</p>
-          <p className="text-xs text-gray-500">Rating</p>
-        </Card>
-        <Card className="text-center p-4">
-          <Users className="w-5 h-5 text-brand-blue mx-auto mb-1" />
-          <p className="font-overpass font-bold text-2xl text-brand-blue">{taller.trabajadoresRegistrados}</p>
-          <p className="text-xs text-gray-500">Trabajadores</p>
-        </Card>
-        <Card className="text-center p-4">
-          <TrendingUp className="w-5 h-5 text-green-600 mx-auto mb-1" />
-          <p className="font-overpass font-bold text-2xl text-brand-blue">{taller.capacidadMensual.toLocaleString()}</p>
-          <p className="text-xs text-gray-500">Cap. mensual</p>
-        </Card>
-        <Card className="text-center p-4">
-          <Clock className="w-5 h-5 text-brand-blue mx-auto mb-1" />
-          <p className="font-overpass font-bold text-2xl text-brand-blue">{taller.ontimeRate}%</p>
-          <p className="text-xs text-gray-500">On-time</p>
-        </Card>
+      {/* "Ver cómo me ve el directorio": previsualizar la vidriera pública.
+          Movido acá desde la cabecera común (vive en la vidriera, no en la metadata global). */}
+      <div className="flex justify-end">
+        <Link href={`/perfil/${taller.id}`} target="_blank" rel="noopener noreferrer">
+          <Button variant="secondary" size="sm" icon={<ExternalLink className="w-4 h-4" />}>
+            Ver cómo me ve el directorio
+          </Button>
+        </Link>
       </div>
+
+      {/* NOTA (2.2): "Trabajadores" y "Cap. mensual" salieron del grid destacado de
+          marketplace (junto con Rating / On-time / barra de completitud, descartados del
+          modelo V4). Su ubicación final es el bloque "Mi capacidad de producción"
+          (toggleable) que arma la Etapa 2.2 — no se renderizan acá por ahora. */}
 
       {taller.descripcion && (
         <Card title="Descripción">

--- a/src/app/(taller)/taller/perfil/page.tsx
+++ b/src/app/(taller)/taller/perfil/page.tsx
@@ -8,22 +8,21 @@ import { Badge } from '@/compartido/componentes/ui/badge'
 import { Card } from '@/compartido/componentes/ui/card'
 import { Button } from '@/compartido/componentes/ui/button'
 import { ProgressRing } from '@/compartido/componentes/ui/progress-ring'
-import { Star, MapPin, Users, TrendingUp, Clock, Award, Download } from 'lucide-react'
+import { Star, Users, TrendingUp, Clock, Award, Download } from 'lucide-react'
 import { PortfolioManager } from '@/taller/componentes/portfolio-manager'
-import { labelOrganizacion, labelRegistro, labelEscalabilidad } from '@/compartido/lib/taller-formulario'
-import { nivelAEtapa } from '@/compartido/lib/formalizacion'
 
-export default async function TallerPerfilPage() {
+// Etapa 2.1 — "Mi vidriera": lo que ven las marcas en el directorio.
+// La cabecera común (nombre + etapa + ARCA) y las sub-tabs viven en el layout.
+// El reparto público/privado es 2.1; el filtrado por visibilidad es 2.2.
+export default async function TallerVidrieraPage() {
   const session = await auth()
   if (!session?.user) redirect('/login')
 
   const taller = await prisma.taller.findFirst({
     where: { userId: session.user.id },
     include: {
-      user: { select: { email: true, phone: true } },
       procesos: { include: { proceso: true } },
       prendas: { include: { prenda: true } },
-      plantilla: { orderBy: { categoria: 'asc' } },
       maquinaria: true,
       certificaciones: { where: { activa: true } },
       certificados: {
@@ -36,15 +35,12 @@ export default async function TallerPerfilPage() {
 
   if (!taller) {
     return (
-      <div className="space-y-6">
-        <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi taller</h1>
-        <Card className="text-center py-12">
-          <p className="text-gray-600 mb-4">Todavía no completaste tu perfil.</p>
-          <Link href="/taller/perfil/completar">
-            <Button>Completar Perfil</Button>
-          </Link>
-        </Card>
-      </div>
+      <Card className="text-center py-12">
+        <p className="text-gray-600 mb-4">Todavía no completaste tu perfil.</p>
+        <Link href="/taller/perfil/completar">
+          <Button>Completar Perfil</Button>
+        </Link>
+      </Card>
     )
   }
 
@@ -59,30 +55,6 @@ export default async function TallerPerfilPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-start justify-between">
-        <div>
-          <div className="flex items-center gap-3 mb-1">
-            <h1 className="font-serif font-bold text-3xl text-ink-primary">{taller.nombre}</h1>
-            <Badge variant="default">{nivelAEtapa(taller.nivel)}</Badge>
-          </div>
-          {taller.provincia && (
-            <p className="flex items-center gap-1 text-gray-600">
-              <MapPin className="w-4 h-4" /> {taller.provincia}{taller.partido ? `, ${taller.partido}` : ''}
-              {taller.ubicacionDetalle && <span className="text-gray-400"> · {taller.ubicacionDetalle}</span>}
-            </p>
-          )}
-          <p className="text-sm text-gray-500 mt-1">{taller.user.email} {taller.user.phone && `· ${taller.user.phone}`}</p>
-        </div>
-        <div className="flex gap-2">
-          <Link href="/taller/perfil/editar">
-            <Button variant="secondary" size="sm">Editar datos básicos</Button>
-          </Link>
-          <Link href="/taller/perfil/completar">
-            <Button variant="ghost" size="sm">{taller.sam ? 'Actualizar perfil productivo' : 'Completar perfil productivo'}</Button>
-          </Link>
-        </div>
-      </div>
-
       <Card>
         <div className="flex items-center gap-6">
           <ProgressRing percentage={completitud} size={100} />
@@ -126,29 +98,6 @@ export default async function TallerPerfilPage() {
         </Card>
       )}
 
-      <Card title="Información General">
-        <div className="grid grid-cols-2 gap-4 text-sm">
-          <div>
-            <p className="text-gray-500">CUIT</p>
-            <p className="font-medium">{taller.cuit}</p>
-          </div>
-          {taller.fundado && (
-            <div>
-              <p className="text-gray-500">Fundado</p>
-              <p className="font-medium">{taller.fundado}</p>
-            </div>
-          )}
-          <div>
-            <p className="text-gray-500">Pedidos completados</p>
-            <p className="font-medium">{taller.pedidosCompletados}</p>
-          </div>
-          <div>
-            <p className="text-gray-500">Puntaje</p>
-            <p className="font-medium">{taller.puntaje} pts</p>
-          </div>
-        </div>
-      </Card>
-
       {taller.procesos.length > 0 && (
         <Card title="Procesos Productivos">
           <div className="flex flex-wrap gap-2">
@@ -172,82 +121,6 @@ export default async function TallerPerfilPage() {
       <Card title="Mi portfolio">
         <PortfolioManager tallerId={taller.id} fotosActuales={taller.portfolioFotos} />
       </Card>
-
-      {taller.organizacion && (
-        <Card title="Perfil productivo">
-          <div className="grid grid-cols-2 md:grid-cols-3 gap-4 text-sm">
-
-            <div className="bg-gray-50 rounded-lg p-3">
-              <p className="text-gray-500 text-xs mb-1">Organización</p>
-              <p className="font-medium text-gray-800">
-                {labelOrganizacion(taller.organizacion)}
-              </p>
-            </div>
-
-            {(taller.metrosCuadrados ?? 0) > 0 && (
-              <div className="bg-gray-50 rounded-lg p-3">
-                <p className="text-gray-500 text-xs mb-1">Espacio</p>
-                <p className="font-medium text-gray-800">{taller.metrosCuadrados} m²</p>
-              </div>
-            )}
-
-            {taller.plantilla.length > 0 && taller.plantilla.some(p => p.cantidad > 0) ? (
-              <div className="bg-gray-50 rounded-lg p-3">
-                <p className="text-gray-500 text-xs mb-1">Composición del equipo</p>
-                <div className="space-y-1">
-                  {taller.plantilla.filter(p => p.cantidad > 0).map(p => (
-                    <p key={p.categoria} className="font-medium text-gray-800 text-sm">
-                      {p.categoria === 'APRENDIZ' ? 'Aprendices'
-                       : p.categoria === 'MEDIO_OFICIAL' ? 'Medio oficial'
-                       : p.categoria === 'OFICIAL' ? 'Oficial'
-                       : 'Oficial calificado'}: {p.cantidad}
-                    </p>
-                  ))}
-                  <p className="text-xs text-gray-500 mt-1">
-                    Total: {taller.plantilla.reduce((sum, p) => sum + p.cantidad, 0)} personas
-                  </p>
-                </div>
-              </div>
-            ) : (
-              <div className="bg-gray-50 rounded-lg p-3">
-                <p className="text-gray-500 text-xs mb-1">Composición del equipo</p>
-                <p className="text-sm text-gray-400 italic">Pendiente de completar</p>
-              </div>
-            )}
-
-            {taller.registroProduccion && (
-              <div className="bg-gray-50 rounded-lg p-3">
-                <p className="text-gray-500 text-xs mb-1">Registro de producción</p>
-                <p className="font-medium text-gray-800">
-                  {labelRegistro(taller.registroProduccion)}
-                </p>
-              </div>
-            )}
-
-            {taller.escalabilidad && (
-              <div className="bg-gray-50 rounded-lg p-3">
-                <p className="text-gray-500 text-xs mb-1">Puede escalar</p>
-                <p className="font-medium text-gray-800">
-                  {labelEscalabilidad(taller.escalabilidad)}
-                </p>
-              </div>
-            )}
-
-            {(taller.sam ?? 0) > 0 && (
-              <div className="bg-gray-50 rounded-lg p-3">
-                <p className="text-gray-500 text-xs mb-1">Tiempo estándar ({taller.prendaPrincipal})</p>
-                <p className="font-medium text-gray-800">{taller.sam} min</p>
-              </div>
-            )}
-
-          </div>
-
-          <p className="text-xs text-gray-400 mt-4">
-            Esta información es visible para el equipo de la plataforma y la Coordinación.
-            No afecta tu recorrido de formalización.
-          </p>
-        </Card>
-      )}
 
       {taller.maquinaria.length > 0 && (
         <Card title="Maquinaria">

--- a/src/app/(taller)/taller/perfil/perfil-header-tabs.tsx
+++ b/src/app/(taller)/taller/perfil/perfil-header-tabs.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { Badge } from '@/compartido/componentes/ui/badge'
+import { Button } from '@/compartido/componentes/ui/button'
+import { BadgeArca } from '@/compartido/componentes/badge-arca'
+import { MapPin, ExternalLink } from 'lucide-react'
+
+// Etapa 2.1 — contenedor "Mi taller": cabecera común + sub-tabs.
+// Cabecera (nombre + etapa actual + ARCA verificado) y sub-tabs viven sobre
+// ambas vistas (vidriera / gestión). En los formularios (editar / completar)
+// el cromo se oculta — molde tomado de `taller/pedidos/layout.tsx` (PR #374).
+
+const subTabs = [
+  { label: 'Mi vidriera', href: '/taller/perfil' },
+  { label: 'Mi gestión productiva', href: '/taller/perfil/gestion' },
+]
+
+function mostrarCromo(pathname: string) {
+  return pathname === '/taller/perfil' || pathname === '/taller/perfil/gestion'
+}
+
+export function PerfilHeaderTabs({
+  nombre,
+  etapa,
+  verificadoAfip,
+  provincia,
+  partido,
+  ubicacionDetalle,
+  email,
+  phone,
+  tallerId,
+  samCompletado,
+}: {
+  nombre: string
+  etapa: string
+  verificadoAfip: boolean
+  provincia: string | null
+  partido: string | null
+  ubicacionDetalle: string | null
+  email: string
+  phone: string | null
+  tallerId: string
+  samCompletado: boolean
+}) {
+  const pathname = usePathname()
+  if (!mostrarCromo(pathname)) return null
+
+  return (
+    <div className="space-y-4">
+      {/* Cabecera común — nombre + etapa actual (nivelAEtapa) + ARCA verificado */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2 mb-1">
+            <h1 className="font-serif font-bold text-3xl text-ink-primary break-words">{nombre}</h1>
+            <Badge variant="default">{etapa}</Badge>
+          </div>
+          <div className="mb-1">
+            <BadgeArca verificado={verificadoAfip} />
+          </div>
+          {provincia && (
+            <p className="flex items-center gap-1 text-gray-600">
+              <MapPin className="w-4 h-4 shrink-0" /> {provincia}
+              {partido ? `, ${partido}` : ''}
+              {ubicacionDetalle && <span className="text-gray-400"> · {ubicacionDetalle}</span>}
+            </p>
+          )}
+          <p className="text-sm text-gray-500 mt-1 break-words">
+            {email}
+            {phone && ` · ${phone}`}
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-2 sm:items-end shrink-0">
+          <Link href={`/perfil/${tallerId}`} target="_blank" rel="noopener noreferrer" className="w-full sm:w-auto">
+            <Button variant="secondary" size="sm" icon={<ExternalLink className="w-4 h-4" />} className="w-full sm:w-auto">
+              Ver cómo me ve el directorio
+            </Button>
+          </Link>
+          <div className="flex flex-wrap gap-2">
+            <Link href="/taller/perfil/editar">
+              <Button variant="secondary" size="sm">Editar datos básicos</Button>
+            </Link>
+            <Link href="/taller/perfil/completar">
+              <Button variant="ghost" size="sm">
+                {samCompletado ? 'Actualizar perfil productivo' : 'Completar perfil productivo'}
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      {/* Sub-tabs: Mi vidriera | Mi gestión productiva */}
+      <nav className="flex gap-1 border-b border-gray-200 overflow-x-auto">
+        {subTabs.map((tab) => {
+          const isActive =
+            tab.href === '/taller/perfil'
+              ? pathname === '/taller/perfil'
+              : pathname.startsWith(tab.href)
+
+          return (
+            <Link
+              key={tab.href}
+              href={tab.href}
+              className={`px-4 py-2.5 text-sm font-overpass font-semibold border-b-2 transition-colors -mb-px whitespace-nowrap ${
+                isActive
+                  ? 'border-brand-blue text-brand-blue'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+              }`}
+            >
+              {tab.label}
+            </Link>
+          )
+        })}
+      </nav>
+    </div>
+  )
+}

--- a/src/app/(taller)/taller/perfil/perfil-header-tabs.tsx
+++ b/src/app/(taller)/taller/perfil/perfil-header-tabs.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation'
 import { Badge } from '@/compartido/componentes/ui/badge'
 import { Button } from '@/compartido/componentes/ui/button'
 import { BadgeArca } from '@/compartido/componentes/badge-arca'
-import { MapPin, ExternalLink } from 'lucide-react'
+import { MapPin } from 'lucide-react'
 
 // Etapa 2.1 — contenedor "Mi taller": cabecera común + sub-tabs.
 // Cabecera (nombre + etapa actual + ARCA verificado) y sub-tabs viven sobre
@@ -28,10 +28,6 @@ export function PerfilHeaderTabs({
   provincia,
   partido,
   ubicacionDetalle,
-  email,
-  phone,
-  tallerId,
-  samCompletado,
 }: {
   nombre: string
   etapa: string
@@ -39,10 +35,6 @@ export function PerfilHeaderTabs({
   provincia: string | null
   partido: string | null
   ubicacionDetalle: string | null
-  email: string
-  phone: string | null
-  tallerId: string
-  samCompletado: boolean
 }) {
   const pathname = usePathname()
   if (!mostrarCromo(pathname)) return null
@@ -66,28 +58,16 @@ export function PerfilHeaderTabs({
               {ubicacionDetalle && <span className="text-gray-400"> · {ubicacionDetalle}</span>}
             </p>
           )}
-          <p className="text-sm text-gray-500 mt-1 break-words">
-            {email}
-            {phone && ` · ${phone}`}
-          </p>
+          {/* PII del responsable (nombre/email/teléfono) vive en "Mi gestión productiva"
+              (privado), no en la cabecera común — minimización de datos (OIT IGDS 457). */}
         </div>
 
         <div className="flex flex-col gap-2 sm:items-end shrink-0">
-          <Link href={`/perfil/${tallerId}`} target="_blank" rel="noopener noreferrer" className="w-full sm:w-auto">
-            <Button variant="secondary" size="sm" icon={<ExternalLink className="w-4 h-4" />} className="w-full sm:w-auto">
-              Ver cómo me ve el directorio
-            </Button>
+          {/* "Ver cómo me ve el directorio" → movido a "Mi vidriera".
+              "Completar perfil productivo" → movido a "Mi gestión productiva". */}
+          <Link href="/taller/perfil/editar">
+            <Button variant="secondary" size="sm">Editar datos básicos</Button>
           </Link>
-          <div className="flex flex-wrap gap-2">
-            <Link href="/taller/perfil/editar">
-              <Button variant="secondary" size="sm">Editar datos básicos</Button>
-            </Link>
-            <Link href="/taller/perfil/completar">
-              <Button variant="ghost" size="sm">
-                {samCompletado ? 'Actualizar perfil productivo' : 'Completar perfil productivo'}
-              </Button>
-            </Link>
-          </div>
         </div>
       </div>
 

--- a/src/taller/componentes/ver-vidriera-modal.tsx
+++ b/src/taller/componentes/ver-vidriera-modal.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { ExternalLink, X } from 'lucide-react'
+import { Button } from '@/compartido/componentes/ui/button'
+
+// "Ver cómo me ve el directorio" como MODAL sobre "Mi vidriera" (no navega a la
+// página pública). Al cerrar, el taller queda en su contexto privado. El contenido
+// (children) es la vidriera pública filtrada por #437, server-rendered en la página.
+
+export function VerVidrieraModal({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    document.body.style.overflow = 'hidden'
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false) }
+    window.addEventListener('keydown', onKey)
+    return () => {
+      document.body.style.overflow = ''
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  return (
+    <>
+      <Button
+        variant="secondary"
+        size="sm"
+        icon={<ExternalLink className="w-4 h-4" />}
+        onClick={() => setOpen(true)}
+      >
+        Ver cómo me ve el directorio
+      </Button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-start sm:items-center justify-center p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Vista previa de tu vidriera pública"
+        >
+          <div className="fixed inset-0 bg-black/50 backdrop-blur-sm" onClick={() => setOpen(false)} />
+          <div className="relative bg-white rounded-xl shadow-lg w-full max-w-3xl max-h-[88vh] flex flex-col animate-in fade-in zoom-in-95 duration-200">
+            <div className="flex items-start justify-between gap-2 px-5 py-3 border-b border-gray-100 shrink-0">
+              <div className="min-w-0">
+                <h2 className="font-overpass font-bold text-brand-blue">Así te ven las marcas</h2>
+                <p className="text-xs text-gray-500">
+                  Vista pública filtrada según tu configuración de visibilidad.
+                </p>
+              </div>
+              <button
+                onClick={() => setOpen(false)}
+                className="p-1 hover:bg-gray-100 rounded-lg transition-colors shrink-0"
+                aria-label="Cerrar"
+              >
+                <X className="w-5 h-5 text-gray-500" />
+              </button>
+            </div>
+            <div className="overflow-y-auto px-5 py-4">
+              {children}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/taller/componentes/vidriera-publica-contenido.tsx
+++ b/src/taller/componentes/vidriera-publica-contenido.tsx
@@ -1,0 +1,128 @@
+import { Badge } from '@/compartido/componentes/ui/badge'
+import { Card } from '@/compartido/componentes/ui/card'
+import { MapPin, Award, ShieldCheck } from 'lucide-react'
+import { GaleriaFotos } from '@/taller/componentes/galeria-fotos'
+import { BadgeArca } from '@/compartido/componentes/badge-arca'
+import { bloqueVisible } from '@/compartido/lib/visibilidad-vidriera'
+
+// Contenido de la vidriera PÚBLICA (lo que ve la marca), filtrado por visibilidad
+// (#437). Server component compartido por dos superficies:
+//   - /perfil/[id] (la página pública real)
+//   - el modal "Ver cómo me ve el directorio" en "Mi vidriera" (preview sin navegar)
+// No incluye el link "Volver al directorio" (es específico de la página pública).
+
+export interface VidrieraPublicaTaller {
+  nombre: string
+  verificadoAfip: boolean
+  provincia: string | null
+  partido: string | null
+  ubicacionDetalle: string | null
+  descripcion: string | null
+  portfolioFotos: string[]
+  visibilidadVidriera: unknown
+  validaciones: { tipoDocumento: { nombre: string } }[]
+  procesos: { id: string; proceso: { nombre: string } }[]
+  prendas: { id: string; prenda: { nombre: string } }[]
+  maquinaria: { id: string; nombre: string; cantidad: number }[]
+  certificaciones: { id: string; nombre: string }[]
+  certificados: { id: string; codigo: string; coleccion: { titulo: string; institucion: string | null } }[]
+}
+
+export function VidrieraPublicaContenido({ taller }: { taller: VidrieraPublicaTaller }) {
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="font-overpass font-bold text-3xl text-brand-blue mb-2">{taller.nombre}</h1>
+        {(taller.verificadoAfip || taller.validaciones.length > 0) && (
+          <div className="flex flex-wrap items-center gap-2 mb-2">
+            {taller.verificadoAfip && <BadgeArca verificado={true} />}
+            {taller.validaciones.map((v, i) => (
+              <Badge key={i} variant="success"><ShieldCheck className="w-3 h-3 mr-1" />{v.tipoDocumento.nombre}</Badge>
+            ))}
+          </div>
+        )}
+        {taller.provincia && (
+          <p className="flex items-center gap-1 text-gray-600">
+            <MapPin className="w-4 h-4" /> {taller.provincia}{taller.partido ? `, ${taller.partido}` : ''}
+            {taller.ubicacionDetalle && <span className="text-gray-400"> · {taller.ubicacionDetalle}</span>}
+          </p>
+        )}
+        {taller.descripcion && (
+          <p className="text-gray-600 text-sm italic mt-2">&quot;{taller.descripcion}&quot;</p>
+        )}
+      </div>
+
+      {taller.procesos.length > 0 && (
+        <Card title="Procesos" className="mb-4">
+          <div className="flex flex-wrap gap-2">
+            {taller.procesos.map((tp) => (
+              <Badge key={tp.id} variant="outline">{tp.proceso.nombre}</Badge>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {taller.prendas.length > 0 && (
+        <Card title="Tipos de prenda" className="mb-4">
+          <div className="flex flex-wrap gap-2">
+            {taller.prendas.map((tp) => (
+              <Badge key={tp.id} variant="outline">{tp.prenda.nombre}</Badge>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {taller.portfolioFotos.length > 0 && (
+        <Card title="Trabajos realizados" className="mb-4">
+          <GaleriaFotos fotos={taller.portfolioFotos} />
+        </Card>
+      )}
+
+      {taller.maquinaria.length > 0 && bloqueVisible(taller, 'maquinaria') && (
+        <Card title="Maquinaria" className="mb-4">
+          <ul className="space-y-1 text-sm">
+            {taller.maquinaria.map((m) => (
+              <li key={m.id} className="flex justify-between">
+                <span>{m.nombre}</span>
+                <span className="text-gray-500">x{m.cantidad}</span>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+
+      {taller.certificaciones.length > 0 && (
+        <Card title="Certificaciones" className="mb-4">
+          <div className="flex flex-wrap gap-2">
+            {taller.certificaciones.map((c) => (
+              <Badge key={c.id} variant="success">
+                <Award className="w-3 h-3 mr-1" />{c.nombre}
+              </Badge>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {taller.certificados.length > 0 && bloqueVisible(taller, 'formacion') && (
+        <Card title="Capacitaciones certificadas">
+          <div className="space-y-2">
+            {taller.certificados.map((cert) => (
+              <div key={cert.id} className="flex items-center justify-between text-sm">
+                <div>
+                  <span className="font-medium">{cert.coleccion.titulo}</span>
+                  {cert.coleccion.institucion && (
+                    <span className="text-gray-500 ml-2">· {cert.coleccion.institucion}</span>
+                  )}
+                </div>
+                <a href={`/verificar?code=${cert.codigo}`}
+                  className="text-brand-blue underline text-xs">
+                  Verificar
+                </a>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/tests/e2e/desglose-plantilla.spec.ts
+++ b/tests/e2e/desglose-plantilla.spec.ts
@@ -8,7 +8,9 @@ test.describe('W-A1 Desglose de plantilla por categoría', () => {
       await ensureNotProduction(page)
       await loginAs(page, 'taller')
 
-      await page.goto('/taller/perfil', { waitUntil: 'load', timeout: 30_000 })
+      // Etapa 2.1: el perfil productivo (Composición del equipo) vive ahora
+      // en la sub-tab "Mi gestión productiva" (/taller/perfil/gestion).
+      await page.goto('/taller/perfil/gestion', { waitUntil: 'load', timeout: 30_000 })
 
       // Debe mostrar "Composición del equipo" con datos del seed
       await expect(page.getByText('Composición del equipo')).toBeVisible({ timeout: 10_000 })

--- a/tests/e2e/flujo-comercial.spec.ts
+++ b/tests/e2e/flujo-comercial.spec.ts
@@ -6,6 +6,23 @@ test.describe('Flujo comercial completo', () => {
   // Timeout largo: este test hace login/logout 3 veces + crea datos
   test.setTimeout(120000)
 
+  // Cleanup: este test crea un pedido real (con orden de manufactura asignada
+  // al taller del seed). Sin limpieza queda como "Pedido activo" en el dashboard
+  // del taller y se acumula en la DB de preview/dev en cada corrida. Cancelamos
+  // el pedido al terminar (lo saca del filtro PENDIENTE/EN_EJECUCION del dashboard).
+  // Best-effort: nunca hace fallar el test.
+  let pedidoIdParaLimpiar: string | null = null
+  test.afterEach(async ({ page }) => {
+    if (!pedidoIdParaLimpiar) return
+    try {
+      await loginAs(page, 'marca')
+      await page.request.put(`/api/pedidos/${pedidoIdParaLimpiar}`, { data: { estado: 'CANCELADO' } })
+    } catch {
+      // ignorar — la limpieza no debe afectar el resultado del test
+    }
+    pedidoIdParaLimpiar = null
+  })
+
   test('Marca crea pedido → taller cotiza → marca acepta', async ({ page }) => {
     await ensureNotProduction(page)
 
@@ -45,6 +62,7 @@ test.describe('Flujo comercial completo', () => {
     // Estamos en /marca/pedidos/[id]
     await page.waitForURL(/\/marca\/pedidos\/[\w-]+$/, { timeout: 10000 })
     const pedidoUrl = page.url()
+    pedidoIdParaLimpiar = pedidoUrl.split('/').pop() ?? null // para el cleanup (afterEach)
 
     // Verificar que el boton de publicar esta visible (estado BORRADOR)
     await expect(page.locator('button[data-action="publicar"]')).toBeVisible()


### PR DESCRIPTION
## Etapa 2.1 — Sub-tabs "Mi taller"

Reparte la vista única de `/taller/perfil` en **dos sub-tabs** sobre una **cabecera común**, sin tocar schema.

### Cabecera común (layout)
- Nombre + **etapa actual vía `nivelAEtapa()`** (nunca el enum crudo BRONCE/PLATA/ORO — lección F-1)
- Badge **ARCA verificado** (`BadgeArca`)
- Ubicación + contacto + botones de edición
- Botón **"Ver cómo me ve el directorio"** → link al `/perfil/[id]` público (que ya filtra por visibilidad #437)

### Sub-tabs
| Sub-tab | Ruta | Contenido |
|---|---|---|
| **Mi vidriera** | `/taller/perfil` | Lo que ven las marcas: completitud, stats, descripción, procesos, prendas, portfolio, maquinaria, certificaciones, certificados |
| **Mi gestión productiva** | `/taller/perfil/gestion` | Privado: Información General (CUIT, puntaje) + Perfil productivo (organización, equipo, registro, escalabilidad, SAM) |

### Implementación
- `perfil/layout.tsx` (server) carga los datos de cabecera una vez y los pasa a…
- `perfil-header-tabs.tsx` (client) que oculta el cromo en `editar`/`completar` vía `usePathname` (molde de `pedidos/layout.tsx`, PR #374)
- `perfil/gestion/page.tsx` (nueva) con el contenido privado

### Alcance acotado
SOLO contenedor + reparto de contenido existente. **Fuera de 2.1** (van a 2.2): reorg de las 3 dimensiones de vidriera, toggles de visibilidad, badges de Formación granular.

### Decisión "Ver cómo me ve el directorio"
**Incluido** (barato): es un `<Link>` al `/perfil/[id]` público existente, que ya aplica el filtrado de visibilidad de #437. No requiere preview mode → no se difiere a 2.2.

### Tests
- `desglose-plantilla.spec.ts`: navegación actualizada a `/taller/perfil/gestion` (donde vive ahora "Composición del equipo")
- Mobile 320/375 verificado sobre el preview (ver checklist en el hilo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)