### PR TITLE
fix: quitar "Formalización %" del user-sidebar (degamificación V4)

### DIFF
--- a/src/app/(taller)/layout.tsx
+++ b/src/app/(taller)/layout.tsx
@@ -3,7 +3,6 @@ import { Footer } from '@/compartido/componentes/layout/footer'
 import { requiereRol } from '@/compartido/lib/permisos'
 import { prisma } from '@/compartido/lib/prisma'
 import { construirEntidadesModo } from '@/compartido/lib/entidades-modo'
-import { porcentajeFormalizacion } from '@/compartido/lib/nivel'
 
 export default async function TallerLayout({ children }: { children: React.ReactNode }) {
   const session = await requiereRol(['TALLER'])
@@ -13,15 +12,13 @@ export default async function TallerLayout({ children }: { children: React.React
     select: {
       nombre: true,
       nivel: true,
-      puntaje: true,
     }
   })
 
   const userName = taller?.nombre || session.user.name || 'Mi Taller'
   const userLevel = taller?.nivel || 'BRONCE'
-  // F-01: el sidebar muestra esto como "Formalización X%" + barra de progreso, así
-  // que debe ser un porcentaje 0-100 (capado), no el score crudo `puntaje`.
-  const userProgress = await porcentajeFormalizacion(taller?.puntaje ?? 0)
+  // El "Formalización X%" + barra del sidebar se eliminaron (degamificación V4,
+  // #439b); ya no se computa el porcentaje acá.
 
   // U-04: datos para el toggle multi-rol (no-op si single-role).
   const entidades = await construirEntidadesModo(session.user.id, session.user.roles)
@@ -45,7 +42,6 @@ export default async function TallerLayout({ children }: { children: React.React
           <UserSidebar
             userRole="TALLER"
             userName={userName}
-            userProgress={userProgress}
             userLevel={userLevel}
           />
           <main className="flex-grow max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-6">

--- a/src/compartido/componentes/layout/user-sidebar.tsx
+++ b/src/compartido/componentes/layout/user-sidebar.tsx
@@ -24,7 +24,6 @@ interface MenuItem {
 interface UserSidebarProps {
   userRole?: 'TALLER' | 'MARCA' | 'ESTADO' | 'ADMIN'
   userName?: string
-  userProgress?: number
   userLevel?: string
   /**
    * U-09 (QA #398): en páginas DEL USUARIO (ej. /cuenta) el sidebar muestra la
@@ -62,7 +61,6 @@ const menuItemsByRole: Record<string, MenuItem[]> = {
 export function UserSidebar({
   userRole = 'TALLER',
   userName = 'Usuario',
-  userProgress = 0,
   userLevel = 'Bronce',
   mostrarFormalizacion = true
 }: UserSidebarProps) {
@@ -172,29 +170,16 @@ export function UserSidebar({
                 <h2 className="font-overpass font-bold text-lg lg:text-base truncate">{userName}</h2>
                 <p className="text-white/70 text-sm lg:text-xs">
                   {!mostrarFormalizacion && 'Mi cuenta'}
-                  {mostrarFormalizacion && userRole === 'TALLER' && `Formalización ${userProgress}%`}
+                  {mostrarFormalizacion && userRole === 'TALLER' && 'Taller'}
                   {mostrarFormalizacion && userRole === 'MARCA' && 'Marca'}
                   {mostrarFormalizacion && userRole === 'ESTADO' && 'Ente Estatal'}
                   {mostrarFormalizacion && userRole === 'ADMIN' && 'Administrador'}
                 </p>
               </div>
             </div>
-
-            {/* Progress bar (solo para talleres, y no en páginas del usuario) */}
-            {mostrarFormalizacion && userRole === 'TALLER' && (
-              <div className="space-y-1">
-                <div className="flex justify-between text-xs text-white/60">
-                  <span>Progreso de formalización</span>
-                  <span className="font-semibold">{userProgress}%</span>
-                </div>
-                <div className="w-full h-2 bg-white/20 rounded-full overflow-hidden">
-                  <div
-                    className="h-full bg-brand-red rounded-full transition-all duration-500"
-                    style={{ width: `${userProgress}%` }}
-                  />
-                </div>
-              </div>
-            )}
+            {/* "Formalización X%" + barra de progreso ELIMINADAS (degamificación V4,
+                coherente con la limpieza del dashboard #439b): el % de formalización
+                no se muestra como gráfico. El recorrido se comunica por etapa/badges. */}
           </div>
 
           {/* Navigation menu */}


### PR DESCRIPTION
## Quitar "Formalización %" del user-sidebar

PR chico aparte (pedido de Sergio en el QA del combinado #439b+#442). El sidebar izquierdo todavía mostraba **"Formalización X%"** (subtítulo bajo el nombre) + una **barra de progreso roja** — la misma gamificación por porcentaje que #439b sacó del dashboard. Faltaba el sidebar.

### Cambios
- **user-sidebar:** el subtítulo del rol TALLER pasa de `Formalización X%` → **`Taller`** (consistente con Marca / Ente Estatal / Administrador). Se elimina la barra de progreso. Se quita el prop `userProgress` (sin uso).
- **(taller)/layout:** se elimina el cómputo `porcentajeFormalizacion(puntaje)` + su import; `puntaje` sale del select.

### Scope
- No toca #442 (estructura 2.2-A) ni #439b (barrido rol Taller). **No bloquea** el merge de esos.
- Degamificación V4: el recorrido se comunica por etapa/badges, no con %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)