### PR TITLE
feat: 2.2-C2 indicador "Editado en [X]" por card de Mi vidriera

### DIFF
--- a/src/app/(taller)/taller/perfil/vidriera/page.tsx
+++ b/src/app/(taller)/taller/perfil/vidriera/page.tsx
@@ -11,7 +11,7 @@ import { Award, Download, MapPin, Milestone, ShieldCheck, Lock, Users, Ruler, Ga
 import { PortfolioManager } from '@/taller/componentes/portfolio-manager'
 import { VerVidrieraModal } from '@/taller/componentes/ver-vidriera-modal'
 import { VidrieraPublicaContenido } from '@/taller/componentes/vidriera-publica-contenido'
-import { TarjetaBloqueVidriera } from '@/taller/componentes/tarjeta-bloque-vidriera'
+import { TarjetaBloqueVidriera, IndicadorEdicion } from '@/taller/componentes/tarjeta-bloque-vidriera'
 import { BadgeArca } from '@/compartido/componentes/badge-arca'
 import { nivelAEtapa } from '@/compartido/lib/formalizacion'
 import { labelOrganizacion, labelRegistro, labelEscalabilidad, rangoCapacidad, labelTipoInscripcion } from '@/compartido/lib/taller-formulario'
@@ -45,6 +45,15 @@ function SeccionTitulo({ children }: { children: React.ReactNode }) {
 const WIZARD = '/taller/perfil/completar'
 const DATOS_BASICOS = '/taller/perfil'
 const EDITAR = '/taller/perfil/editar'
+
+// Etapa 2.2-C2 — destinos de edición para el indicador "Editado en [X] →".
+// Cada bloque apunta al tab/wizard donde el taller carga ese dato (la vidriera cura,
+// la edición vive en otro lado). Todas las rutas existen (verificado). Formación
+// apunta a Academia: la card "Mis cursos" (PR B) todavía no existe → sin link roto.
+const ED_DATOS_BASICOS = { href: EDITAR, label: 'Datos básicos' }
+const ED_INSCRIPCION = { href: DATOS_BASICOS, label: 'Datos básicos' }
+const ED_PERFIL_PRODUCTIVO = { href: WIZARD, label: 'Perfil productivo' }
+const ED_ACADEMIA = { href: '/taller/aprender', label: 'Academia' }
 
 export default async function TallerVidrieraPage() {
   const session = await auth()
@@ -126,6 +135,7 @@ export default async function TallerVidrieraPage() {
         <p className="flex items-center gap-1.5 text-sm text-gray-700 mt-2">
           <MapPin className="w-4 h-4 text-gray-400" /> {ubicacion || <span className="text-gray-400 italic">Sin completar</span>}
         </p>
+        <IndicadorEdicion {...ED_DATOS_BASICOS} />
       </Card>
 
       {/* Tipo de inscripción: toggle (solo el tipo, nunca la categoría) */}
@@ -137,6 +147,7 @@ export default async function TallerVidrieraPage() {
         sinDatosTexto="Verificá tu CUIT en ARCA para mostrar tu tipo de inscripción."
         wizardHref={DATOS_BASICOS}
         wizardCta="Ir a Datos básicos"
+        editadoEn={ED_INSCRIPCION}
       >
         <p className="flex items-center gap-1.5 text-sm text-gray-700">
           <FileText className="w-4 h-4 text-gray-400" /> {tipoInscripcion}
@@ -152,6 +163,7 @@ export default async function TallerVidrieraPage() {
         sinDatosTexto="Sumá el año en que empezó tu taller."
         wizardHref={EDITAR}
         wizardCta="Agregar año de fundación"
+        editadoEn={ED_DATOS_BASICOS}
       >
         <p className="flex items-center gap-1.5 text-sm text-gray-700">
           <Calendar className="w-4 h-4 text-gray-400" /> Fundado en {taller.fundado}
@@ -168,7 +180,10 @@ export default async function TallerVidrieraPage() {
           <span className="text-xs text-gray-400">Siempre visible</span>
         </div>
         {taller.descripcion ? (
-          <p className="text-sm text-gray-700 whitespace-pre-wrap mt-2">{taller.descripcion}</p>
+          <>
+            <p className="text-sm text-gray-700 whitespace-pre-wrap mt-2">{taller.descripcion}</p>
+            <IndicadorEdicion {...ED_DATOS_BASICOS} />
+          </>
         ) : (
           <div className="mt-2">
             <p className="text-sm text-gray-400">Contá a qué se dedica tu taller.</p>
@@ -200,6 +215,7 @@ export default async function TallerVidrieraPage() {
         sinDatosTexto="Declará los procesos que hacés (corte, confección, etc.)."
         wizardHref={WIZARD}
         wizardCta="Cargar procesos"
+        editadoEn={ED_PERFIL_PRODUCTIVO}
       >
         <div className="flex flex-wrap gap-2">
           {taller.procesos.map((tp) => (
@@ -217,6 +233,7 @@ export default async function TallerVidrieraPage() {
         sinDatosTexto="Sumá los rubros/prendas que producís."
         wizardHref={WIZARD}
         wizardCta="Cargar prendas"
+        editadoEn={ED_PERFIL_PRODUCTIVO}
       >
         <div className="flex flex-wrap gap-2">
           {taller.prendas.map((tp) => (
@@ -234,6 +251,7 @@ export default async function TallerVidrieraPage() {
         sinDatosTexto="Indicá tu capacidad mensual para mostrar un rango a las marcas."
         wizardHref={WIZARD}
         wizardCta="Cargar capacidad"
+        editadoEn={ED_PERFIL_PRODUCTIVO}
       >
         <p className="flex items-center gap-1.5 text-sm text-gray-700">
           <Gauge className="w-4 h-4 text-gray-400" /> {rango}
@@ -252,6 +270,7 @@ export default async function TallerVidrieraPage() {
         sinDatosTexto="Mostrá la composición de tu equipo."
         wizardHref={WIZARD}
         wizardCta="Cargar equipo"
+        editadoEn={ED_PERFIL_PRODUCTIVO}
       >
         <ul className="space-y-1 text-sm">
           {equipoConDatos.map((p) => (
@@ -272,6 +291,7 @@ export default async function TallerVidrieraPage() {
         sinDatosTexto="Sumá los metros cuadrados de tu taller."
         wizardHref={WIZARD}
         wizardCta="Cargar espacio"
+        editadoEn={ED_PERFIL_PRODUCTIVO}
       >
         <p className="flex items-center gap-1.5 text-sm text-gray-700">
           <Ruler className="w-4 h-4 text-gray-400" /> {taller.metrosCuadrados} m²
@@ -287,6 +307,7 @@ export default async function TallerVidrieraPage() {
         sinDatosTexto="Cargá tu maquinaria para mostrarla a las marcas."
         wizardHref={WIZARD}
         wizardCta="Cargar maquinaria"
+        editadoEn={ED_PERFIL_PRODUCTIVO}
       >
         <ul className="space-y-1 text-sm">
           {taller.maquinaria.map((m) => (
@@ -307,6 +328,7 @@ export default async function TallerVidrieraPage() {
         sinDatosTexto="Contá cómo organizás la producción."
         wizardHref={WIZARD}
         wizardCta="Cargar organización"
+        editadoEn={ED_PERFIL_PRODUCTIVO}
       >
         <p className="flex items-center gap-1.5 text-sm text-gray-700">
           <Workflow className="w-4 h-4 text-gray-400" /> {labelOrganizacion(taller.organizacion)}
@@ -332,6 +354,7 @@ export default async function TallerVidrieraPage() {
           sinDatosTexto=""
           wizardHref="/taller/aprender"
           wizardCta=""
+          editadoEn={ED_ACADEMIA}
         >
           <div className="space-y-2">
             {taller.certificados.map((c) => (

--- a/src/app/(taller)/taller/perfil/vidriera/page.tsx
+++ b/src/app/(taller)/taller/perfil/vidriera/page.tsx
@@ -50,9 +50,13 @@ const EDITAR = '/taller/perfil/editar'
 // Cada bloque apunta al tab/wizard donde el taller carga ese dato (la vidriera cura,
 // la edición vive en otro lado). Todas las rutas existen (verificado). Formación
 // apunta a Academia: la card "Mis cursos" (PR B) todavía no existe → sin link roto.
+const GESTION = '/taller/perfil/gestion'
 const ED_DATOS_BASICOS = { href: EDITAR, label: 'Datos básicos' }
 const ED_INSCRIPCION = { href: DATOS_BASICOS, label: 'Datos básicos' }
-const ED_PERFIL_PRODUCTIVO = { href: WIZARD, label: 'Perfil productivo' }
+// Perfil productivo → tab "Mi gestión productiva" (no el wizard /completar): el taller
+// llega a sus datos cargados + botón "Actualizar perfil productivo" (que abre el wizard
+// solo si decide), en vez de arrancar el wizard de cero (QA Sergio 2.2-C2).
+const ED_PERFIL_PRODUCTIVO = { href: GESTION, label: 'Perfil productivo' }
 const ED_ACADEMIA = { href: '/taller/aprender', label: 'Academia' }
 
 export default async function TallerVidrieraPage() {

--- a/src/taller/componentes/tarjeta-bloque-vidriera.tsx
+++ b/src/taller/componentes/tarjeta-bloque-vidriera.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from 'react'
 import Link from 'next/link'
-import { Eye, EyeOff, Check, Plus } from 'lucide-react'
+import { Eye, EyeOff, Check, Plus, Pencil, ArrowRight } from 'lucide-react'
 import { Card } from '@/compartido/componentes/ui/card'
 import { Modal } from '@/compartido/componentes/ui/modal'
 import { Button } from '@/compartido/componentes/ui/button'
@@ -40,7 +40,30 @@ interface Props {
   wizardCta: string
   /** Portfolio: render del contenido siempre, con banner de estado. */
   contenidoSiempre?: boolean
+  /**
+   * Etapa 2.2-C2 — indicador "Editado en [destino] →": dónde edita el taller este
+   * contenido (la vidriera cura; la edición vive en otro tab/wizard). Solo se
+   * muestra en estados con datos (ON/OFF); el estado sin-datos ya tiene su propio
+   * CTA "Cargar X". Si se omite (ej. Portfolio, editable inline acá), no se renderiza.
+   */
+  editadoEn?: { href: string; label: string }
   children?: React.ReactNode
+}
+
+// Indicador "Editado en [destino] →" (Etapa 2.2-C2). Reutilizable: lo usan tanto las
+// cards toggleables como las forzado-visibles (Ubicación, Descripción) de Mi vidriera.
+// SOLO vive en Mi vidriera (vista del taller): la vidriera pública no lo renderiza.
+export function IndicadorEdicion({ href, label }: { href: string; label: string }) {
+  return (
+    <Link
+      href={href}
+      className="mt-3 inline-flex items-center gap-1 text-xs text-gray-400 hover:text-brand-blue hover:underline w-fit"
+    >
+      <Pencil className="w-3 h-3 shrink-0" />
+      <span>Editado en {label}</span>
+      <ArrowRight className="w-3 h-3 shrink-0" />
+    </Link>
+  )
 }
 
 function Switch({
@@ -85,6 +108,7 @@ export function TarjetaBloqueVidriera({
   wizardHref,
   wizardCta,
   contenidoSiempre = false,
+  editadoEn,
   children,
 }: Props) {
   const { toast } = useToast()
@@ -167,6 +191,7 @@ export function TarjetaBloqueVidriera({
           </p>
         )}
         {children}
+        {editadoEn && <div><IndicadorEdicion href={editadoEn.href} label={editadoEn.label} /></div>}
         {ConfirmModal}
       </Card>
     )
@@ -183,6 +208,7 @@ export function TarjetaBloqueVidriera({
         <p className="flex items-center gap-1.5 text-sm text-gray-400 mt-2">
           <EyeOff className="w-4 h-4" /> Oculto a las marcas
         </p>
+        {editadoEn && <div><IndicadorEdicion href={editadoEn.href} label={editadoEn.label} /></div>}
         {ConfirmModal}
       </Card>
     )
@@ -196,6 +222,7 @@ export function TarjetaBloqueVidriera({
         {Toggle}
       </div>
       {children}
+      {editadoEn && <div><IndicadorEdicion href={editadoEn.href} label={editadoEn.label} /></div>}
       {ConfirmModal}
     </Card>
   )


### PR DESCRIPTION
## Etapa 2.2-C2 — descubribilidad fina (indicadores de edición)

Cierra la vidriera del Modelo B: la capa visual que faltaba sobre 2.2-C1. Cada card de **Mi vidriera** muestra un link chico **"Editado en [destino] →"** que lleva al tab/wizard donde el taller edita ese dato. Refuerza el modelo conceptual *vidriera = curaduría; la edición vive en otro lado* y resuelve que hoy el taller no sabe dónde ir a editar sin probar tab por tab.

### Qué incluye
- **`IndicadorEdicion`** (componente reutilizable) en `tarjeta-bloque-vidriera.tsx`.
- Prop opcional **`editadoEn`** en `TarjetaBloqueVidriera`: render del indicador en los estados **con datos** (ON / OFF / contenidoSiempre). El estado **sin-datos** conserva su CTA propio ("Cargar X") — no se duplica.
- Indicador también en las cards **forzado-visibles** (Ubicación, Descripción).

### Mapeo card → destino (todas las rutas verificadas, sin links rotos)
| Card | Editado en | Ruta |
|---|---|---|
| Ubicación · Año · Descripción | Datos básicos | `/taller/perfil/editar` |
| Tipo de inscripción | Datos básicos | `/taller/perfil` |
| Procesos · Prendas · Capacidad · Equipo · Espacio · Maquinaria · Organización | Perfil productivo | `/taller/perfil/completar` |
| Formación | Academia | `/taller/aprender` |

- **Formación → Academia**: la card "Mis cursos" (PR B) todavía no existe → apunta al destino actual disponible (`/taller/aprender`), **sin link roto**.
- **Portfolio**: editable inline en la propia card → no lleva indicador.

### Garantías
- **Solo en Mi vidriera** (vista del taller). La vidriera pública (`vidriera-publica-contenido.tsx`, `/perfil/[id]`) **no** usa `IndicadorEdicion` → el indicador no se filtra a la marca.
- **Behavior-preserving**: no toca toggles, render condicional, flag, R-DIR ni anti-footgun (todo cerrado en C1). Solo capa visual.
- **Refinamientos visuales (PASO 3)**: revisados los 3 estados de C1 (visible / oculto / sin-datos) — están limpios; no se inventaron cambios.
- Mobile 320/375: indicador `text-xs` en su propia línea (`w-fit`), no rompe layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)