### PR TITLE
feat: 2.2-B vidriera en 3 dimensiones + render condicional (modeloB_revisado)

### DIFF
--- a/src/__tests__/visibilidad-vidriera.test.ts
+++ b/src/__tests__/visibilidad-vidriera.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   BLOQUES_VIDRIERA,
   bloqueVisible,
+  bloqueVisiblePublico,
   normalizarVisibilidad,
   samVisible,
   type BloqueVidriera,
@@ -98,6 +99,93 @@ describe('visibilidad-vidriera', () => {
       const taller = { visibilidadVidriera: { capacidad: true } }
       expect(bloqueVisible(taller, 'capacidad')).toBe(true)
       expect(samVisible('publico')).toBe(false)
+    })
+  })
+
+  describe('set del piloto (Etapa 2.2-B): 10 keys toggle-libre', () => {
+    it('incluye las nuevas keys ademas de las de #437', () => {
+      const esperadas = [
+        'formacion', 'equipo', 'espacio', 'capacidad', 'organizacion',
+        'maquinaria', 'procesos', 'prendas', 'anioFundacion', 'portfolio',
+      ]
+      expect([...BLOQUES_VIDRIERA].sort()).toEqual([...esperadas].sort())
+      expect(BLOQUES_VIDRIERA).toHaveLength(10)
+    })
+
+    it('NO incluye tiempos (= SAM) ni certificaciones externas (fuera del piloto)', () => {
+      expect((BLOQUES_VIDRIERA as readonly string[]).includes('tiempos')).toBe(false)
+      expect((BLOQUES_VIDRIERA as readonly string[]).includes('certificaciones')).toBe(false)
+    })
+  })
+
+  // Matriz flag × visibilidad — el corazon de 2.2-B (privacy-by-default).
+  describe('bloqueVisiblePublico: render condicional por modeloB_revisado', () => {
+    describe('modeloB_revisado=true (existentes) => BEHAVIOR-PRESERVING (#437)', () => {
+      it('flag=true + visibilidad=null => todo visible (existentes intactos)', () => {
+        const taller = { modeloB_revisado: true, visibilidadVidriera: null }
+        for (const b of BLOQUES_VIDRIERA) {
+          expect(bloqueVisiblePublico(taller, b)).toBe(true)
+        }
+      })
+
+      it('flag=true + campo ausente => todo visible', () => {
+        const taller = { modeloB_revisado: true }
+        for (const b of BLOQUES_VIDRIERA) {
+          expect(bloqueVisiblePublico(taller, b)).toBe(true)
+        }
+      })
+
+      it('flag=true + un bloque en false explicito => ese bloque oculto, resto visible', () => {
+        const taller = { modeloB_revisado: true, visibilidadVidriera: { maquinaria: false } }
+        expect(bloqueVisiblePublico(taller, 'maquinaria')).toBe(false)
+        expect(bloqueVisiblePublico(taller, 'procesos')).toBe(true)
+        expect(bloqueVisiblePublico(taller, 'portfolio')).toBe(true)
+      })
+    })
+
+    describe('modeloB_revisado=false (nuevos) => privacy-by-default', () => {
+      it('flag=false + visibilidad=null => bloques toggle-libre OCULTOS', () => {
+        const taller = { modeloB_revisado: false, visibilidadVidriera: null }
+        for (const b of BLOQUES_VIDRIERA) {
+          expect(bloqueVisiblePublico(taller, b)).toBe(false)
+        }
+      })
+
+      it('flag ausente (default Prisma) se comporta como false => oculto', () => {
+        const taller = { visibilidadVidriera: null }
+        for (const b of BLOQUES_VIDRIERA) {
+          expect(bloqueVisiblePublico(taller, b)).toBe(false)
+        }
+      })
+
+      it('flag=false + un bloque en true explicito => SOLO ese bloque visible', () => {
+        const taller = { modeloB_revisado: false, visibilidadVidriera: { procesos: true } }
+        expect(bloqueVisiblePublico(taller, 'procesos')).toBe(true)
+        expect(bloqueVisiblePublico(taller, 'prendas')).toBe(false)
+        expect(bloqueVisiblePublico(taller, 'maquinaria')).toBe(false)
+      })
+
+      it('flag=false + un bloque en false explicito => oculto (igual que el default)', () => {
+        const taller = { modeloB_revisado: false, visibilidadVidriera: { maquinaria: false } }
+        expect(bloqueVisiblePublico(taller, 'maquinaria')).toBe(false)
+      })
+
+      it('flag=false + valor no-booleano (string "true") => NO se muestra (defensivo)', () => {
+        const taller = { modeloB_revisado: false, visibilidadVidriera: { procesos: 'true' } }
+        expect(bloqueVisiblePublico(taller, 'procesos')).toBe(false)
+      })
+    })
+
+    describe('robustez de tipos crudos', () => {
+      it('visibilidadVidriera array u otros tipos => oculto si flag=false', () => {
+        expect(bloqueVisiblePublico({ modeloB_revisado: false, visibilidadVidriera: [] }, 'equipo')).toBe(false)
+        expect(bloqueVisiblePublico({ modeloB_revisado: false, visibilidadVidriera: 'x' }, 'equipo')).toBe(false)
+      })
+
+      it('visibilidadVidriera array u otros tipos => visible si flag=true', () => {
+        expect(bloqueVisiblePublico({ modeloB_revisado: true, visibilidadVidriera: [] }, 'equipo')).toBe(true)
+        expect(bloqueVisiblePublico({ modeloB_revisado: true, visibilidadVidriera: 42 }, 'equipo')).toBe(true)
+      })
     })
   })
 })

