### PR TITLE
feat: 2.2-A estructura — 3er sub-tab "Datos básicos" + reorder + dedup

### DIFF
--- a/.claude/specs/v4-etapa2-2-vidriera-discovery.md
+++ b/.claude/specs/v4-etapa2-2-vidriera-discovery.md
@@ -244,6 +244,10 @@ export function badgeFormacionVisible(taller, certificadoId): boolean {
 
 - **Panel "Configuración de visibilidad"** en **Mi gestión productiva** (`/taller/perfil/gestion`): un toggle (ojo on/off) por bloque TOGGLE-LIBRE + sub-toggles por badge dentro de Formación. Agrupado por las 3 categorías (las FORZADO-* se muestran informativas, sin control).
 - **Mi vidriera = read-only** (preview fiel): donde un bloque está oculto, muestra *"Este bloque no se muestra a las marcas. Cambialo desde Configuración de visibilidad si querés exponerlo."* con **deep-link** al panel (anchor/scroll en gestión).
+- **Patrón "dónde se edita cada bloque" (pedido en QA del combinado #439b+#442, 2026-06-27).** Cada card de "Mi vidriera" muestra un link directo al tab donde se edita su contenido, para reforzar el modelo conceptual *vidriera = curaduría, edición en otro tab* (hoy el taller no sabe a dónde ir sin probar tab por tab). Mapa card → destino:
+  - **Descripción**, **Tipos de prenda/rubros**, **Año** → *"Editado en Datos básicos →"* (`/taller/perfil`).
+  - **Procesos**, **Maquinaria**, **Portfolio**, **Equipo/Espacio/Organización/Capacidad** → *"Editado en Mi gestión productiva →"* (`/taller/perfil/gestion`, vía el wizard `completar` donde corresponda).
+  - Formato: micro-link bajo el título de cada card (ej. bajo "Descripción" un `Editado en Datos básicos →`). No confundir con el deep-link de "bloque oculto" (ese va al panel de visibilidad); este apunta a **dónde se edita el dato**, no dónde se togglea su visibilidad.
 - **Aviso de confirmación** (§5.5) al activar.
 - **Endpoint: server action dedicada** `actualizarVisibilidadVidriera(input)`:
   - Autoriza `auth()` + `taller.userId === session.user.id`.

--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,16 @@
 # Daily Log
 
+## 2026-06-27
+
+### Gerardo Breard
+- **15:51** `074c260` — fix: 2.2-A — modelo de distribución de info por contexto (QA Sergio, reemplaza issue B)
+  - `src/app/(taller)/taller/page.tsx`
+  - `src/app/(taller)/taller/perfil/layout.tsx`
+  - `src/app/(taller)/taller/perfil/page.tsx`
+  - `src/app/(taller)/taller/perfil/perfil-header-tabs.tsx`
+  - `src/compartido/componentes/ui/checklist-onboarding.tsx`
+
+
 ## 2026-06-24
 
 ### Gerardo Breard

--- a/src/app/(taller)/taller/page.tsx
+++ b/src/app/(taller)/taller/page.tsx
@@ -168,14 +168,12 @@ export default async function TallerDashboardPage() {
 
   return (
     <div className="space-y-6">
-      {/* Encabezado */}
+      {/* Encabezado. "Tu recorrido de formalización" se movió desde acá a la card
+          "Tus primeros pasos" (ChecklistOnboarding) / ProximoNivelCard (QA #442). */}
       <div>
         <h1 className="font-serif font-bold text-3xl text-ink-primary">
           Bienvenido, {taller?.nombre ?? session.user.name}
         </h1>
-        <p className="text-gray-500 mt-1">
-          Tu recorrido de formalización: <span className="font-semibold">{etapa}</span>
-        </p>
       </div>
 
       {/* Banner taller no verificado */}
@@ -229,7 +227,7 @@ export default async function TallerDashboardPage() {
           {onboardingCompleto ? (
             <ProximoNivelCard tallerId={taller.id} />
           ) : (
-            <ChecklistOnboarding pasos={pasosOnboarding} />
+            <ChecklistOnboarding pasos={pasosOnboarding} etapa={etapa} />
           )}
           <SincronizarNivel tallerId={taller.id} nivelActual={taller.nivel} />
         </>

--- a/src/app/(taller)/taller/page.tsx
+++ b/src/app/(taller)/taller/page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'
 import { ProgressRing } from '@/compartido/componentes/ui/progress-ring'
 import { ProximoNivelCard } from '@/taller/componentes/proximo-nivel-card'
 import { SincronizarNivel } from '@/taller/componentes/sincronizar-nivel'
+import { BadgeArca } from '@/compartido/componentes/badge-arca'
 import { calcularPasosTaller } from '@/compartido/lib/onboarding'
 import { ChecklistOnboarding } from '@/compartido/componentes/ui/checklist-onboarding'
 import { nivelAEtapa } from '@/compartido/lib/formalizacion'
@@ -94,6 +95,12 @@ export default async function TallerDashboardPage() {
   const completadasSet = new Set(validacionesCompletadas.map(v => v.tipo))
   const tiposPendientes = tiposRequeridos.map(t => t.nombre).filter(t => !completadasSet.has(t))
   const procesosTaller = procesosDelTaller.map(p => p.procesoId)
+
+  // Card "Tu recorrido" (change 2 QA Sergio): verificados de los requisitos del
+  // recorrido. Se computa desde completadasSet + tiposRequeridos (ambos existen
+  // también en #439b), NO desde taller.validaciones (que #439b elimina).
+  const totalRequisitos = tiposRequeridos.length
+  const requisitosVerificados = tiposRequeridos.filter(t => completadasSet.has(t.nombre)).length
 
   type ColeccionConCount = Awaited<ReturnType<typeof prisma.coleccion.findMany<{ include: { _count: { select: { videos: true } } } }>>>[number]
   let coleccionesRecomendadas: ColeccionConCount[]
@@ -221,13 +228,48 @@ export default async function TallerDashboardPage() {
         )
       )}
 
-      {/* Checklist onboarding (T-03) o ProximoNivelCard (F-01) */}
+      {/* Tu recorrido de formalización (change 2, QA Sergio): estado de un vistazo —
+          etapa actual + ARCA + requisitos verificados + link al recorrido completo.
+          Es el hogar de etapa+ARCA en Inicio (la cabecera de Mi taller ya no los
+          muestra). Reemplaza conceptualmente al ring de gamificación que #439b
+          elimina. El recorrido salió de la card "Tus primeros pasos" (issue 6):
+          ahora vive acá, prominente, sin duplicarse. */}
+      {taller && (
+        <div className="bg-white rounded-card shadow-card p-6 border border-gray-100">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0">
+              <h2 className="font-overpass font-bold text-lg text-brand-blue mb-2">
+                Tu recorrido de formalización
+              </h2>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-semibold bg-brand-blue/10 text-brand-blue">
+                  {etapa}
+                </span>
+                <BadgeArca verificado={taller.verificadoAfip} />
+              </div>
+              <p className="text-sm text-gray-500 mt-2">
+                {requisitosVerificados} de {totalRequisitos} requisitos verificados
+              </p>
+            </div>
+            <Link
+              href="/taller/formalizacion"
+              className="inline-flex items-center gap-1 text-sm font-overpass font-semibold text-brand-blue hover:underline shrink-0"
+            >
+              Ver mi recorrido completo →
+            </Link>
+          </div>
+        </div>
+      )}
+
+      {/* Checklist onboarding (T-03) o ProximoNivelCard (F-01).
+          El subtítulo de recorrido del issue 6 se quitó de acá: ahora vive en la
+          card "Tu recorrido de formalización" de arriba (sin duplicar). */}
       {taller && (
         <>
           {onboardingCompleto ? (
             <ProximoNivelCard tallerId={taller.id} />
           ) : (
-            <ChecklistOnboarding pasos={pasosOnboarding} etapa={etapa} />
+            <ChecklistOnboarding pasos={pasosOnboarding} />
           )}
           <SincronizarNivel tallerId={taller.id} nivelActual={taller.nivel} />
         </>

--- a/src/app/(taller)/taller/perfil/gestion/page.tsx
+++ b/src/app/(taller)/taller/perfil/gestion/page.tsx
@@ -6,12 +6,13 @@ import { redirect } from 'next/navigation'
 import Link from 'next/link'
 import { Card } from '@/compartido/componentes/ui/card'
 import { Button } from '@/compartido/componentes/ui/button'
-import { Lock } from 'lucide-react'
 import { labelOrganizacion, labelRegistro, labelEscalabilidad } from '@/compartido/lib/taller-formulario'
 
-// Etapa 2.1 — "Mi gestión productiva": datos privados del taller (solo el taller
-// y el acompañamiento los ven; no aparecen en el directorio). Contenido repartido
-// desde la vista única anterior de perfil. El filtrado por visibilidad es 2.2.
+// Etapa 2.2-A — "Mi gestión productiva": segundo sub-tab (Datos básicos →
+// gestión → vidriera). Queda SÓLO con el Perfil productivo (organización,
+// espacio, equipo, registro, escalabilidad, SAM). Las cards "Datos del
+// responsable" e "Información General" se movieron a "Datos básicos" (dedup, §4).
+// El panel de "Configuración de visibilidad" se agrega acá en 2.2-C.
 export default async function TallerGestionPage() {
   const session = await auth()
   if (!session?.user) redirect('/login')
@@ -20,7 +21,6 @@ export default async function TallerGestionPage() {
     where: { userId: session.user.id },
     include: {
       plantilla: { orderBy: { categoria: 'asc' } },
-      user: { select: { name: true, email: true, phone: true } },
     },
   })
 
@@ -37,53 +37,8 @@ export default async function TallerGestionPage() {
 
   return (
     <div className="space-y-6">
-      {/* Datos del responsable — PII privada, movida desde la cabecera común.
-          No visible para las marcas (minimización de datos, OIT IGDS 457). */}
-      <Card title="Datos del responsable">
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
-          {taller.user.name && (
-            <div>
-              <p className="text-gray-500">Responsable</p>
-              <p className="font-medium break-words">{taller.user.name}</p>
-            </div>
-          )}
-          <div>
-            <p className="text-gray-500">Email</p>
-            <p className="font-medium break-words">{taller.user.email}</p>
-          </div>
-          {taller.user.phone && (
-            <div>
-              <p className="text-gray-500">Teléfono</p>
-              <p className="font-medium break-words">{taller.user.phone}</p>
-            </div>
-          )}
-        </div>
-        <p className="flex items-center gap-1 text-xs text-gray-400 mt-4">
-          <Lock className="w-3 h-3 shrink-0" />
-          Esta información de contacto es privada. Las marcas no la ven en tu vidriera.
-        </p>
-      </Card>
-
-      <Card title="Información General">
-        <div className="grid grid-cols-2 gap-4 text-sm">
-          <div>
-            <p className="text-gray-500">CUIT</p>
-            <p className="font-medium">{taller.cuit}</p>
-          </div>
-          {taller.fundado && (
-            <div>
-              <p className="text-gray-500">Fundado</p>
-              <p className="font-medium">{taller.fundado}</p>
-            </div>
-          )}
-          <div>
-            <p className="text-gray-500">Pedidos completados</p>
-            <p className="font-medium">{taller.pedidosCompletados}</p>
-          </div>
-          {/* "Puntaje" eliminado: la mecánica de scoring fue descartada en la V4. */}
-        </div>
-      </Card>
-
+      {/* "Datos del responsable" e "Información General" se movieron a "Datos
+          básicos" (2.2-A, dedup §4). Esta vista queda con el Perfil productivo. */}
       {taller.organizacion && (
         <Card title="Perfil productivo">
           <div className="grid grid-cols-2 md:grid-cols-3 gap-4 text-sm">

--- a/src/app/(taller)/taller/perfil/layout.tsx
+++ b/src/app/(taller)/taller/perfil/layout.tsx
@@ -3,14 +3,13 @@ export const dynamic = 'force-dynamic'
 import { auth } from '@/compartido/lib/auth'
 import { prisma } from '@/compartido/lib/prisma'
 import { redirect } from 'next/navigation'
-import { nivelAEtapa } from '@/compartido/lib/formalizacion'
 import { PerfilHeaderTabs } from './perfil-header-tabs'
 
-// Etapa 2.1 — "Mi taller" se reparte en dos sub-tabs (Mi vidriera / Mi gestión
-// productiva). La cabecera común y las sub-tabs viven en este layout, sobre
-// ambas páginas. Los datos de cabecera (nombre + etapa + ARCA) se cargan acá
-// una sola vez; el cromo se oculta solo en editar/completar (lo decide el
-// componente cliente vía pathname).
+// Etapa 2.2-A — "Mi taller" tiene 3 sub-tabs (Datos básicos / Mi gestión
+// productiva / Mi vidriera). La cabecera + los sub-tabs viven en este layout.
+// Modelo Sergio: la cabecera carga SOLO el nombre del taller (la metadata de
+// identidad se distribuyó por contexto a las páginas). El cromo se oculta en
+// editar/completar (lo decide el componente cliente vía pathname).
 export default async function PerfilLayout({ children }: { children: React.ReactNode }) {
   const session = await auth()
   if (!session?.user) redirect('/login')
@@ -19,11 +18,6 @@ export default async function PerfilLayout({ children }: { children: React.React
     where: { userId: session.user.id },
     select: {
       nombre: true,
-      nivel: true,
-      verificadoAfip: true,
-      provincia: true,
-      partido: true,
-      ubicacionDetalle: true,
     },
   })
 
@@ -32,14 +26,9 @@ export default async function PerfilLayout({ children }: { children: React.React
 
   return (
     <div className="space-y-6">
-      <PerfilHeaderTabs
-        nombre={taller.nombre}
-        etapa={nivelAEtapa(taller.nivel)}
-        verificadoAfip={taller.verificadoAfip}
-        provincia={taller.provincia}
-        partido={taller.partido}
-        ubicacionDetalle={taller.ubicacionDetalle}
-      />
+      {/* Cabecera = solo nombre + pills (modelo Sergio). La metadata de identidad
+          (etapa/ARCA/ubicación) se distribuyó por contexto a las páginas. */}
+      <PerfilHeaderTabs nombre={taller.nombre} />
       {children}
     </div>
   )

--- a/src/app/(taller)/taller/perfil/page.tsx
+++ b/src/app/(taller)/taller/perfil/page.tsx
@@ -23,9 +23,6 @@ export default async function TallerDatosBasicosPage() {
     select: {
       descripcion: true,
       fundado: true,
-      provincia: true,
-      partido: true,
-      ubicacionDetalle: true,
       cuit: true,
       pedidosCompletados: true,
       user: { select: { name: true, email: true, phone: true } },
@@ -43,14 +40,12 @@ export default async function TallerDatosBasicosPage() {
     )
   }
 
-  const ubicacion = [taller.provincia, taller.partido, taller.ubicacionDetalle]
-    .filter(Boolean)
-    .join(', ')
-
   return (
     <div className="space-y-6">
       {/* Información del taller — campos públicos. Estos se LEEN en la vidriera
-          (misma fila Taller): editarlos acá los actualiza también allá, sin copia. */}
+          (misma fila Taller): editarlos acá los actualiza también allá, sin copia.
+          La ubicación NO se repite acá: ya vive en la cabecera común (metadata
+          global), debajo del nombre — evita la duplicación que marcó el QA (#442). */}
       <Card title="Información del taller">
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
           <div className="sm:col-span-2">
@@ -64,10 +59,6 @@ export default async function TallerDatosBasicosPage() {
           <div>
             <p className="text-gray-500">Año de fundación</p>
             <p className="font-medium">{taller.fundado ?? <span className="text-gray-400 italic">Sin completar</span>}</p>
-          </div>
-          <div>
-            <p className="text-gray-500">Ubicación</p>
-            <p className="font-medium break-words">{ubicacion || <span className="text-gray-400 italic">Sin completar</span>}</p>
           </div>
         </div>
         <p className="flex items-center gap-1 text-xs text-gray-400 mt-4">

--- a/src/app/(taller)/taller/perfil/page.tsx
+++ b/src/app/(taller)/taller/perfil/page.tsx
@@ -24,7 +24,11 @@ export default async function TallerDatosBasicosPage() {
     select: {
       descripcion: true,
       fundado: true,
+      provincia: true,
+      partido: true,
+      ubicacionDetalle: true,
       cuit: true,
+      verificadoAfip: true,
       pedidosCompletados: true,
       user: { select: { name: true, email: true, phone: true } },
     },
@@ -41,12 +45,16 @@ export default async function TallerDatosBasicosPage() {
     )
   }
 
+  const ubicacion = [taller.provincia, taller.partido, taller.ubicacionDetalle]
+    .filter(Boolean)
+    .join(', ')
+
   return (
     <div className="space-y-6">
-      {/* Información del taller — campos públicos. Estos se LEEN en la vidriera
-          (misma fila Taller): editarlos acá los actualiza también allá, sin copia.
-          La ubicación NO se repite acá: ya vive en la cabecera común (metadata
-          global), debajo del nombre — evita la duplicación que marcó el QA (#442). */}
+      {/* Información del taller — identidad pública del taller. En el modelo de
+          Sergio (cabecera = solo nombre), la UBICACIÓN vive acá (su hogar de
+          identidad), no en la cabecera. Estos campos se LEEN en la vidriera
+          (misma fila Taller): editarlos acá los actualiza también allá, sin copia. */}
       <Card title="Información del taller">
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
           <div className="sm:col-span-2">
@@ -60,6 +68,10 @@ export default async function TallerDatosBasicosPage() {
           <div>
             <p className="text-gray-500">Año de fundación</p>
             <p className="font-medium">{taller.fundado ?? <span className="text-gray-400 italic">Sin completar</span>}</p>
+          </div>
+          <div>
+            <p className="text-gray-500">Ubicación</p>
+            <p className="font-medium break-words">{ubicacion || <span className="text-gray-400 italic">Sin completar</span>}</p>
           </div>
         </div>
         {/* Acción contextual: editar los datos básicos. Vive en el CUERPO del tab
@@ -102,12 +114,18 @@ export default async function TallerDatosBasicosPage() {
         </p>
       </Card>
 
-      {/* Datos de registro — identidad fiscal/operativa. CUIT es privado. */}
+      {/* Datos de registro — identidad fiscal/operativa. CUIT es privado.
+          Change 3 (Sergio): el CUIT muestra el número + texto chico "Verificado por
+          ARCA" al lado (no el badge prominente — ese vive en Inicio / Mi recorrido
+          / Mi vidriera>Credenciales). */}
       <Card title="Datos de registro">
         <div className="grid grid-cols-2 gap-4 text-sm">
           <div>
             <p className="text-gray-500">CUIT</p>
             <p className="font-medium">{taller.cuit}</p>
+            <p className="text-xs text-gray-400 mt-0.5">
+              {taller.verificadoAfip ? 'Verificado por ARCA' : 'Sin verificar en ARCA'}
+            </p>
           </div>
           <div>
             <p className="text-gray-500">Pedidos completados</p>

--- a/src/app/(taller)/taller/perfil/page.tsx
+++ b/src/app/(taller)/taller/perfil/page.tsx
@@ -13,7 +13,8 @@ import { Lock, Eye } from 'lucide-react'
 // ubicación) que SINCRONIZA a la vidriera por lectura del mismo registro Taller
 // (spec §3 — sin copia ni trigger), + datos del responsable (privados, sólo el
 // taller y la Coordinación). La edición es vía el form existente
-// `/taller/perfil/editar` (botón "Editar datos básicos" en la cabecera del layout).
+// `/taller/perfil/editar`, con el botón "Editar datos básicos" como acción del
+// CUERPO de este tab (card "Información del taller"), no en la cabecera (QA #442 A).
 export default async function TallerDatosBasicosPage() {
   const session = await auth()
   if (!session?.user) redirect('/login')
@@ -61,10 +62,17 @@ export default async function TallerDatosBasicosPage() {
             <p className="font-medium">{taller.fundado ?? <span className="text-gray-400 italic">Sin completar</span>}</p>
           </div>
         </div>
-        <p className="flex items-center gap-1 text-xs text-gray-400 mt-4">
-          <Eye className="w-3 h-3 shrink-0" />
-          Esta información aparece en tu vidriera pública. Editala desde &ldquo;Editar datos básicos&rdquo;.
-        </p>
+        {/* Acción contextual: editar los datos básicos. Vive en el CUERPO del tab
+            (QA #442 A), no flotando junto al título global de Mi taller. */}
+        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="flex items-center gap-1 text-xs text-gray-400">
+            <Eye className="w-3 h-3 shrink-0" />
+            Esta información aparece en tu vidriera pública.
+          </p>
+          <Link href="/taller/perfil/editar">
+            <Button variant="secondary" size="sm">Editar datos básicos</Button>
+          </Link>
+        </div>
       </Card>
 
       {/* Datos del responsable — PII privada, movida desde "Mi gestión productiva"

--- a/src/app/(taller)/taller/perfil/page.tsx
+++ b/src/app/(taller)/taller/perfil/page.tsx
@@ -4,37 +4,31 @@ import { auth } from '@/compartido/lib/auth'
 import { prisma } from '@/compartido/lib/prisma'
 import { redirect } from 'next/navigation'
 import Link from 'next/link'
-import { Badge } from '@/compartido/componentes/ui/badge'
 import { Card } from '@/compartido/componentes/ui/card'
 import { Button } from '@/compartido/componentes/ui/button'
-import { Award, Download } from 'lucide-react'
-import { PortfolioManager } from '@/taller/componentes/portfolio-manager'
-import { VerVidrieraModal } from '@/taller/componentes/ver-vidriera-modal'
-import { VidrieraPublicaContenido } from '@/taller/componentes/vidriera-publica-contenido'
+import { Lock, Eye } from 'lucide-react'
 
-// Etapa 2.1 — "Mi vidriera": lo que ven las marcas en el directorio.
-// La cabecera común (nombre + etapa + ARCA) y las sub-tabs viven en el layout.
-// El reparto público/privado es 2.1; el filtrado por visibilidad es 2.2.
-export default async function TallerVidrieraPage() {
+// Etapa 2.2-A — "Datos básicos": primer sub-tab (ruta índice). Lo obligatorio
+// que el taller carga UNA vez: identidad pública del taller (descripción, año,
+// ubicación) que SINCRONIZA a la vidriera por lectura del mismo registro Taller
+// (spec §3 — sin copia ni trigger), + datos del responsable (privados, sólo el
+// taller y la Coordinación). La edición es vía el form existente
+// `/taller/perfil/editar` (botón "Editar datos básicos" en la cabecera del layout).
+export default async function TallerDatosBasicosPage() {
   const session = await auth()
   if (!session?.user) redirect('/login')
 
   const taller = await prisma.taller.findFirst({
     where: { userId: session.user.id },
-    include: {
-      procesos: { include: { proceso: true } },
-      prendas: { include: { prenda: true } },
-      maquinaria: true,
-      certificaciones: { where: { activa: true } },
-      certificados: {
-        where: { revocado: false },
-        include: { coleccion: { select: { titulo: true, institucion: true } } },
-        orderBy: { fecha: 'desc' },
-      },
-      validaciones: {
-        where: { estado: 'COMPLETADO' },
-        select: { tipoDocumento: { select: { nombre: true } } },
-      },
+    select: {
+      descripcion: true,
+      fundado: true,
+      provincia: true,
+      partido: true,
+      ubicacionDetalle: true,
+      cuit: true,
+      pedidosCompletados: true,
+      user: { select: { name: true, email: true, phone: true } },
     },
   })
 
@@ -49,101 +43,79 @@ export default async function TallerVidrieraPage() {
     )
   }
 
+  const ubicacion = [taller.provincia, taller.partido, taller.ubicacionDetalle]
+    .filter(Boolean)
+    .join(', ')
+
   return (
     <div className="space-y-6">
-      {/* "Ver cómo me ve el directorio": MODAL sobre Mi vidriera (no navega a la
-          página pública). El contenido es la vidriera pública filtrada por #437;
-          al cerrar, el taller queda en su contexto privado. */}
-      <div className="flex justify-end">
-        <VerVidrieraModal>
-          <VidrieraPublicaContenido taller={taller} />
-        </VerVidrieraModal>
-      </div>
-
-      {/* NOTA (2.2): "Trabajadores" y "Cap. mensual" salieron del grid destacado de
-          marketplace (junto con Rating / On-time / barra de completitud, descartados del
-          modelo V4). Su ubicación final es el bloque "Mi capacidad de producción"
-          (toggleable) que arma la Etapa 2.2 — no se renderizan acá por ahora. */}
-
-      {taller.descripcion && (
-        <Card title="Descripción">
-          <p className="text-sm text-gray-700 whitespace-pre-wrap">{taller.descripcion}</p>
-        </Card>
-      )}
-
-      {taller.procesos.length > 0 && (
-        <Card title="Procesos Productivos">
-          <div className="flex flex-wrap gap-2">
-            {taller.procesos.map((tp) => (
-              <Badge key={tp.id} variant="outline">{tp.proceso.nombre}</Badge>
-            ))}
+      {/* Información del taller — campos públicos. Estos se LEEN en la vidriera
+          (misma fila Taller): editarlos acá los actualiza también allá, sin copia. */}
+      <Card title="Información del taller">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+          <div className="sm:col-span-2">
+            <p className="text-gray-500">Descripción</p>
+            {taller.descripcion ? (
+              <p className="font-medium whitespace-pre-wrap break-words">{taller.descripcion}</p>
+            ) : (
+              <p className="text-gray-400 italic">Sin descripción todavía</p>
+            )}
           </div>
-        </Card>
-      )}
-
-      {taller.prendas.length > 0 && (
-        <Card title="Tipos de Prenda">
-          <div className="flex flex-wrap gap-2">
-            {taller.prendas.map((tp) => (
-              <Badge key={tp.id} variant="default">{tp.prenda.nombre}</Badge>
-            ))}
+          <div>
+            <p className="text-gray-500">Año de fundación</p>
+            <p className="font-medium">{taller.fundado ?? <span className="text-gray-400 italic">Sin completar</span>}</p>
           </div>
-        </Card>
-      )}
-
-      <Card title="Mi portfolio">
-        <PortfolioManager tallerId={taller.id} fotosActuales={taller.portfolioFotos} />
+          <div>
+            <p className="text-gray-500">Ubicación</p>
+            <p className="font-medium break-words">{ubicacion || <span className="text-gray-400 italic">Sin completar</span>}</p>
+          </div>
+        </div>
+        <p className="flex items-center gap-1 text-xs text-gray-400 mt-4">
+          <Eye className="w-3 h-3 shrink-0" />
+          Esta información aparece en tu vidriera pública. Editala desde &ldquo;Editar datos básicos&rdquo;.
+        </p>
       </Card>
 
-      {taller.maquinaria.length > 0 && (
-        <Card title="Maquinaria">
-          <ul className="space-y-1 text-sm">
-            {taller.maquinaria.map((m) => (
-              <li key={m.id} className="flex justify-between">
-                <span>{m.nombre} {m.tipo && <span className="text-gray-400">({m.tipo})</span>}</span>
-                <span className="text-gray-500 font-medium">x{m.cantidad}</span>
-              </li>
-            ))}
-          </ul>
-        </Card>
-      )}
-
-      {taller.certificaciones.length > 0 && (
-        <Card title="Certificaciones">
-          <div className="flex flex-wrap gap-2">
-            {taller.certificaciones.map((c) => (
-              <Badge key={c.id} variant="success">
-                <Award className="w-3 h-3 mr-1" />{c.nombre}
-              </Badge>
-            ))}
+      {/* Datos del responsable — PII privada, movida desde "Mi gestión productiva"
+          (2.2-A). No visible para las marcas (minimización de datos, OIT IGDS 457). */}
+      <Card title="Datos del responsable">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+          {taller.user.name && (
+            <div>
+              <p className="text-gray-500">Responsable</p>
+              <p className="font-medium break-words">{taller.user.name}</p>
+            </div>
+          )}
+          <div>
+            <p className="text-gray-500">Email</p>
+            <p className="font-medium break-words">{taller.user.email}</p>
           </div>
-        </Card>
-      )}
+          {taller.user.phone && (
+            <div>
+              <p className="text-gray-500">Teléfono</p>
+              <p className="font-medium break-words">{taller.user.phone}</p>
+            </div>
+          )}
+        </div>
+        <p className="flex items-center gap-1 text-xs text-gray-400 mt-4">
+          <Lock className="w-3 h-3 shrink-0" />
+          Esta información de contacto es privada. Las marcas no la ven en tu vidriera.
+        </p>
+      </Card>
 
-      {taller.certificados.length > 0 && (
-        <Card title="Certificados de cursos">
-          <div className="space-y-2">
-            {taller.certificados.map((c) => (
-              <div key={c.id} className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0">
-                <div className="flex items-center gap-2">
-                  <Award className="w-4 h-4 text-green-600" />
-                  <div>
-                    <p className="text-sm font-medium text-gray-800">{c.coleccion.titulo}</p>
-                    <p className="text-xs text-gray-500">Código: {c.codigo} · Calificación: {c.calificacion}%</p>
-                  </div>
-                </div>
-                <a
-                  href={`/api/certificados/${c.id}/pdf`}
-                  download
-                  className="inline-flex items-center gap-1 text-xs text-brand-blue hover:underline"
-                >
-                  <Download className="w-3 h-3" /> PDF
-                </a>
-              </div>
-            ))}
+      {/* Datos de registro — identidad fiscal/operativa. CUIT es privado. */}
+      <Card title="Datos de registro">
+        <div className="grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <p className="text-gray-500">CUIT</p>
+            <p className="font-medium">{taller.cuit}</p>
           </div>
-        </Card>
-      )}
+          <div>
+            <p className="text-gray-500">Pedidos completados</p>
+            <p className="font-medium">{taller.pedidosCompletados}</p>
+          </div>
+        </div>
+      </Card>
     </div>
   )
 }

--- a/src/app/(taller)/taller/perfil/perfil-header-tabs.tsx
+++ b/src/app/(taller)/taller/perfil/perfil-header-tabs.tsx
@@ -3,7 +3,6 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { Badge } from '@/compartido/componentes/ui/badge'
-import { Button } from '@/compartido/componentes/ui/button'
 import { BadgeArca } from '@/compartido/componentes/badge-arca'
 import { MapPin } from 'lucide-react'
 
@@ -47,38 +46,28 @@ export function PerfilHeaderTabs({
 
   return (
     <div className="space-y-4">
-      {/* Cabecera común — nombre + etapa actual (nivelAEtapa) + ARCA verificado */}
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-2 mb-1">
-            <h1 className="font-serif font-bold text-3xl text-ink-primary break-words">{nombre}</h1>
-            <Badge variant="default">{etapa}</Badge>
-          </div>
-          <div className="mb-1">
-            <BadgeArca verificado={verificadoAfip} />
-          </div>
-          {provincia && (
-            <p className="flex items-center gap-1 text-gray-600">
-              <MapPin className="w-4 h-4 shrink-0" /> {provincia}
-              {partido ? `, ${partido}` : ''}
-              {ubicacionDetalle && <span className="text-gray-400"> · {ubicacionDetalle}</span>}
-            </p>
-          )}
-          {/* PII del responsable (nombre/email/teléfono) vive en "Mi gestión productiva"
-              (privado), no en la cabecera común — minimización de datos (OIT IGDS 457). */}
+      {/* Cabecera común — nombre + etapa actual (nivelAEtapa) + ARCA verificado.
+          El botón "Editar datos básicos" NO vive acá (QA #442 A): es una acción del
+          CUERPO del tab Datos básicos (card "Información del taller"), no de la
+          cabecera. "Ver cómo me ve el directorio" → Mi vidriera; "Completar perfil
+          productivo" → Mi gestión productiva. */}
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2 mb-1">
+          <h1 className="font-serif font-bold text-3xl text-ink-primary break-words">{nombre}</h1>
+          <Badge variant="default">{etapa}</Badge>
         </div>
-
-        {/* "Editar datos básicos" vive SOLO en el tab "Datos básicos" (QA #442):
-            la edición de identidad pertenece a esa pestaña, no a gestión/vidriera.
-            "Ver cómo me ve el directorio" → "Mi vidriera"; "Completar perfil
-            productivo" → "Mi gestión productiva". */}
-        {pathname === '/taller/perfil' && (
-          <div className="flex flex-col gap-2 sm:items-end shrink-0">
-            <Link href="/taller/perfil/editar">
-              <Button variant="secondary" size="sm">Editar datos básicos</Button>
-            </Link>
-          </div>
+        <div className="mb-1">
+          <BadgeArca verificado={verificadoAfip} />
+        </div>
+        {provincia && (
+          <p className="flex items-center gap-1 text-gray-600">
+            <MapPin className="w-4 h-4 shrink-0" /> {provincia}
+            {partido ? `, ${partido}` : ''}
+            {ubicacionDetalle && <span className="text-gray-400"> · {ubicacionDetalle}</span>}
+          </p>
         )}
+        {/* PII del responsable (nombre/email/teléfono) vive en "Mi gestión productiva"
+            (privado), no en la cabecera común — minimización de datos (OIT IGDS 457). */}
       </div>
 
       {/* Sub-tabs (pills): Datos básicos | Mi gestión productiva | Mi vidriera.

--- a/src/app/(taller)/taller/perfil/perfil-header-tabs.tsx
+++ b/src/app/(taller)/taller/perfil/perfil-header-tabs.tsx
@@ -2,15 +2,16 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Badge } from '@/compartido/componentes/ui/badge'
-import { BadgeArca } from '@/compartido/componentes/badge-arca'
-import { MapPin } from 'lucide-react'
 
-// Etapa 2.2-A — contenedor "Mi taller": cabecera común + sub-tabs.
-// 3 sub-tabs en orden secuencial: Datos básicos (índice) → Mi gestión productiva
-// → Mi vidriera (obligatorio → productivo → curatorial). Cabecera (nombre + etapa
-// + ARCA) y sub-tabs viven sobre las 3 vistas. En los formularios (editar /
-// completar) el cromo se oculta — molde de `taller/pedidos/layout.tsx` (PR #374).
+// Etapa 2.2-A — contenedor "Mi taller": cabecera + sub-tabs.
+// Modelo de distribución de Sergio (QA combinado, 2026-06-27): la cabecera
+// compartida queda con SOLO el nombre del taller + los pills de navegación.
+// La metadata de identidad vive donde corresponde por contexto:
+//   - ubicación → "Datos básicos" (card "Información del taller")
+//   - etapa + ARCA → Inicio (card "Tu recorrido"), Mi recorrido, y Credenciales
+//     de Mi vidriera (esto último es 2.2-B/C).
+// En los formularios (editar / completar) el cromo se oculta — molde de
+// `taller/pedidos/layout.tsx` (PR #374).
 
 const subTabs = [
   { label: 'Datos básicos', href: '/taller/perfil' },
@@ -26,48 +27,16 @@ function mostrarCromo(pathname: string) {
   )
 }
 
-export function PerfilHeaderTabs({
-  nombre,
-  etapa,
-  verificadoAfip,
-  provincia,
-  partido,
-  ubicacionDetalle,
-}: {
-  nombre: string
-  etapa: string
-  verificadoAfip: boolean
-  provincia: string | null
-  partido: string | null
-  ubicacionDetalle: string | null
-}) {
+export function PerfilHeaderTabs({ nombre }: { nombre: string }) {
   const pathname = usePathname()
   if (!mostrarCromo(pathname)) return null
 
   return (
     <div className="space-y-4">
-      {/* Cabecera común — nombre + etapa actual (nivelAEtapa) + ARCA verificado.
-          El botón "Editar datos básicos" NO vive acá (QA #442 A): es una acción del
-          CUERPO del tab Datos básicos (card "Información del taller"), no de la
-          cabecera. "Ver cómo me ve el directorio" → Mi vidriera; "Completar perfil
-          productivo" → Mi gestión productiva. */}
+      {/* Cabecera = SOLO el nombre del taller (sin etapa/ARCA/ubicación — se
+          distribuyen por contexto, modelo Sergio QA combinado). */}
       <div className="min-w-0">
-        <div className="flex flex-wrap items-center gap-2 mb-1">
-          <h1 className="font-serif font-bold text-3xl text-ink-primary break-words">{nombre}</h1>
-          <Badge variant="default">{etapa}</Badge>
-        </div>
-        <div className="mb-1">
-          <BadgeArca verificado={verificadoAfip} />
-        </div>
-        {provincia && (
-          <p className="flex items-center gap-1 text-gray-600">
-            <MapPin className="w-4 h-4 shrink-0" /> {provincia}
-            {partido ? `, ${partido}` : ''}
-            {ubicacionDetalle && <span className="text-gray-400"> · {ubicacionDetalle}</span>}
-          </p>
-        )}
-        {/* PII del responsable (nombre/email/teléfono) vive en "Mi gestión productiva"
-            (privado), no en la cabecera común — minimización de datos (OIT IGDS 457). */}
+        <h1 className="font-serif font-bold text-3xl text-ink-primary break-words">{nombre}</h1>
       </div>
 
       {/* Sub-tabs (pills): Datos básicos | Mi gestión productiva | Mi vidriera.

--- a/src/app/(taller)/taller/perfil/perfil-header-tabs.tsx
+++ b/src/app/(taller)/taller/perfil/perfil-header-tabs.tsx
@@ -68,17 +68,23 @@ export function PerfilHeaderTabs({
               (privado), no en la cabecera común — minimización de datos (OIT IGDS 457). */}
         </div>
 
-        <div className="flex flex-col gap-2 sm:items-end shrink-0">
-          {/* "Ver cómo me ve el directorio" → movido a "Mi vidriera".
-              "Completar perfil productivo" → movido a "Mi gestión productiva". */}
-          <Link href="/taller/perfil/editar">
-            <Button variant="secondary" size="sm">Editar datos básicos</Button>
-          </Link>
-        </div>
+        {/* "Editar datos básicos" vive SOLO en el tab "Datos básicos" (QA #442):
+            la edición de identidad pertenece a esa pestaña, no a gestión/vidriera.
+            "Ver cómo me ve el directorio" → "Mi vidriera"; "Completar perfil
+            productivo" → "Mi gestión productiva". */}
+        {pathname === '/taller/perfil' && (
+          <div className="flex flex-col gap-2 sm:items-end shrink-0">
+            <Link href="/taller/perfil/editar">
+              <Button variant="secondary" size="sm">Editar datos básicos</Button>
+            </Link>
+          </div>
+        )}
       </div>
 
-      {/* Sub-tabs: Datos básicos | Mi gestión productiva | Mi vidriera */}
-      <nav className="flex gap-1 border-b border-gray-200 overflow-x-auto">
+      {/* Sub-tabs (pills): Datos básicos | Mi gestión productiva | Mi vidriera.
+          Pills con contraste fuerte (activo = azul lleno) para que se lean como
+          navegación, no como texto. Responsive: overflow-x-auto + nowrap en 320/375. */}
+      <nav className="flex gap-2 overflow-x-auto pb-1" aria-label="Secciones de Mi taller">
         {subTabs.map((tab) => {
           const isActive =
             tab.href === '/taller/perfil'
@@ -89,10 +95,11 @@ export function PerfilHeaderTabs({
             <Link
               key={tab.href}
               href={tab.href}
-              className={`px-4 py-2.5 text-sm font-overpass font-semibold border-b-2 transition-colors -mb-px whitespace-nowrap ${
+              aria-current={isActive ? 'page' : undefined}
+              className={`px-4 py-2 rounded-lg text-sm font-overpass font-semibold whitespace-nowrap transition-colors ${
                 isActive
-                  ? 'border-brand-blue text-brand-blue'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                  ? 'bg-brand-blue text-white shadow-sm'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-800'
               }`}
             >
               {tab.label}

--- a/src/app/(taller)/taller/perfil/perfil-header-tabs.tsx
+++ b/src/app/(taller)/taller/perfil/perfil-header-tabs.tsx
@@ -7,18 +7,24 @@ import { Button } from '@/compartido/componentes/ui/button'
 import { BadgeArca } from '@/compartido/componentes/badge-arca'
 import { MapPin } from 'lucide-react'
 
-// Etapa 2.1 — contenedor "Mi taller": cabecera común + sub-tabs.
-// Cabecera (nombre + etapa actual + ARCA verificado) y sub-tabs viven sobre
-// ambas vistas (vidriera / gestión). En los formularios (editar / completar)
-// el cromo se oculta — molde tomado de `taller/pedidos/layout.tsx` (PR #374).
+// Etapa 2.2-A — contenedor "Mi taller": cabecera común + sub-tabs.
+// 3 sub-tabs en orden secuencial: Datos básicos (índice) → Mi gestión productiva
+// → Mi vidriera (obligatorio → productivo → curatorial). Cabecera (nombre + etapa
+// + ARCA) y sub-tabs viven sobre las 3 vistas. En los formularios (editar /
+// completar) el cromo se oculta — molde de `taller/pedidos/layout.tsx` (PR #374).
 
 const subTabs = [
-  { label: 'Mi vidriera', href: '/taller/perfil' },
+  { label: 'Datos básicos', href: '/taller/perfil' },
   { label: 'Mi gestión productiva', href: '/taller/perfil/gestion' },
+  { label: 'Mi vidriera', href: '/taller/perfil/vidriera' },
 ]
 
 function mostrarCromo(pathname: string) {
-  return pathname === '/taller/perfil' || pathname === '/taller/perfil/gestion'
+  return (
+    pathname === '/taller/perfil' ||
+    pathname === '/taller/perfil/gestion' ||
+    pathname === '/taller/perfil/vidriera'
+  )
 }
 
 export function PerfilHeaderTabs({
@@ -71,7 +77,7 @@ export function PerfilHeaderTabs({
         </div>
       </div>
 
-      {/* Sub-tabs: Mi vidriera | Mi gestión productiva */}
+      {/* Sub-tabs: Datos básicos | Mi gestión productiva | Mi vidriera */}
       <nav className="flex gap-1 border-b border-gray-200 overflow-x-auto">
         {subTabs.map((tab) => {
           const isActive =

--- a/src/app/(taller)/taller/perfil/vidriera/page.tsx
+++ b/src/app/(taller)/taller/perfil/vidriera/page.tsx
@@ -1,0 +1,152 @@
+export const dynamic = 'force-dynamic'
+
+import { auth } from '@/compartido/lib/auth'
+import { prisma } from '@/compartido/lib/prisma'
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { Badge } from '@/compartido/componentes/ui/badge'
+import { Card } from '@/compartido/componentes/ui/card'
+import { Button } from '@/compartido/componentes/ui/button'
+import { Award, Download } from 'lucide-react'
+import { PortfolioManager } from '@/taller/componentes/portfolio-manager'
+import { VerVidrieraModal } from '@/taller/componentes/ver-vidriera-modal'
+import { VidrieraPublicaContenido } from '@/taller/componentes/vidriera-publica-contenido'
+
+// Etapa 2.2-A — "Mi vidriera": lo que ven las marcas en el directorio.
+// Tercer (último) sub-tab del orden secuencial Datos básicos → gestión → vidriera.
+// La cabecera común (nombre + etapa + ARCA) y las sub-tabs viven en el layout.
+// Los campos públicos (nombre, descripción, año, ubicación) se EDITAN en "Datos
+// básicos" y se LEEN acá: misma fila Taller, sin copia ni sync (spec §3). El
+// filtrado por visibilidad (toggles + privacy-by-default) es 2.2-B/C.
+export default async function TallerVidrieraPage() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const taller = await prisma.taller.findFirst({
+    where: { userId: session.user.id },
+    include: {
+      procesos: { include: { proceso: true } },
+      prendas: { include: { prenda: true } },
+      maquinaria: true,
+      certificaciones: { where: { activa: true } },
+      certificados: {
+        where: { revocado: false },
+        include: { coleccion: { select: { titulo: true, institucion: true } } },
+        orderBy: { fecha: 'desc' },
+      },
+      validaciones: {
+        where: { estado: 'COMPLETADO' },
+        select: { tipoDocumento: { select: { nombre: true } } },
+      },
+    },
+  })
+
+  if (!taller) {
+    return (
+      <Card className="text-center py-12">
+        <p className="text-gray-600 mb-4">Todavía no completaste tu perfil.</p>
+        <Link href="/taller/perfil/completar">
+          <Button>Completar Perfil</Button>
+        </Link>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* "Ver cómo me ve el directorio": MODAL sobre Mi vidriera (no navega a la
+          página pública). El contenido es la vidriera pública filtrada por #437;
+          al cerrar, el taller queda en su contexto privado. */}
+      <div className="flex justify-end">
+        <VerVidrieraModal>
+          <VidrieraPublicaContenido taller={taller} />
+        </VerVidrieraModal>
+      </div>
+
+      {/* NOTA (2.2): "Trabajadores" y "Cap. mensual" salieron del grid destacado de
+          marketplace (junto con Rating / On-time / barra de completitud, descartados del
+          modelo V4). Su ubicación final es el bloque "Mi capacidad de producción"
+          (toggleable) que arma la Etapa 2.2 — no se renderizan acá por ahora. */}
+
+      {taller.descripcion && (
+        <Card title="Descripción">
+          <p className="text-sm text-gray-700 whitespace-pre-wrap">{taller.descripcion}</p>
+        </Card>
+      )}
+
+      {taller.procesos.length > 0 && (
+        <Card title="Procesos Productivos">
+          <div className="flex flex-wrap gap-2">
+            {taller.procesos.map((tp) => (
+              <Badge key={tp.id} variant="outline">{tp.proceso.nombre}</Badge>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {taller.prendas.length > 0 && (
+        <Card title="Tipos de Prenda">
+          <div className="flex flex-wrap gap-2">
+            {taller.prendas.map((tp) => (
+              <Badge key={tp.id} variant="default">{tp.prenda.nombre}</Badge>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      <Card title="Mi portfolio">
+        <PortfolioManager tallerId={taller.id} fotosActuales={taller.portfolioFotos} />
+      </Card>
+
+      {taller.maquinaria.length > 0 && (
+        <Card title="Maquinaria">
+          <ul className="space-y-1 text-sm">
+            {taller.maquinaria.map((m) => (
+              <li key={m.id} className="flex justify-between">
+                <span>{m.nombre} {m.tipo && <span className="text-gray-400">({m.tipo})</span>}</span>
+                <span className="text-gray-500 font-medium">x{m.cantidad}</span>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+
+      {taller.certificaciones.length > 0 && (
+        <Card title="Certificaciones">
+          <div className="flex flex-wrap gap-2">
+            {taller.certificaciones.map((c) => (
+              <Badge key={c.id} variant="success">
+                <Award className="w-3 h-3 mr-1" />{c.nombre}
+              </Badge>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {taller.certificados.length > 0 && (
+        <Card title="Certificados de cursos">
+          <div className="space-y-2">
+            {taller.certificados.map((c) => (
+              <div key={c.id} className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0">
+                <div className="flex items-center gap-2">
+                  <Award className="w-4 h-4 text-green-600" />
+                  <div>
+                    <p className="text-sm font-medium text-gray-800">{c.coleccion.titulo}</p>
+                    <p className="text-xs text-gray-500">Código: {c.codigo} · Calificación: {c.calificacion}%</p>
+                  </div>
+                </div>
+                <a
+                  href={`/api/certificados/${c.id}/pdf`}
+                  download
+                  className="inline-flex items-center gap-1 text-xs text-brand-blue hover:underline"
+                >
+                  <Download className="w-3 h-3" /> PDF
+                </a>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/src/compartido/componentes/ui/checklist-onboarding.tsx
+++ b/src/compartido/componentes/ui/checklist-onboarding.tsx
@@ -4,28 +4,21 @@ import type { PasoOnboarding } from '@/compartido/lib/onboarding'
 
 interface Props {
   pasos: PasoOnboarding[]
-  /** Etapa de formalización actual (nivelAEtapa). Se muestra como subtítulo del
-   *  recorrido dentro de la card — movido desde el header del dashboard (QA #442). */
-  etapa?: string
 }
 
-export function ChecklistOnboarding({ pasos, etapa }: Props) {
+export function ChecklistOnboarding({ pasos }: Props) {
   const primerPendiente = pasos.find(p => !p.completado)
   const completados = pasos.filter(p => p.completado).length
 
   return (
     <div className="rounded-xl border border-brand-blue/20 bg-brand-blue/5 p-6">
+      {/* El subtítulo "Tu recorrido de formalización: {etapa}" (issue 6) se quitó:
+          el recorrido ahora vive en su card dedicada en Inicio (change 2, QA Sergio),
+          sin duplicarse. Esta card queda enfocada en los pasos de onboarding. */}
       <div className="flex items-start justify-between gap-3 mb-4">
-        <div className="min-w-0">
-          <h2 className="font-overpass font-bold text-lg text-brand-blue">
-            Tus primeros pasos en la plataforma
-          </h2>
-          {etapa && (
-            <p className="text-sm text-gray-500 mt-0.5">
-              Tu recorrido de formalización: <span className="font-semibold">{etapa}</span>
-            </p>
-          )}
-        </div>
+        <h2 className="font-overpass font-bold text-lg text-brand-blue">
+          Tus primeros pasos en la plataforma
+        </h2>
         <span className="text-xs text-gray-500 font-medium shrink-0">
           {completados}/{pasos.length} completados
         </span>

--- a/src/compartido/componentes/ui/checklist-onboarding.tsx
+++ b/src/compartido/componentes/ui/checklist-onboarding.tsx
@@ -4,19 +4,29 @@ import type { PasoOnboarding } from '@/compartido/lib/onboarding'
 
 interface Props {
   pasos: PasoOnboarding[]
+  /** Etapa de formalización actual (nivelAEtapa). Se muestra como subtítulo del
+   *  recorrido dentro de la card — movido desde el header del dashboard (QA #442). */
+  etapa?: string
 }
 
-export function ChecklistOnboarding({ pasos }: Props) {
+export function ChecklistOnboarding({ pasos, etapa }: Props) {
   const primerPendiente = pasos.find(p => !p.completado)
   const completados = pasos.filter(p => p.completado).length
 
   return (
     <div className="rounded-xl border border-brand-blue/20 bg-brand-blue/5 p-6">
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="font-overpass font-bold text-lg text-brand-blue">
-          Tus primeros pasos en la plataforma
-        </h2>
-        <span className="text-xs text-gray-500 font-medium">
+      <div className="flex items-start justify-between gap-3 mb-4">
+        <div className="min-w-0">
+          <h2 className="font-overpass font-bold text-lg text-brand-blue">
+            Tus primeros pasos en la plataforma
+          </h2>
+          {etapa && (
+            <p className="text-sm text-gray-500 mt-0.5">
+              Tu recorrido de formalización: <span className="font-semibold">{etapa}</span>
+            </p>
+          )}
+        </div>
+        <span className="text-xs text-gray-500 font-medium shrink-0">
           {completados}/{pasos.length} completados
         </span>
       </div>

--- a/src/taller/componentes/proximo-nivel-card.tsx
+++ b/src/taller/componentes/proximo-nivel-card.tsx
@@ -176,8 +176,11 @@ export async function ProximoNivelCard({ tallerId }: { tallerId: string }) {
   return (
     <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
       <div className="mb-4">
+        {/* "Próximos pasos para avanzar" (no "Tu recorrido de formalización"): el
+            estado del recorrido vive ahora en la card dedicada del dashboard (change 2
+            QA Sergio). Esta card es complementaria — los pasos para avanzar de etapa. */}
         <h2 className="font-overpass font-bold text-lg text-brand-blue">
-          Tu recorrido de formalización
+          Próximos pasos para avanzar
         </h2>
         <p className="text-sm text-zinc-500 mt-1">Próxima etapa: {etapaProxima}</p>
         <div className="mt-2">


### PR DESCRIPTION
## Etapa 2.2-A — Estructura (sub-tab + reorder + sync + dedup)

PR **estructural y behavior-preserving**. Reorganiza "Mi taller" sin tocar lógica de visibilidad (toggles, flag `modeloB_revisado`, render condicional) — eso es **2.2-B/C**. Spec: `.claude/specs/v4-etapa2-2-vidriera-discovery.md` §2–§4.

### Qué cambia

**"Mi taller" pasa de 2 a 3 sub-tabs**, en orden secuencial (obligatorio → productivo → curatorial):

| # | Tab | Ruta | Contenido |
|---|---|---|---|
| 1 | **Datos básicos** *(NUEVO — índice)* | `/taller/perfil` | Información del taller (descripción, año, ubicación) · Datos del responsable (privado) · Datos de registro (CUIT, pedidos) |
| 2 | Mi gestión productiva | `/taller/perfil/gestion` | **Sólo** Perfil productivo |
| 3 | **Mi vidriera** *(movida del índice)* | `/taller/perfil/vidriera` | Lo que ven las marcas (contenido intacto) |

- **Datos básicos** es ahora la ruta índice (se aterriza ahí). La identidad pública (descripción, año, ubicación) se **lee** en la vidriera desde la misma fila `Taller` — sin copia ni trigger (sync = lectura compartida, spec §3).
- La card **"Datos del responsable"** (PII privada) se movió de gestión → Datos básicos.
- De gestión se quitan **"Datos del responsable"** e **"Información General"** (dedup, spec §4); queda sólo el Perfil productivo.
- `perfil-header-tabs`: 3 entradas en el nuevo orden; `mostrarCromo` cubre `/vidriera`; tab activa = índice `===`, resto `startsWith` (sin doble-activo).

### Fuera de scope (2.2-B/C)
Taxonomía de 3 categorías, render condicional con `modeloB_revisado`, toggles de visibilidad, badges de Formación, banners. Acá **el contenido sigue accesible, sólo reorganizado**.

### Sync (sin código nuevo)
No se crean campos espejo ni eventos. "Sincronizado" = misma fila `Taller`, `force-dynamic` → la vidriera refleja el siguiente render. El render público no SELECT-ea los campos privados del responsable.

### Verificación
- Mobile 320/375 (3 tabs scrollean sin desborde) + desktop — playwright-core sobre el preview (resultados en comentario).
- CI: typecheck + unit + e2e.

### Nota de coordinación con #439b (en QA, sin mergear)
No hay solape de archivos: 2.2-A toca la estructura de sub-tabs de `/taller/perfil`; #439b toca `/taller` (dashboard), `/taller/formalizacion` y `/taller/perfil/completar`. **Un punto a coordinar tras mergear ambos:** el botón de salida del wizard `completar` (en develop "Ver mi perfil"; #439b lo relabela "Ver mi vidriera") navega a `/taller/perfil`, que con 2.2-A es **Datos básicos**, no la vidriera. Debería apuntar a `/taller/perfil/vidriera`. No se toca acá (es archivo de #439b). Ver comentario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)