### PR TITLE
feat: 2.3-B0 gracia 60d — schema + estado + helper + banners

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,12 @@
 # Daily Log
 
+## 2026-07-02
+
+### Gerardo Breard
+- **11:42** `1e7ceed` — docs(etapa2-3): marcar 2.3-A vidriera minima HECHO (#448, 9062603)
+  - `.claude/specs/v4-etapa2-3-discovery.md`
+
+
 ## 2026-06-27
 
 ### Gerardo Breard

--- a/prisma/migrations/20260702120000_etapa2_3b0_gracia_estado_cuenta/migration.sql
+++ b/prisma/migrations/20260702120000_etapa2_3b0_gracia_estado_cuenta/migration.sql
@@ -1,0 +1,42 @@
+-- Etapa 2.3-B0: gracia de 60 dias para verificar CUIT. Aditiva + backfill (AMNISTIA).
+--
+-- Crea el enum EstadoCuenta y 4 campos en "talleres" (tabla real, NO el nombre del
+-- modelo). NO reusa User.active (inerte en login + colisiona con el baneo de admin).
+--
+-- Backfill = AMNISTIA (decision Sergio/Gerardo):
+--   - Verificados     -> ACTIVA, sin reloj de gracia (inicioGracia NULL).
+--   - No verificados  -> EN_GRACIA, reloj arranca AHORA (NOW() = fecha de lanzamiento):
+--                        tienen 60 dias desde ESTE deploy, no desde su createdAt.
+--   - NADIE queda INACTIVA en el backfill: cero inactivacion retroactiva.
+--
+-- Solo modelo + datos. La transicion por tiempo (EN_GRACIA -> INACTIVA), los emails y
+-- la reactivacion al verificar CUIT son 2.3-B1 (el cron).
+
+-- CreateEnum
+CREATE TYPE "EstadoCuenta" AS ENUM ('ACTIVA', 'EN_GRACIA', 'INACTIVA');
+
+-- AlterTable
+ALTER TABLE "talleres" ADD COLUMN "estadoCuenta" "EstadoCuenta" NOT NULL DEFAULT 'ACTIVA';
+ALTER TABLE "talleres" ADD COLUMN "inicioGracia" TIMESTAMP(3);
+ALTER TABLE "talleres" ADD COLUMN "inactivadaAt" TIMESTAMP(3);
+ALTER TABLE "talleres" ADD COLUMN "recordatorioCuitEnviadoAt" TIMESTAMP(3);
+
+-- Backfill (amnistia). El DEFAULT 'ACTIVA' ya dejo a todos en ACTIVA; corregimos los
+-- no verificados a EN_GRACIA con el reloj arrancando ahora.
+UPDATE "talleres"
+   SET "estadoCuenta" = 'ACTIVA', "inicioGracia" = NULL
+ WHERE "verificadoAfip" = true;
+
+UPDATE "talleres"
+   SET "estadoCuenta" = 'EN_GRACIA', "inicioGracia" = NOW()
+ WHERE "verificadoAfip" = false;
+
+-- Query de control (ejecutar tras aplicar; NO forma parte de la migracion):
+--   SELECT "estadoCuenta", count(*) FROM "talleres" GROUP BY "estadoCuenta";
+--   -- Esperado: solo ACTIVA + EN_GRACIA, CERO INACTIVA.
+--   SELECT count(*) FILTER (WHERE "verificadoAfip" AND "estadoCuenta" <> 'ACTIVA')      AS verif_no_activa,
+--          count(*) FILTER (WHERE NOT "verificadoAfip" AND "estadoCuenta" <> 'EN_GRACIA') AS noverif_no_gracia,
+--          count(*) FILTER (WHERE "estadoCuenta" = 'INACTIVA')                          AS inactivas,
+--          count(*) FILTER (WHERE NOT "verificadoAfip" AND "inicioGracia" IS NULL)      AS gracia_sin_reloj
+--     FROM "talleres";
+--   -- Esperado: 0, 0, 0, 0.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,20 @@ enum NivelTaller {
   ORO
 }
 
+// Etapa 2.3-B: ciclo de vida de la cuenta del taller respecto de la gracia de 60 dias
+// para verificar CUIT. NO reusa User.active (inerte en login + colisiona con el baneo
+// de admin). Estado ALMACENADO (coarse): lo mantienen el alta/backfill (2.3-B0) y el
+// cron (2.3-B1). El estado FINO para banners/emails lo computa `clasificarGracia` en vivo.
+//   - ACTIVA:    CUIT verificado (o cuenta al dia). No aplica gracia.
+//   - EN_GRACIA: sin verificar, dentro de los 60 dias desde `inicioGracia`.
+//   - INACTIVA:  vencio la gracia (60+ dias) sin verificar. Recuperable al verificar CUIT.
+// En los 3 estados el login + Academia + Recursos siguen abiertos (restringido != cerrado).
+enum EstadoCuenta {
+  ACTIVA
+  EN_GRACIA
+  INACTIVA
+}
+
 enum EstadoPedido {
   BORRADOR
   PUBLICADO
@@ -302,6 +316,20 @@ model Taller {
   // (existentes via backfill, o tras revisar la config) => respeta null=visible (#437).
   // La logica de render condicional que LO USA es 2.2-B; este campo solo lo modela.
   modeloB_revisado  Boolean  @default(false)
+
+  // Etapa 2.3-B: gracia de 60 dias para verificar CUIT.
+  // - estadoCuenta: estado ALMACENADO (default ACTIVA; el alta/backfill y el cron de B1
+  //   lo setean). El estado FINO para banners/emails lo computa `clasificarGracia` desde
+  //   `inicioGracia`, no este campo.
+  // - inicioGracia: cuando arranca el reloj de 60 dias. Existentes = fecha de lanzamiento
+  //   (backfill = NOW() de la migracion, amnistia); nuevos sin verificar = su alta. NULL
+  //   si esta verificado (no aplica gracia).
+  // - inactivadaAt: cuando paso a INACTIVA (lo setea el cron de B1). NULL si nunca inactiva.
+  // - recordatorioCuitEnviadoAt: idempotencia del email dia ~50 (lo setea el cron de B1).
+  estadoCuenta              EstadoCuenta @default(ACTIVA)
+  inicioGracia              DateTime?
+  inactivadaAt              DateTime?
+  recordatorioCuitEnviadoAt DateTime?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/src/__tests__/crear-entidad-rol.test.ts
+++ b/src/__tests__/crear-entidad-rol.test.ts
@@ -34,6 +34,12 @@ describe('crearEntidadParaRol', () => {
     })
     expect(res).toEqual({ id: 't1' })
     expect(tx.taller.create).toHaveBeenCalled()
+    // 2.3-B0: taller verificado arranca ACTIVA sin reloj de gracia.
+    expect(tx.taller.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ estadoCuenta: 'ACTIVA', inicioGracia: null }),
+      }),
+    )
     expect(tx.validacion.createMany).toHaveBeenCalledWith({
       data: [
         { tallerId: 't1', tipo: 'CUIT/Monotributo', tipoDocumentoId: 'td1', estado: 'NO_INICIADO' },
@@ -41,6 +47,19 @@ describe('crearEntidadParaRol', () => {
       ],
     })
     expect(tx.marca.create).not.toHaveBeenCalled()
+  })
+
+  it('TALLER sin verificar: arranca EN_GRACIA con el reloj en su alta (2.3-B0)', async () => {
+    await crearEntidadParaRol(tx as unknown as Prisma.TransactionClient, {
+      userId: 'u1',
+      rol: 'TALLER',
+      nombre: 'Taller Nuevo',
+      cuit: '20-12345678-9',
+      verificadoAfip: false,
+    })
+    const arg = tx.taller.create.mock.calls[0][0] as { data: { estadoCuenta: string; inicioGracia: Date | null } }
+    expect(arg.data.estadoCuenta).toBe('EN_GRACIA')
+    expect(arg.data.inicioGracia).toBeInstanceOf(Date)
   })
 
   it('MARCA: crea la marca y NO crea validaciones', async () => {

--- a/src/__tests__/gracia.test.ts
+++ b/src/__tests__/gracia.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import {
+  clasificarGracia,
+  estadoCuentaInicial,
+  DIAS_GRACIA,
+  DIAS_VENCE_PRONTO,
+} from '@/compartido/lib/gracia'
+
+// Fechas fabricadas → testeable sin esperar 60 días reales.
+const INICIO = new Date('2026-01-01T00:00:00.000Z')
+const masDias = (n: number, extraMs = 0) =>
+  new Date(INICIO.getTime() + n * 86_400_000 + extraMs)
+
+describe('clasificarGracia (pura, fechas inyectadas)', () => {
+  describe('NO_APLICA', () => {
+    it('taller verificado => NO_APLICA aunque tenga inicioGracia', () => {
+      const r = clasificarGracia({ verificadoAfip: true, inicioGracia: INICIO }, masDias(90))
+      expect(r.estado).toBe('NO_APLICA')
+      expect(r.diasRestantes).toBe(0)
+    })
+
+    it('sin inicioGracia (null) => NO_APLICA', () => {
+      expect(clasificarGracia({ verificadoAfip: false, inicioGracia: null }, masDias(70)).estado).toBe('NO_APLICA')
+    })
+
+    it('inicioGracia ausente/undefined => NO_APLICA', () => {
+      expect(clasificarGracia({}, masDias(70)).estado).toBe('NO_APLICA')
+    })
+  })
+
+  describe('ventana de estados por día (sin verificar)', () => {
+    const enGracia = { verificadoAfip: false, inicioGracia: INICIO }
+
+    it('día 0 => EN_GRACIA, quedan 60', () => {
+      const r = clasificarGracia(enGracia, masDias(0))
+      expect(r.estado).toBe('EN_GRACIA')
+      expect(r.diasTranscurridos).toBe(0)
+      expect(r.diasRestantes).toBe(DIAS_GRACIA)
+    })
+
+    it('día 49 => EN_GRACIA (aún no vence pronto), quedan 11', () => {
+      const r = clasificarGracia(enGracia, masDias(49))
+      expect(r.estado).toBe('EN_GRACIA')
+      expect(r.diasRestantes).toBe(11)
+    })
+
+    it('día 50 => VENCE_PRONTO (ventana del email), quedan 10', () => {
+      const r = clasificarGracia(enGracia, masDias(DIAS_VENCE_PRONTO))
+      expect(r.estado).toBe('VENCE_PRONTO')
+      expect(r.diasRestantes).toBe(10)
+    })
+
+    it('día 59 => VENCE_PRONTO, queda 1', () => {
+      const r = clasificarGracia(enGracia, masDias(59))
+      expect(r.estado).toBe('VENCE_PRONTO')
+      expect(r.diasRestantes).toBe(1)
+    })
+
+    it('día 60 => INACTIVA, quedan 0', () => {
+      const r = clasificarGracia(enGracia, masDias(DIAS_GRACIA))
+      expect(r.estado).toBe('INACTIVA')
+      expect(r.diasRestantes).toBe(0)
+    })
+
+    it('día 61 => INACTIVA (sigue inactiva, no se rompe)', () => {
+      expect(clasificarGracia(enGracia, masDias(61)).estado).toBe('INACTIVA')
+    })
+
+    it('día 100 => INACTIVA', () => {
+      expect(clasificarGracia(enGracia, masDias(100)).estado).toBe('INACTIVA')
+    })
+  })
+
+  describe('tolerancia a corrida perdida (ventana, no día exacto)', () => {
+    it('el email dispara en CUALQUIER día de la ventana [50, 60), no solo el 50', () => {
+      const t = { verificadoAfip: false, inicioGracia: INICIO }
+      // Si el cron se saltea el día 50, los días 51..59 siguen en VENCE_PRONTO.
+      for (const d of [50, 51, 55, 59]) {
+        expect(clasificarGracia(t, masDias(d)).estado).toBe('VENCE_PRONTO')
+      }
+    })
+
+    it('fracción de día no adelanta el estado (floor de días)', () => {
+      const t = { verificadoAfip: false, inicioGracia: INICIO }
+      // día 59 + 23h sigue siendo día 59 => VENCE_PRONTO, no INACTIVA.
+      expect(clasificarGracia(t, masDias(59, 23 * 3_600_000)).estado).toBe('VENCE_PRONTO')
+    })
+  })
+})
+
+describe('estadoCuentaInicial (estado al alta)', () => {
+  it('verificado => ACTIVA sin reloj de gracia', () => {
+    expect(estadoCuentaInicial(true, INICIO)).toEqual({ estadoCuenta: 'ACTIVA', inicioGracia: null })
+  })
+
+  it('sin verificar => EN_GRACIA con el reloj arrancando en su alta', () => {
+    expect(estadoCuentaInicial(false, INICIO)).toEqual({ estadoCuenta: 'EN_GRACIA', inicioGracia: INICIO })
+  })
+
+  it('un taller creado sin verificar arranca en día 0 de EN_GRACIA', () => {
+    const { inicioGracia } = estadoCuentaInicial(false, INICIO)
+    const r = clasificarGracia({ verificadoAfip: false, inicioGracia }, INICIO)
+    expect(r.estado).toBe('EN_GRACIA')
+    expect(r.diasRestantes).toBe(DIAS_GRACIA)
+  })
+})

--- a/src/app/(taller)/taller/page.tsx
+++ b/src/app/(taller)/taller/page.tsx
@@ -11,6 +11,7 @@ import { calcularPasosTaller } from '@/compartido/lib/onboarding'
 import { ChecklistOnboarding } from '@/compartido/componentes/ui/checklist-onboarding'
 import { nivelAEtapa } from '@/compartido/lib/formalizacion'
 import { BannerVidriera } from '@/taller/componentes/banner-vidriera'
+import { BannerGracia } from '@/taller/componentes/banner-gracia'
 
 export default async function TallerDashboardPage() {
   const session = await auth()
@@ -167,23 +168,10 @@ export default async function TallerDashboardPage() {
         </h1>
       </div>
 
-      {/* Banner taller no verificado */}
-      {taller && !taller.verificadoAfip && (
-        <div className="border-l-4 border-l-amber-400 bg-amber-50 rounded-card p-4">
-          <p className="font-overpass font-bold text-amber-800 mb-1">
-            Tu taller esta en proceso de formalizacion
-          </p>
-          <p className="text-sm text-amber-700">
-            Podes navegar la plataforma, capacitarte y subir documentos para avanzar. Una vez que la Coordinación verifique tu CUIT, vas a poder cotizar pedidos y aparecer en el directorio.
-          </p>
-          <Link
-            href="/taller/formalizacion"
-            className="inline-flex items-center gap-1 mt-2 text-sm font-semibold text-amber-800 hover:underline"
-          >
-            Ir a Formalizacion →
-          </Link>
-        </div>
-      )}
+      {/* Banner de gracia de CUIT (2.3-B0): countdown (EN_GRACIA) o reactivación
+          (INACTIVA) para talleres sin verificar. Reemplaza al banner genérico "en
+          proceso de formalización". Devuelve null para verificados. */}
+      {taller && <BannerGracia taller={taller} />}
 
       {/* Banner de cambio de etapa de formalización */}
       {cambioNivel && cambioNivel.nivelNuevo && (

--- a/src/app/api/auth/registro/route.ts
+++ b/src/app/api/auth/registro/route.ts
@@ -5,6 +5,7 @@ import { logActividad } from '@/compartido/lib/log'
 import { consultarPadron, errorBloqueaRegistro, mensajeErrorArca, type DatosArca } from '@/compartido/lib/arca'
 import { sendEmail, buildBienvenidaEmail } from '@/compartido/lib/email'
 import { rateLimit, getClientIp } from '@/compartido/lib/ratelimit'
+import { estadoCuentaInicial } from '@/compartido/lib/gracia'
 import { apiHandler, errorResponse, errorConflict } from '@/compartido/lib/api-errors'
 import bcrypt from 'bcryptjs'
 import { z } from 'zod'
@@ -110,6 +111,8 @@ export const POST = apiHandler(async (req: NextRequest) => {
                   capacidadMensual: data.tallerData.capacidadMensual || 0,
                   verificadoAfip: cuitVerificado,
                   verificadoAfipAt: cuitVerificado ? new Date() : null,
+                  // Estado inicial de gracia (2.3-B0): { estadoCuenta, inicioGracia }.
+                  ...estadoCuentaInicial(cuitVerificado, new Date()),
                   tipoInscripcionAfip: datosArca?.tipoInscripcion ?? null,
                   categoriaMonotributo: datosArca?.categoriaMonotributo ?? null,
                   estadoCuitAfip: datosArca?.estadoCuit ?? null,

--- a/src/compartido/lib/crear-entidad-rol.ts
+++ b/src/compartido/lib/crear-entidad-rol.ts
@@ -1,5 +1,6 @@
 import type { Prisma } from '@prisma/client'
 import type { DatosArca } from './arca'
+import { estadoCuentaInicial } from './gracia'
 
 export type RolEntidad = 'TALLER' | 'MARCA'
 
@@ -31,6 +32,9 @@ export async function crearEntidadParaRol(
   }
 
   if (rol === 'TALLER') {
+    // Estado inicial de gracia (2.3-B0): sin verificar arranca EN_GRACIA con el reloj
+    // en su alta; verificado arranca ACTIVA sin reloj.
+    const gracia = estadoCuentaInicial(verificadoAfip, new Date())
     const taller = await tx.taller.create({
       data: {
         userId,
@@ -38,6 +42,8 @@ export async function crearEntidadParaRol(
         cuit,
         verificadoAfip,
         verificadoAfipAt: verificadoAfip ? new Date() : null,
+        estadoCuenta: gracia.estadoCuenta,
+        inicioGracia: gracia.inicioGracia,
         tipoInscripcionAfip: datosArca?.tipoInscripcion ?? null,
         categoriaMonotributo: datosArca?.categoriaMonotributo ?? null,
         estadoCuitAfip: datosArca?.estadoCuit ?? null,

--- a/src/compartido/lib/gracia.ts
+++ b/src/compartido/lib/gracia.ts
@@ -1,0 +1,83 @@
+// Etapa 2.3-B: gracia de 60 dias para verificar CUIT.
+//
+// Este modulo es PURO (sin Prisma, sin `new Date()` interno): las fechas se inyectan,
+// asi la clasificacion es testeable sin esperar 60 dias reales. Lo usan:
+//   - los banners del dashboard (B0, en vivo con `new Date()` del server component)
+//   - el cron (B1) para decidir email dia ~50 e inactivacion dia 60
+//   - el alta de un taller (B0) para el estado inicial (`estadoCuentaInicial`)
+
+/** Dias de gracia para verificar el CUIT antes de pasar a INACTIVA. */
+export const DIAS_GRACIA = 60
+
+/**
+ * Umbral de "vence pronto" (ventana del recordatorio de B1). A partir de este dia y
+ * hasta el 60, el cron manda el email — es una VENTANA (>=50), no el dia 50 exacto,
+ * para tolerar una corrida perdida del cron.
+ */
+export const DIAS_VENCE_PRONTO = 50
+
+const MS_POR_DIA = 86_400_000
+
+/**
+ * Estado FINO de la gracia, computado en vivo desde `inicioGracia`. Distinto del
+ * `estadoCuenta` ALMACENADO (coarse: ACTIVA/EN_GRACIA/INACTIVA que mantienen alta +
+ * backfill + cron). `VENCE_PRONTO` y `NO_APLICA` no existen como estado almacenado:
+ *   - VENCE_PRONTO = sub-ventana de EN_GRACIA (dia >=50) para el email de B1.
+ *   - NO_APLICA    = corresponde a ACTIVA (verificado o sin reloj de gracia).
+ */
+export type EstadoGracia = 'NO_APLICA' | 'EN_GRACIA' | 'VENCE_PRONTO' | 'INACTIVA'
+
+export interface ResultadoGracia {
+  estado: EstadoGracia
+  /** Dias transcurridos desde `inicioGracia` (0 si no aplica). */
+  diasTranscurridos: number
+  /** Dias hasta el dia 60 (para el countdown del banner). 0 si vencio o no aplica. */
+  diasRestantes: number
+}
+
+type TallerGracia = {
+  verificadoAfip?: boolean | null
+  inicioGracia?: Date | null
+}
+
+/**
+ * Clasifica la situacion de gracia de un taller a una fecha dada (`ahora`). PURA.
+ *
+ * - Verificado o sin `inicioGracia` -> NO_APLICA (no hay reloj corriendo).
+ * - dia < 50   -> EN_GRACIA
+ * - 50 <= dia < 60 -> VENCE_PRONTO (ventana del email)
+ * - dia >= 60  -> INACTIVA
+ *
+ * El dia se cuenta en UTC-agnostico por diferencia de timestamps (Date es un instante):
+ * `floor((ahora - inicioGracia) / dia)`. Dia 0 = mismo dia que inicioGracia.
+ */
+export function clasificarGracia(taller: TallerGracia, ahora: Date): ResultadoGracia {
+  if (taller.verificadoAfip || !taller.inicioGracia) {
+    return { estado: 'NO_APLICA', diasTranscurridos: 0, diasRestantes: 0 }
+  }
+  const diasTranscurridos = Math.floor((ahora.getTime() - taller.inicioGracia.getTime()) / MS_POR_DIA)
+  const diasRestantes = Math.max(0, DIAS_GRACIA - diasTranscurridos)
+
+  if (diasTranscurridos >= DIAS_GRACIA) {
+    return { estado: 'INACTIVA', diasTranscurridos, diasRestantes: 0 }
+  }
+  if (diasTranscurridos >= DIAS_VENCE_PRONTO) {
+    return { estado: 'VENCE_PRONTO', diasTranscurridos, diasRestantes }
+  }
+  return { estado: 'EN_GRACIA', diasTranscurridos, diasRestantes }
+}
+
+/**
+ * Estado de cuenta inicial al crear un taller (B0). Verificado -> ACTIVA sin reloj;
+ * sin verificar -> EN_GRACIA con el reloj arrancando en `ahora` (su alta). Devuelve
+ * string literals que Prisma acepta directo en el `create` (sin importar el enum
+ * generado, para no acoplar este modulo puro a @prisma/client).
+ */
+export function estadoCuentaInicial(
+  verificadoAfip: boolean,
+  ahora: Date,
+): { estadoCuenta: 'ACTIVA' | 'EN_GRACIA'; inicioGracia: Date | null } {
+  return verificadoAfip
+    ? { estadoCuenta: 'ACTIVA', inicioGracia: null }
+    : { estadoCuenta: 'EN_GRACIA', inicioGracia: ahora }
+}

--- a/src/taller/componentes/banner-gracia.tsx
+++ b/src/taller/componentes/banner-gracia.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link'
+import { AlertTriangle, Clock } from 'lucide-react'
+import { clasificarGracia } from '@/compartido/lib/gracia'
+
+// Banner de gracia de CUIT en el dashboard del taller (Etapa 2.3-B0). Reemplaza al
+// banner generico "en proceso de formalizacion": misma poblacion (talleres sin CUIT
+// verificado), pero con el copy por estado de Sergio y el countdown de dias.
+//
+// Server component sin estado: se computa en vivo con `clasificarGracia` (mismo helper
+// que usara el cron de B1), asi el banner refleja la realidad AUN sin el cron (que
+// todavia no corre en B0). Para un taller verificado devuelve null (no aplica gracia).
+//
+// Coexistencia con 2.2-B: el BannerVidriera se muestra SOLO para verificados; este,
+// SOLO para no verificados. Son mutuamente excluyentes por `verificadoAfip` -> nunca
+// aparecen los dos juntos.
+
+export function BannerGracia({
+  taller,
+}: {
+  taller: { verificadoAfip: boolean; inicioGracia: Date | null }
+}) {
+  const { estado, diasRestantes } = clasificarGracia(taller, new Date())
+
+  // Verificado / sin reloj de gracia -> sin banner (su foco no es la gracia).
+  if (estado === 'NO_APLICA') return null
+
+  if (estado === 'INACTIVA') {
+    return (
+      <div className="border-l-4 border-l-red-400 bg-red-50 rounded-card p-4">
+        <p className="flex items-center gap-1.5 font-overpass font-bold text-red-800 mb-1">
+          <AlertTriangle className="w-4 h-4 shrink-0" /> Tu cuenta está inactiva
+        </p>
+        <p className="text-sm text-red-700">
+          Verificá tu CUIT para reactivarla y aparecer en el directorio. Mientras tanto,
+          seguís teniendo acceso a la Academia y los Recursos.
+        </p>
+        <Link
+          href="/taller/formalizacion"
+          className="inline-flex items-center gap-1 mt-2 text-sm font-semibold text-red-800 hover:underline"
+        >
+          Verificar mi CUIT →
+        </Link>
+      </div>
+    )
+  }
+
+  // EN_GRACIA / VENCE_PRONTO -> countdown (tono estimulante).
+  const dias = diasRestantes === 1 ? 'queda 1 día' : `quedan ${diasRestantes} días`
+  return (
+    <div className="border-l-4 border-l-amber-400 bg-amber-50 rounded-card p-4">
+      <p className="flex items-center gap-1.5 font-overpass font-bold text-amber-800 mb-1">
+        <Clock className="w-4 h-4 shrink-0" /> Te {dias} para verificar tu CUIT y aparecer en el directorio
+      </p>
+      <p className="text-sm text-amber-700">
+        Una vez verificado tu CUIT vas a poder cotizar pedidos y aparecer en el directorio.
+        Mientras tanto, podés capacitarte en la Academia y usar los Recursos.
+      </p>
+      <Link
+        href="/taller/formalizacion"
+        className="inline-flex items-center gap-1 mt-2 text-sm font-semibold text-amber-800 hover:underline"
+      >
+        Ir a Formalización →
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## Etapa 2.3-B0 — Schema + enforcement de la gracia de 60 días

Primera mitad de B (B1 = cron + emails, aparte). Deja el **modelo + helper puro + estado inicial + enforcement verificado + banners**. Nada se mueve solo todavía (las transiciones por tiempo, emails y reactivación son B1).

> ⚠️ **El schema lo revisa Gerardo antes de mergear** (regla del repo).

### 1. Schema (migración aditiva + backfill — tabla real `talleres`)
- `enum EstadoCuenta { ACTIVA, EN_GRACIA, INACTIVA }` — **NUEVO**, no reusa `User.active` (inerte en login + colisiona con el baneo de admin).
- `Taller`: `estadoCuenta` (default ACTIVA), `inicioGracia`, `inactivadaAt`, `recordatorioCuitEnviadoAt`.
- **Backfill = AMNISTÍA:** verificados → `ACTIVA` (sin reloj); no verificados → `EN_GRACIA` con `inicioGracia=NOW()` (arranca en la fecha de lanzamiento, **no** en `createdAt`); **nadie** queda `INACTIVA` (cero inactivación retroactiva). Query de control documentada en la migración.

### 2. Helper puro `clasificarGracia` (`src/compartido/lib/gracia.ts`)
Sin Prisma, fechas inyectadas → testeable sin esperar 60 días. `NO_APLICA | EN_GRACIA | VENCE_PRONTO` (ventana email día ≥50) `| INACTIVA` (día ≥60) + `diasRestantes` (countdown). `estadoCuentaInicial()` = estado al alta. **Tests:** día 0/49/50/59/60/61/100, verificado, sin reloj, ventana tolerante a corrida perdida, fracción de día (floor).

### 3. Enforcement — el mapeo (lo crítico del hallazgo)
El hallazgo del discovery era que `User.active` está inerte. Pero gracia/inactiva **no agregan restricción operativa nueva**: todo lo comercial ya gatea en `verificadoAfip`.

| Acción del taller | Gate | ¿Existe? |
|---|---|---|
| Cotizar | `POST /api/cotizaciones` → 403 `TALLER_NO_VERIFICADO` | ✅ directo |
| Ser invitado a cotizar | `pedidos/[id]/invitaciones` → 400 | ✅ directo (marca-side) |
| Aparecer en directorio | `where verificadoAfip:true` | ✅ directo |
| Recibir/operar una orden | requiere cotización aceptada (⇒ cotizó ⇒ verificado) + ownership | ✅ transitivo |
| Academia / Recursos | sin gate CUIT | ✅ correcto (abierto) |

**Ningún gate falta** → B0 no crea enforcement net-new, solo lo verifica. El login sigue abierto (Academia/Recursos accesibles en los 3 estados).

### 4. Banners (`BannerGracia`, dashboard taller)
- **EN_GRACIA/VENCE_PRONTO:** countdown "Te quedan X días para verificar tu CUIT y aparecer en el directorio".
- **INACTIVA:** "Tu cuenta está inactiva. Verificá tu CUIT para reactivarla…".
Reemplaza el banner genérico. Se computa **en vivo** con `clasificarGracia` → refleja la realidad aun sin el cron (B1). **Coexistencia con 2.2-B:** `BannerVidriera` es solo-verificados, `BannerGracia` solo-no-verificados → mutuamente excluyentes, nunca juntos.

### 5. Estado al alta
`crear-entidad-rol.ts` (registro/completar + U-09) y el registro inline setean `estadoCuenta`+`inicioGracia` según `verificadoAfip` (nuevos sin verificar arrancan `EN_GRACIA` desde su alta).

### Fuera de scope (B1)
Cron, emails (recordatorio día 50 / reactivación / lanzamiento), transición automática por tiempo, reactivación al verificar CUIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)