--- a/src/app/(taller)/taller/page.tsx
+++ b/src/app/(taller)/taller/page.tsx
@@ -10,6 +10,7 @@ import { BadgeArca } from '@/compartido/componentes/badge-arca'
 import { calcularPasosTaller } from '@/compartido/lib/onboarding'
 import { ChecklistOnboarding } from '@/compartido/componentes/ui/checklist-onboarding'
 import { nivelAEtapa } from '@/compartido/lib/formalizacion'
+import { BannerVidriera } from '@/taller/componentes/banner-vidriera'
 
 export default async function TallerDashboardPage() {
   const session = await auth()
@@ -209,6 +210,13 @@ export default async function TallerDashboardPage() {
             </div>
           </div>
         )
+      )}
+
+      {/* Banner de vidriera (2.2-B, §5.4): invita a revisar/mostrar la vidriera.
+          Solo para talleres verificados (los no verificados aún no aparecen en el
+          directorio: su banner de formalización ya cubre el foco). */}
+      {taller && taller.verificadoAfip && (
+        <BannerVidriera revisado={taller.modeloB_revisado} />
       )}
 
       {/* Tu recorrido de formalización (change 2, QA Sergio): estado de un vistazo —

--- a/src/app/(taller)/taller/perfil/vidriera/page.tsx
+++ b/src/app/(taller)/taller/perfil/vidriera/page.tsx
@@ -95,7 +95,7 @@ export default async function TallerVidrieraPage() {
 
       {/* DIMENSIÓN 1 — Credenciales (forzado-VISIBLE: siempre se muestra a la marca) */}
       <h2 className="font-overpass font-bold text-xs uppercase tracking-wide text-gray-400">Credenciales</h2>
-      <Card title="Credenciales">
+      <Card>
         <div className="flex flex-wrap items-center gap-2 mb-3">
           <Badge variant="default"><Milestone className="w-3 h-3 mr-1" />{nivelAEtapa(taller.nivel)}</Badge>
           <BadgeArca verificado={taller.verificadoAfip} />

--- a/src/app/(taller)/taller/perfil/vidriera/page.tsx
+++ b/src/app/(taller)/taller/perfil/vidriera/page.tsx
@@ -7,17 +7,44 @@ import Link from 'next/link'
 import { Badge } from '@/compartido/componentes/ui/badge'
 import { Card } from '@/compartido/componentes/ui/card'
 import { Button } from '@/compartido/componentes/ui/button'
-import { Award, Download } from 'lucide-react'
+import { Award, Download, MapPin, Milestone, ShieldCheck, EyeOff } from 'lucide-react'
 import { PortfolioManager } from '@/taller/componentes/portfolio-manager'
 import { VerVidrieraModal } from '@/taller/componentes/ver-vidriera-modal'
 import { VidrieraPublicaContenido } from '@/taller/componentes/vidriera-publica-contenido'
+import { BadgeArca } from '@/compartido/componentes/badge-arca'
+import { nivelAEtapa } from '@/compartido/lib/formalizacion'
+import { bloqueVisiblePublico, type BloqueVidriera } from '@/compartido/lib/visibilidad-vidriera'
 
-// Etapa 2.2-A — "Mi vidriera": lo que ven las marcas en el directorio.
+// Etapa 2.2-B — "Mi vidriera": lo que ven las marcas, reorganizado en las 3
+// DIMENSIONES de V4 2.2 (Credenciales / Formación / Descripción).
 // Tercer (último) sub-tab del orden secuencial Datos básicos → gestión → vidriera.
-// La cabecera común (nombre + etapa + ARCA) y las sub-tabs viven en el layout.
 // Los campos públicos (nombre, descripción, año, ubicación) se EDITAN en "Datos
