### PR TITLE
feat(schema): flag modeloB_revisado en Taller (prep 2.2-B)

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,13 @@
 # Daily Log
 
+## 2026-06-24
+
+### Gerardo Breard
+- **17:58** `856e5b4` — feat(schema): flag modeloB_revisado en Taller (prep 2.2-B, privacy-by-default)
+  - `prisma/migrations/20260624120000_agregar_modelob_revisado/migration.sql`
+  - `prisma/schema.prisma`
+
+
 ## 2026-06-23
 
 ### Gerardo Breard

--- a/prisma/migrations/20260624120000_agregar_modelob_revisado/migration.sql
+++ b/prisma/migrations/20260624120000_agregar_modelob_revisado/migration.sql
@@ -1,0 +1,13 @@
+-- Etapa 2.2-B (§5): flag privacy-by-default `modeloB_revisado`.
+-- Decide como se interpreta el null de visibilidadVidriera en el render publico.
+-- Aditiva con backfill:
+--   - Columna NOT NULL DEFAULT false  => talleres NUEVOS entran en false (privacy-by-default).
+--   - Backfill existentes -> true     => preservan su visibilidad actual (null=visible de #437),
+--                                        no se les cambia nada al pasar a 2.2-B.
+-- NO incluye logica de render/visibilidad: eso es 2.2-B. Esta migracion solo crea el campo.
+
+-- AlterTable
+ALTER TABLE "talleres" ADD COLUMN "modeloB_revisado" BOOLEAN NOT NULL DEFAULT false;
+
+-- Backfill: talleres existentes mantienen su visibilidad actual (revisado = true).
+UPDATE "talleres" SET "modeloB_revisado" = true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -297,6 +297,12 @@ model Taller {
   // Credenciales (etapa + ARCA) nunca se oculta; SAM nunca se expone en publico.
   visibilidadVidriera  Json?
 
+  // Etapa 2.2-B (§5): privacy-by-default. Decide como se interpreta el null de
+  // visibilidadVidriera. false (taller nuevo) => null se trata como OCULTO; true
+  // (existentes via backfill, o tras revisar la config) => respeta null=visible (#437).
+  // La logica de render condicional que LO USA es 2.2-B; este campo solo lo modela.
+  modeloB_revisado  Boolean  @default(false)
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 


### PR DESCRIPTION
## Contexto

Modela el campo **`modeloB_revisado`** en `model Taller`, preparación para **Etapa 2.2-B** (privacy-by-default, §5 del spec `v4-etapa2-2-vidriera-discovery.md`).

**SCOPE ESTRICTO:** solo el campo + la migración. **NO incluye lógica de render ni de visibilidad** — eso es 2.2-B. El campo queda listo para que 2.2-B lo use. Backend invisible: no toca UI.

## Cambios

### Schema
```prisma
modeloB_revisado  Boolean  @default(false)   // en model Taller, junto a visibilidadVidriera
```

### Migración aditiva con backfill
`prisma/migrations/20260624120000_agregar_modelob_revisado/migration.sql`:
```sql
ALTER TABLE "talleres" ADD COLUMN "modeloB_revisado" BOOLEAN NOT NULL DEFAULT false;
UPDATE "talleres" SET "modeloB_revisado" = true;
```
- **Tabla real `"talleres"`** (confirmada vía `@@map("talleres")`). ⚠️ El SQL de ejemplo del spec usaba `"Taller"`, que es **incorrecto** — acá va el nombre real.
- **Semántica del backfill** (confirmada por Sergio): existentes → `true` (preservan su visibilidad actual, `null=visible` de #437, no se les cambia nada); `default false` aplica solo a talleres **NUEVOS** creados después (privacy-by-default V4).

## Aplicación a DEV
- `prisma migrate deploy` (sin shadow DB) → aplicada OK.
- `migrate status` → **up to date** ("Database schema is up to date!").
- Client regenerado (`prisma generate`).

## Verificación del backfill (read-only)
```
total talleres:         6
modeloB_revisado=true:  6
modeloB_revisado=false: 0
OK: backfill correcto, ningun existente en false
```

## Out of scope (2.2-B)
`bloqueVisiblePublico`, render condicional en ambas vidrieras, UI de toggles, escritura de config. Nada de eso acá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)