-// básicos" y se LEEN acá: misma fila Taller, sin copia ni sync (spec §3). El
-// filtrado por visibilidad (toggles + privacy-by-default) es 2.2-B/C.
+// básicos" y se LEEN acá: misma fila Taller, sin copia ni sync (spec §3).
+//
+// Render FIEL a lo que ve la marca: cada bloque toggle-libre se evalúa con el mismo
+// `bloqueVisiblePublico` que la vidriera pública. Como es la vista del taller (no
+// se le ocultan sus propios datos), los bloques que la marca NO ve se marcan con
+// "No visible para las marcas" en vez de desaparecer. La UI de toggles y el aviso
+// al activar son 2.2-C. Para talleres existentes (modeloB_revisado=true) todo está
+// visible → no aparece ningún marcador: igual que hoy.
+function MarcadorOculto() {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">
+      <EyeOff className="w-3 h-3" /> No visible para las marcas
+    </span>
+  )
+}
+
+// Título de card con marcador opcional "No visible para las marcas" a la derecha.
+function TituloConMarcador({ texto, oculto }: { texto: string; oculto: boolean }) {
+  return (
+    <span className="flex flex-wrap items-center justify-between gap-2">
+      <span>{texto}</span>
+      {oculto && <MarcadorOculto />}
+    </span>
+  )
+}
+
 export default async function TallerVidrieraPage() {
   const session = await auth()
   if (!session?.user) redirect('/login')
@@ -52,30 +79,75 @@ export default async function TallerVidrieraPage() {
     )
   }
 
+  // Fiel a lo que ve la marca (mismo helper que la vidriera pública).
+  const visible = (b: BloqueVidriera) => bloqueVisiblePublico(taller, b)
+
   return (
     <div className="space-y-6">
       {/* "Ver cómo me ve el directorio": MODAL sobre Mi vidriera (no navega a la
-          página pública). El contenido es la vidriera pública filtrada por #437;
-          al cerrar, el taller queda en su contexto privado. */}
+          página pública). El contenido es la vidriera pública filtrada; al cerrar,
+          el taller queda en su contexto privado. */}
       <div className="flex justify-end">
         <VerVidrieraModal>
           <VidrieraPublicaContenido taller={taller} />
         </VerVidrieraModal>
       </div>
 
-      {/* NOTA (2.2): "Trabajadores" y "Cap. mensual" salieron del grid destacado de
-          marketplace (junto con Rating / On-time / barra de completitud, descartados del
-          modelo V4). Su ubicación final es el bloque "Mi capacidad de producción"
-          (toggleable) que arma la Etapa 2.2 — no se renderizan acá por ahora. */}
-
-      {taller.descripcion && (
-        <Card title="Descripción">
+      {/* DIMENSIÓN 1 — Credenciales (forzado-VISIBLE: siempre se muestra a la marca) */}
+      <h2 className="font-overpass font-bold text-xs uppercase tracking-wide text-gray-400">Credenciales</h2>
+      <Card title="Credenciales">
+        <div className="flex flex-wrap items-center gap-2 mb-3">
+          <Badge variant="default"><Milestone className="w-3 h-3 mr-1" />{nivelAEtapa(taller.nivel)}</Badge>
+          <BadgeArca verificado={taller.verificadoAfip} />
+          {taller.validaciones.map((v, i) => (
+            <Badge key={i} variant="success"><ShieldCheck className="w-3 h-3 mr-1" />{v.tipoDocumento.nombre}</Badge>
+          ))}
+        </div>
+        {(taller.provincia || taller.ubicacionDetalle) && (
+          <p className="flex items-center gap-1 text-sm text-gray-600 mb-2">
+            <MapPin className="w-4 h-4" /> {taller.provincia}{taller.partido ? `, ${taller.partido}` : ''}
+            {taller.ubicacionDetalle && <span className="text-gray-400"> · {taller.ubicacionDetalle}</span>}
+          </p>
+        )}
+        {taller.descripcion && (
           <p className="text-sm text-gray-700 whitespace-pre-wrap">{taller.descripcion}</p>
-        </Card>
+        )}
+      </Card>
+
+      {/* DIMENSIÓN 2 — Formación (Academia, toggle-libre master `formacion`) */}
+      {taller.certificados.length > 0 && (
+        <>
+          <h2 className="font-overpass font-bold text-xs uppercase tracking-wide text-gray-400">Formación</h2>
+          <Card title={<TituloConMarcador texto="Certificados de cursos" oculto={!visible('formacion')} />}>
+            <div className="space-y-2">
+              {taller.certificados.map((c) => (
+                <div key={c.id} className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0">
+                  <div className="flex items-center gap-2">
+                    <Award className="w-4 h-4 text-green-600" />
+                    <div>
+                      <p className="text-sm font-medium text-gray-800">{c.coleccion.titulo}</p>
+                      <p className="text-xs text-gray-500">Código: {c.codigo} · Calificación: {c.calificacion}%</p>
+                    </div>
+                  </div>
+                  <a
+                    href={`/api/certificados/${c.id}/pdf`}
+                    download
+                    className="inline-flex items-center gap-1 text-xs text-brand-blue hover:underline"
+                  >
+                    <Download className="w-3 h-3" /> PDF
+                  </a>
+                </div>
+              ))}
+            </div>
+          </Card>
+        </>
       )}
 
+      {/* DIMENSIÓN 3 — Descripción (perfil productivo, toggle-libre por bloque) */}
+      <h2 className="font-overpass font-bold text-xs uppercase tracking-wide text-gray-400">Descripción</h2>
+
       {taller.procesos.length > 0 && (
-        <Card title="Procesos Productivos">
+        <Card title={<TituloConMarcador texto="Procesos Productivos" oculto={!visible('procesos')} />}>
           <div className="flex flex-wrap gap-2">
             {taller.procesos.map((tp) => (
               <Badge key={tp.id} variant="outline">{tp.proceso.nombre}</Badge>
@@ -85,7 +157,7 @@ export default async function TallerVidrieraPage() {
       )}
 
       {taller.prendas.length > 0 && (
-        <Card title="Tipos de Prenda">
+        <Card title={<TituloConMarcador texto="Tipos de Prenda" oculto={!visible('prendas')} />}>
           <div className="flex flex-wrap gap-2">
             {taller.prendas.map((tp) => (
               <Badge key={tp.id} variant="default">{tp.prenda.nombre}</Badge>
@@ -94,12 +166,12 @@ export default async function TallerVidrieraPage() {
         </Card>
       )}
 
-      <Card title="Mi portfolio">
+      <Card title={<TituloConMarcador texto="Mi portfolio" oculto={taller.portfolioFotos.length > 0 && !visible('portfolio')} />}>
         <PortfolioManager tallerId={taller.id} fotosActuales={taller.portfolioFotos} />
       </Card>
 
       {taller.maquinaria.length > 0 && (
-        <Card title="Maquinaria">
+        <Card title={<TituloConMarcador texto="Maquinaria" oculto={!visible('maquinaria')} />}>
           <ul className="space-y-1 text-sm">
             {taller.maquinaria.map((m) => (
               <li key={m.id} className="flex justify-between">
@@ -111,6 +183,8 @@ export default async function TallerVidrieraPage() {
         </Card>
       )}
 
+      {/* Certificaciones de calidad (externas): fuera del piloto de toggles (D4),
+          sin gate, como hasta hoy. */}
       {taller.certificaciones.length > 0 && (
         <Card title="Certificaciones">
           <div className="flex flex-wrap gap-2">
@@ -118,31 +192,6 @@ export default async function TallerVidrieraPage() {
               <Badge key={c.id} variant="success">
                 <Award className="w-3 h-3 mr-1" />{c.nombre}
               </Badge>
-            ))}
-          </div>
-        </Card>
-      )}
-
-      {taller.certificados.length > 0 && (
-        <Card title="Certificados de cursos">
-          <div className="space-y-2">
-            {taller.certificados.map((c) => (
-              <div key={c.id} className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0">
-                <div className="flex items-center gap-2">
-                  <Award className="w-4 h-4 text-green-600" />
-                  <div>
-                    <p className="text-sm font-medium text-gray-800">{c.coleccion.titulo}</p>
-                    <p className="text-xs text-gray-500">Código: {c.codigo} · Calificación: {c.calificacion}%</p>
-                  </div>
-                </div>
-                <a
-                  href={`/api/certificados/${c.id}/pdf`}
-                  download
-                  className="inline-flex items-center gap-1 text-xs text-brand-blue hover:underline"
-                >
-                  <Download className="w-3 h-3" /> PDF
-                </a>
-              </div>
             ))}
           </div>
         </Card>

--- a/src/compartido/lib/visibilidad-vidriera.ts
+++ b/src/compartido/lib/visibilidad-vidriera.ts
@@ -11,7 +11,15 @@
 // - Credenciales (etapa + ARCA) NUNCA se oculta: no es un bloque toggleable.
 // - SAM NUNCA se expone en la vidriera publica, sin importar el toggle de `capacidad`.
 
-/** Bloques de la vidriera que el taller puede mostrar/ocultar a las marcas. */
+/**
+ * Bloques TOGGLE-LIBRE de la vidriera que el taller puede mostrar/ocultar a las
+ * marcas. Set del PILOTO (Etapa 2.2-B, §6.1): 10 keys. La expansion respecto de
+ * #437 (formacion/equipo/espacio/capacidad/organizacion/maquinaria) es aditiva:
+ * solo TS + array; el JSONB ya soporta las nuevas keys, sin migracion.
+ *
+ * Fuera del set (a proposito): 'tiempos' (= SAM, forzado-privado, D3) y las
+ * certificaciones externas (`TallerCertificacion`, fuera del piloto, D4).
+ */
 export type BloqueVidriera =
   | 'formacion'
   | 'equipo'
@@ -19,6 +27,10 @@ export type BloqueVidriera =
   | 'capacidad'
   | 'organizacion'
   | 'maquinaria'
+  | 'procesos'
+  | 'prendas'
+  | 'anioFundacion'
+  | 'portfolio'
 
 /** Lista canonica de bloques toggleables (Credenciales no esta: es fijo). */
 export const BLOQUES_VIDRIERA: readonly BloqueVidriera[] = [
@@ -28,6 +40,10 @@ export const BLOQUES_VIDRIERA: readonly BloqueVidriera[] = [
   'capacidad',
   'organizacion',
   'maquinaria',
+  'procesos',
+  'prendas',
+  'anioFundacion',
+  'portfolio',
 ] as const
 
 /** Forma persistida en `Taller.visibilidadVidriera` (todas las keys opcionales). */
@@ -63,6 +79,39 @@ export function bloqueVisible(
   bloque: BloqueVidriera,
 ): boolean {
   return normalizarVisibilidad(taller?.visibilidadVidriera)[bloque]
+}
+
+/**
+ * ¿Se muestra este bloque TOGGLE-LIBRE en la vidriera publica, aplicando
+ * privacy-by-default segun `modeloB_revisado` (Etapa 2.2-B, §5.2)?
+ *
+ * - `modeloB_revisado === true` (talleres EXISTENTES via backfill, o tras revisar
+ *   la config): respeta el null=visible de #437 → mismo comportamiento que hoy.
+ *   Es la garantia BEHAVIOR-PRESERVING: para los existentes nada cambia.
+ * - `modeloB_revisado === false` (talleres NUEVOS): privacy-by-default → un bloque
+ *   en null/ausente se trata como OCULTO; solo se muestra lo activado explicito.
+ *
+ * Forzado-VISIBLE (Credenciales: etapa + ARCA + ubicacion) no se consulta aca:
+ * se renderiza siempre. Forzado-PRIVADO (CUIT, responsable, SAM, los 7) nunca se
+ * expone, sin importar el flag (no son bloques de este set).
+ */
+export function bloqueVisiblePublico(
+  taller: { visibilidadVidriera?: unknown; modeloB_revisado?: boolean },
+  bloque: BloqueVidriera,
+): boolean {
+  const obj =
+    taller?.visibilidadVidriera &&
+    typeof taller.visibilidadVidriera === 'object' &&
+    !Array.isArray(taller.visibilidadVidriera)
+      ? (taller.visibilidadVidriera as Record<string, unknown>)
+      : {}
+  const raw = obj[bloque]
+  if (taller?.modeloB_revisado) {
+    // #437: null/true/ausente → visible; solo `false` explicito oculta.
+    return raw !== false
+  }
+  // Privacy-by-default: SOLO el `true` explicito se muestra.
+  return raw === true
 }
 
 /**

--- a/src/taller/componentes/banner-vidriera.tsx
+++ b/src/taller/componentes/banner-vidriera.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Eye, X } from 'lucide-react'
+
+// Banner del dashboard del taller que invita a revisar/mostrar la vidriera
+// (Etapa 2.2-B, §5.4). Dos audiencias según `modeloB_revisado`:
+//   - revisado=false (taller NUEVO): "Tenés datos que podés mostrar a las marcas".
+//     Persiste mientras el flag siga en false (es privacy-by-default; aún no mostró nada).
+//   - revisado=true (taller EXISTENTE): nudge "Revisá qué muestra tu vidriera",
+//     descartable con un dismiss liviano en localStorage (D6).
+//
+// CTA: por ahora apunta a "Mi vidriera" (vista read-only de lo que ve la marca).
+// El panel de "Configuración de visibilidad" para activar/ocultar bloques llega
+// en 2.2-C; este banner queda funcional (link a una ruta existente, no roto).
+
+const DISMISS_KEY = 'pdt:banner-vidriera-revisar-dismissed'
+
+export function BannerVidriera({ revisado }: { revisado: boolean }) {
+  const [mostrar, setMostrar] = useState(false)
+
+  useEffect(() => {
+    // El banner de "nuevos" se muestra siempre; el de "existentes" respeta el dismiss.
+    if (!revisado) {
+      setMostrar(true)
+      return
+    }
+    try {
+      setMostrar(localStorage.getItem(DISMISS_KEY) !== '1')
+    } catch {
+      setMostrar(true)
+    }
+  }, [revisado])
+
+  if (!mostrar) return null
+
+  const descartar = () => {
+    try {
+      localStorage.setItem(DISMISS_KEY, '1')
+    } catch {
+      /* sin localStorage: el banner reaparece, no es crítico */
+    }
+    setMostrar(false)
+  }
+
+  return (
+    <div className="border-l-4 border-l-brand-blue bg-brand-blue/5 rounded-card p-4 flex items-start gap-3">
+      <Eye className="w-5 h-5 text-brand-blue shrink-0 mt-0.5" />
+      <div className="min-w-0 flex-1">
+        <p className="font-overpass font-bold text-brand-blue mb-1">
+          {revisado ? 'Revisá qué muestra tu vidriera' : 'Tenés datos que podés mostrar a las marcas'}
+        </p>
+        <p className="text-sm text-gray-600">
+          {revisado
+            ? 'Controlá qué información ven las marcas que visitan tu perfil en el directorio.'
+            : 'Tu vidriera arranca privada. Revisá tu información cargada y preparate para elegir qué mostrar.'}
+        </p>
+        <Link
+          href="/taller/perfil/vidriera"
+          className="inline-flex items-center gap-1 mt-2 text-sm font-semibold text-brand-blue hover:underline"
+        >
+          Ver mi vidriera →
+        </Link>
+      </div>
+      {revisado && (
+        <button
+          type="button"
+          onClick={descartar}
+          aria-label="Descartar aviso"
+          className="text-gray-400 hover:text-gray-600 shrink-0"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/taller/componentes/vidriera-publica-contenido.tsx
+++ b/src/taller/componentes/vidriera-publica-contenido.tsx
@@ -1,18 +1,33 @@
 import { Badge } from '@/compartido/componentes/ui/badge'
 import { Card } from '@/compartido/componentes/ui/card'
-import { MapPin, Award, ShieldCheck } from 'lucide-react'
+import { MapPin, Award, ShieldCheck, Milestone } from 'lucide-react'
 import { GaleriaFotos } from '@/taller/componentes/galeria-fotos'
 import { BadgeArca } from '@/compartido/componentes/badge-arca'
-import { bloqueVisible } from '@/compartido/lib/visibilidad-vidriera'
+import { bloqueVisiblePublico } from '@/compartido/lib/visibilidad-vidriera'
+import { nivelAEtapa } from '@/compartido/lib/formalizacion'
 
-// Contenido de la vidriera PÚBLICA (lo que ve la marca), filtrado por visibilidad
-// (#437). Server component compartido por dos superficies:
+// Contenido de la vidriera PÚBLICA (lo que ve la marca), reorganizado en las 3
+// DIMENSIONES de V4 2.2 (Etapa 2.2-B):
+//   - Credenciales  → forzado-VISIBLE: etapa + ARCA + validaciones + ubicación + descripción.
+//   - Formación     → toggle-libre (master `formacion`): badges de Academia (cursos PDT).
+//   - Descripción   → bloques del perfil productivo (toggle-libre): procesos, prendas,
+//                      maquinaria, portfolio. Cada uno gateado por `bloqueVisiblePublico`.
+//
+// Render condicional (§5.2): `bloqueVisiblePublico` aplica privacy-by-default según
+// `modeloB_revisado`. Existentes (flag=true) ven lo mismo que hoy (#437 null=visible);
+// nuevos (flag=false) solo ven Credenciales + lo activado explícito.
+//
+// Server component compartido por dos superficies:
 //   - /perfil/[id] (la página pública real)
 //   - el modal "Ver cómo me ve el directorio" en "Mi vidriera" (preview sin navegar)
 // No incluye el link "Volver al directorio" (es específico de la página pública).
+//
+// Invariantes: SAM nunca se expone acá (no es un bloque). CUIT / responsable /
+// los 7 del recorrido son forzado-privados: nunca entran a esta consulta.
 
 export interface VidrieraPublicaTaller {
   nombre: string
+  nivel: string
   verificadoAfip: boolean
   provincia: string | null
   partido: string | null
@@ -20,6 +35,7 @@ export interface VidrieraPublicaTaller {
   descripcion: string | null
   portfolioFotos: string[]
   visibilidadVidriera: unknown
+  modeloB_revisado: boolean
   validaciones: { tipoDocumento: { nombre: string } }[]
   procesos: { id: string; proceso: { nombre: string } }[]
   prendas: { id: string; prenda: { nombre: string } }[]
@@ -28,19 +44,34 @@ export interface VidrieraPublicaTaller {
   certificados: { id: string; codigo: string; coleccion: { titulo: string; institucion: string | null } }[]
 }
 
+function DimensionTitulo({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="font-overpass font-bold text-xs uppercase tracking-wide text-gray-400 mt-6 mb-2">
+      {children}
+    </h2>
+  )
+}
+
 export function VidrieraPublicaContenido({ taller }: { taller: VidrieraPublicaTaller }) {
+  const verProcesos = taller.procesos.length > 0 && bloqueVisiblePublico(taller, 'procesos')
+  const verPrendas = taller.prendas.length > 0 && bloqueVisiblePublico(taller, 'prendas')
+  const verMaquinaria = taller.maquinaria.length > 0 && bloqueVisiblePublico(taller, 'maquinaria')
+  const verPortfolio = taller.portfolioFotos.length > 0 && bloqueVisiblePublico(taller, 'portfolio')
+  const verFormacion = taller.certificados.length > 0 && bloqueVisiblePublico(taller, 'formacion')
+  const hayDescripcion = verProcesos || verPrendas || verMaquinaria || verPortfolio || taller.certificaciones.length > 0
+
   return (
     <div>
-      <div className="mb-6">
+      {/* DIMENSIÓN 1 — Credenciales (forzado-VISIBLE, nunca se oculta) */}
+      <div className="mb-2">
         <h1 className="font-overpass font-bold text-3xl text-brand-blue mb-2">{taller.nombre}</h1>
-        {(taller.verificadoAfip || taller.validaciones.length > 0) && (
-          <div className="flex flex-wrap items-center gap-2 mb-2">
-            {taller.verificadoAfip && <BadgeArca verificado={true} />}
-            {taller.validaciones.map((v, i) => (
-              <Badge key={i} variant="success"><ShieldCheck className="w-3 h-3 mr-1" />{v.tipoDocumento.nombre}</Badge>
-            ))}
-          </div>
-        )}
+        <div className="flex flex-wrap items-center gap-2 mb-2">
+          <Badge variant="default"><Milestone className="w-3 h-3 mr-1" />{nivelAEtapa(taller.nivel)}</Badge>
+          {taller.verificadoAfip && <BadgeArca verificado={true} />}
+          {taller.validaciones.map((v, i) => (
+            <Badge key={i} variant="success"><ShieldCheck className="w-3 h-3 mr-1" />{v.tipoDocumento.nombre}</Badge>
+          ))}
+        </div>
         {taller.provincia && (
           <p className="flex items-center gap-1 text-gray-600">
             <MapPin className="w-4 h-4" /> {taller.provincia}{taller.partido ? `, ${taller.partido}` : ''}
@@ -52,7 +83,35 @@ export function VidrieraPublicaContenido({ taller }: { taller: VidrieraPublicaTa
         )}
       </div>
 
-      {taller.procesos.length > 0 && (
+      {/* DIMENSIÓN 2 — Formación (toggle-libre: master `formacion`) */}
+      {verFormacion && (
+        <>
+          <DimensionTitulo>Formación</DimensionTitulo>
+          <Card title="Capacitaciones certificadas" className="mb-4">
+            <div className="space-y-2">
+              {taller.certificados.map((cert) => (
+                <div key={cert.id} className="flex items-center justify-between text-sm">
+                  <div>
+                    <span className="font-medium">{cert.coleccion.titulo}</span>
+                    {cert.coleccion.institucion && (
+                      <span className="text-gray-500 ml-2">· {cert.coleccion.institucion}</span>
+                    )}
+                  </div>
+                  <a href={`/verificar?code=${cert.codigo}`}
+                    className="text-brand-blue underline text-xs">
+                    Verificar
+                  </a>
+                </div>
+              ))}
+            </div>
+          </Card>
+        </>
+      )}
+
+      {/* DIMENSIÓN 3 — Descripción (perfil productivo, toggle-libre por bloque) */}
+      {hayDescripcion && <DimensionTitulo>Descripción</DimensionTitulo>}
+
+      {verProcesos && (
         <Card title="Procesos" className="mb-4">
           <div className="flex flex-wrap gap-2">
             {taller.procesos.map((tp) => (
@@ -62,7 +121,7 @@ export function VidrieraPublicaContenido({ taller }: { taller: VidrieraPublicaTa
         </Card>
       )}
 
-      {taller.prendas.length > 0 && (
+      {verPrendas && (
         <Card title="Tipos de prenda" className="mb-4">
           <div className="flex flex-wrap gap-2">
             {taller.prendas.map((tp) => (
@@ -72,13 +131,13 @@ export function VidrieraPublicaContenido({ taller }: { taller: VidrieraPublicaTa
         </Card>
       )}
 
-      {taller.portfolioFotos.length > 0 && (
+      {verPortfolio && (
         <Card title="Trabajos realizados" className="mb-4">
           <GaleriaFotos fotos={taller.portfolioFotos} />
         </Card>
       )}
 
-      {taller.maquinaria.length > 0 && bloqueVisible(taller, 'maquinaria') && (
+      {verMaquinaria && (
         <Card title="Maquinaria" className="mb-4">
           <ul className="space-y-1 text-sm">
             {taller.maquinaria.map((m) => (
@@ -91,6 +150,8 @@ export function VidrieraPublicaContenido({ taller }: { taller: VidrieraPublicaTa
         </Card>
       )}
 
+      {/* Certificaciones de calidad (externas): fuera del piloto de toggles (D4),
+          se mantienen sin gate como hasta hoy. */}
       {taller.certificaciones.length > 0 && (
         <Card title="Certificaciones" className="mb-4">
           <div className="flex flex-wrap gap-2">
@@ -98,27 +159,6 @@ export function VidrieraPublicaContenido({ taller }: { taller: VidrieraPublicaTa
               <Badge key={c.id} variant="success">
                 <Award className="w-3 h-3 mr-1" />{c.nombre}
               </Badge>
-            ))}
-          </div>
-        </Card>
-      )}
-
-      {taller.certificados.length > 0 && bloqueVisible(taller, 'formacion') && (
-        <Card title="Capacitaciones certificadas">
-          <div className="space-y-2">
-            {taller.certificados.map((cert) => (
-              <div key={cert.id} className="flex items-center justify-between text-sm">
-                <div>
-                  <span className="font-medium">{cert.coleccion.titulo}</span>
-                  {cert.coleccion.institucion && (
-                    <span className="text-gray-500 ml-2">· {cert.coleccion.institucion}</span>
-                  )}
-                </div>
-                <a href={`/verificar?code=${cert.codigo}`}
-                  className="text-brand-blue underline text-xs">
-                  Verificar
-                </a>
-              </div>
             ))}
           </div>
         </Card>


### PR DESCRIPTION
## Etapa 2.2-B — Taxonomía + render condicional (render-only, behavior-preserving)

Reorganiza la vidriera en las **3 dimensiones** de V4 2.2 y agrega **render condicional** con privacy-by-default según el flag `modeloB_revisado` (ya en develop, #441). **Sin UI de toggles ni escritura** — eso es 2.2-C.

### Qué cambia
- **`visibilidad-vidriera.ts`**: `BloqueVidriera` al set del piloto (**10 keys**, aditivo: solo TS, el JSONB ya lo soporta) + nuevo helper **`bloqueVisiblePublico`** (flag-aware):
  - `modeloB_revisado=true` (existentes) → respeta `null=visible` (#437) → **behavior-preserving**.
  - `modeloB_revisado=false` (nuevos) → `null` se trata como **oculto**; solo el `true` explícito se muestra (privacy-by-default).
- **`vidriera-publica-contenido.tsx`** (pública `/perfil/[id]` + modal "Ver cómo me ve el directorio"): 3 dimensiones (Credenciales / Formación / Descripción), gates con `bloqueVisiblePublico` en procesos, prendas, portfolio, maquinaria, formación. Etapa (`nivelAEtapa`) en Credenciales.
- **`/taller/perfil/vidriera`** (Mi vidriera): mismas 3 dimensiones, **fiel a lo que ve la marca** (mismo helper). Los bloques que la marca no ve se marcan **"No visible para las marcas"** (no se ocultan al dueño). Para existentes no aparece ningún marcador → igual que hoy.
- **Banner de vidriera** en el dashboard (§5.4): texto distinto para nuevos vs existentes, CTA a Mi vidriera, dismiss liviano (localStorage) para el nudge de existentes.
- **Tests**: matriz flag × visibilidad de `bloqueVisiblePublico` + verificación del set de 10 keys.

### Behavior-preserving (testeable)
Talleres existentes están en `modeloB_revisado=true` → `bloqueVisiblePublico` respeta `null=visible`: **mismos bloques visibles que hoy** (cubierto por tests). Cambios visuales intencionales de la V4: el badge de **Etapa** en Credenciales y los encabezados de dimensión. Ningún bloque toggle-libre cambia su visibilidad para los existentes.

### Decisiones (a revisar en QA)
1. **Bloques net-new (`equipo`/`espacio`/`capacidad`/`organización`) NO se cablearon al render público**: exponerlos haría aparecer datos productivos nuevos en el perfil de los talleres existentes (rompe "cero cambio percibido" + exposición sin opt-in). Se difieren a **2.2-C**, donde llegan junto con sus toggles (opt-in explícito). El tipo/array ya los contempla.
2. **Elegibilidad del directorio (R-DIR, §4.4)** — NO incluida acá: cambia el query del listado público (otra superficie/blast-radius). Recomiendo cortarla aparte. (No estaba en el alcance puntual de este PR.)
3. **Banner**: incluido ahora con CTA a "Mi vidriera" (ruta existente, no roto). El CTA al panel de "Configuración de visibilidad" llega en 2.2-C.

### Fuera de alcance (2.2-C)
UI del panel de toggles, endpoint/escritura, Formación granular interactiva, aviso al activar, indicadores "Editado en X →".

🤖 Generated with [Claude Code](https://claude.com/claude-code)