### PR TITLE
feat: 2.3-B1 cron gracia CUIT — recordatorio + inactivacion + reactivacion (#cierre Etapa 2)

### DIFF
--- a/.claude/specs/v4-etapa2-3b1-runbook.md
+++ b/.claude/specs/v4-etapa2-3b1-runbook.md
@@ -1,0 +1,114 @@
+# Runbook — Etapa 2.3-B1 (cron de gracia + emails + reactivación)
+
+Cierre de la Etapa 2. Pone en movimiento el modelo de B0 (enum `EstadoCuenta`,
+`clasificarGracia`, banners). Este doc es el runbook operativo + la guía de QA para Sergio.
+
+## Piezas
+
+| Pieza | Archivo | Qué hace |
+|---|---|---|
+| Cron diario | `src/app/api/cron/gracia-cuit/route.ts` | Recordatorio día ~50 + inactivación día 60 |
+| Email lanzamiento (one-off) | `src/app/api/cron/gracia-lanzamiento/route.ts` | Aviso masivo "tenés 60 días", disparo manual |
+| Decisión pura | `src/compartido/lib/gracia.ts` → `planificarAccionGracia` | NADA / RECORDATORIO / INACTIVAR (testeada) |
+| Reactivación | `src/compartido/lib/arca.ts` → `sincronizarTaller` | Verificar CUIT → ACTIVA + reloj limpio |
+| Emails | `src/compartido/lib/email.ts` | `buildRecordatorioCuitEmail`, `buildCuentaInactivaEmail`, `buildLanzamientoGraciaEmail` |
+| Schedule | `vercel.json#crons` | `0 11 * * *` (08:00 ART) |
+
+## 1. CRON_SECRET (env var — pendiente de setear)
+
+El cron y el endpoint de lanzamiento se protegen con `Authorization: Bearer ${CRON_SECRET}`.
+Vercel adjunta ese header automáticamente a los crons si la env var existe. **Sin
+`CRON_SECRET` configurado, el endpoint responde 401** (no queda abierto por omisión).
+
+**Setear en Vercel** (Production + Preview) — lo hace Gerardo (requiere acceso al dashboard):
+
+```
+vercel env add CRON_SECRET production
+vercel env add CRON_SECRET preview
+# valor: un secreto largo aleatorio, ej: openssl rand -hex 32
+```
+
+Y en `.env.local` para pruebas locales/curl.
+
+## 2. Qué hace cada corrida
+
+Sobre los talleres con `estadoCuenta = EN_GRACIA` (fuente: `planificarAccionGracia`):
+
+- **Ventana [50, 60) días y sin recordatorio previo** → email recordatorio + sella
+  `recordatorioCuitEnviadoAt` (idempotencia: no re-envía).
+- **≥ 60 días** → `estadoCuenta = INACTIVA` + `inactivadaAt = NOW` + email de inactivación.
+  Al salir de `EN_GRACIA`, la próxima corrida ya no lo toca (inactivación no-op repetible).
+
+La ventana (no el día exacto) tolera corridas perdidas: si el cron se saltea el día 50,
+los días 51..59 siguen mandando el recordatorio. Si salta directo a ≥60, inactiva (la
+inactivación tiene prioridad sobre el recordatorio).
+
+Cada corrida loguea un resumen: `{ evaluados, recordatorios, inactivaciones, sinEmail, errores }`
+(consola + `logActividad('CRON_GRACIA_CUIT')` para la bitácora).
+
+## 3. Disparar el cron manualmente (QA / debug)
+
+```bash
+curl -i https://<preview-o-prod>/api/cron/gracia-cuit \
+  -H "Authorization: Bearer $CRON_SECRET"
+# Sin el header → 401
+```
+
+## 4. Demo de Sergio — ver INACTIVA con el cron
+
+Usa el taller de demo dedicado (`demo.gracia`, retrodatado a 55 días en B0). Pasos:
+
+```sql
+-- 1) Correr el reloj a 65 días para que el cron lo inactive
+UPDATE "talleres"
+SET "inicioGracia" = NOW() - INTERVAL '65 days'
+WHERE id = (SELECT id FROM "talleres" t JOIN "User" u ON u.id = t."userId"
+            WHERE u.email = 'demo.gracia@pdt.org.ar');
+```
+
+```bash
+# 2) Disparar el cron
+curl -s https://<preview>/api/cron/gracia-cuit -H "Authorization: Bearer $CRON_SECRET"
+# → { ..., inactivaciones: 1 }
+```
+
+3) En el dashboard del taller demo: **banner rojo "Tu cuenta está inactiva"** + el taller
+   deja de aparecer en el directorio. Se mandó el email de inactivación.
+
+4) Para ver la **reactivación**: verificar el CUIT desde el flujo ARCA (o `sincronizarTaller`)
+   → vuelve a `estadoCuenta = ACTIVA`, banner desaparece, elegible de nuevo para el directorio
+   (si cumple vidriera mínima).
+
+Para volver a probar el **recordatorio**: `inicioGracia = NOW() - INTERVAL '55 days'` +
+`recordatorioCuitEnviadoAt = NULL` + `estadoCuenta = 'EN_GRACIA'`, y disparar el cron.
+
+## 5. Email de lanzamiento (one-off manual)
+
+**NO** es parte del cron. Se dispara **una sola vez**, poco después de promover B0 a prod
+(cuando el backfill ya arrancó el reloj de los talleres existentes sin verificar). Avisa
+"tenés 60 días desde hoy". No toca `inicioGracia` — solo notifica.
+
+```bash
+curl -i -X POST "https://plataforma-textil.vercel.app/api/cron/gracia-lanzamiento?confirmar=SI" \
+  -H "Authorization: Bearer $CRON_SECRET"
+```
+
+- Requiere `?confirmar=SI` (evita un disparo accidental de envío masivo).
+- **No es idempotente**: dispararlo dos veces manda dos emails. Por eso es manual y una vez.
+- Lo dispara **Gerardo** cuando decide. Queda documentado, no automático.
+
+## 6. A dónde van los emails en DEV/preview
+
+- **Unit tests**: `sendEmail` está mockeado — no sale ningún email real.
+- **DEV/preview**: si `RESEND_API_KEY` no está seteada, `sendEmail` cae a modo dev (log por
+  consola, no envía). Los talleres del seed usan direcciones `@pdt.org.ar` (dominio no real,
+  no entregable) → aunque Resend estuviera activo, no se spamea a ninguna persona real.
+- **Prod**: `EMAIL_FROM = notificaciones@plataformatextil.com.ar` (dominio propio verificado).
+
+## 7. Tests
+
+- `src/__tests__/gracia.test.ts` — `planificarAccionGracia` (día 49/50/55/60/65, recordatorio
+  ya enviado, corrida perdida, no-EN_GRACIA) + `datosReactivacion`.
+- `src/__tests__/cron-gracia.test.ts` — route: 401 sin/con secret malo/sin CRON_SECRET;
+  recordatorio + sello; inactivación; batch mixto; sin email; **idempotencia (doble corrida)**.
+- `src/__tests__/arca.test.ts` — `sincronizarTaller` reactiva (ACTIVA + reloj limpio).

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-07-02
 
 ### Gerardo Breard
+- **20:34** `7a98302` — docs(etapa2-3): marcar B0 gracia HECHO (#449, 23d20b0)
+  - `.claude/specs/v4-etapa2-3-discovery.md`
+
 - **11:42** `1e7ceed` — docs(etapa2-3): marcar 2.3-A vidriera minima HECHO (#448, 9062603)
   - `.claude/specs/v4-etapa2-3-discovery.md`
 

--- a/src/__tests__/arca.test.ts
+++ b/src/__tests__/arca.test.ts
@@ -261,4 +261,31 @@ describe('sincronizarTaller', () => {
     expect(resultado.exitosa).toBe(false)
     expect(resultado.error).toContain('sin CUIT')
   })
+
+  // 2.3-B1: reactivación automática — verificar el CUIT limpia el reloj de gracia.
+  it('reactiva la cuenta (ACTIVA + reloj limpio) al verificar exitosamente', async () => {
+    mockGetTaxpayerDetails.mockResolvedValue(fixtureActivo)
+    mockFindUnique.mockResolvedValue({
+      id: 'taller-5',
+      cuit: '20-30123456-7',
+      verificadoAfipAt: null,
+    })
+    mockUpdate.mockResolvedValue({})
+
+    const resultado = await sincronizarTaller('taller-5', true)
+
+    expect(resultado.exitosa).toBe(true)
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'taller-5' },
+        data: expect.objectContaining({
+          verificadoAfip: true,
+          estadoCuenta: 'ACTIVA',
+          inicioGracia: null,
+          inactivadaAt: null,
+          recordatorioCuitEnviadoAt: null,
+        }),
+      })
+    )
+  })
 })

--- a/src/__tests__/cron-gracia.test.ts
+++ b/src/__tests__/cron-gracia.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// Test de integración del cron de gracia (2.3-B1): auth por Bearer, acciones por estado
+// e idempotencia. La DECISIÓN pura (planificarAccionGracia) se testea en gracia.test.ts;
+// acá se verifica que la ROUTE ejecuta los writes + emails correctos.
+
+const { mockFindMany, mockUpdate, mockSendEmail } = vi.hoisted(() => ({
+  mockFindMany: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockSendEmail: vi.fn().mockResolvedValue({ exito: true }),
+}))
+
+vi.mock('@/compartido/lib/prisma', () => ({
+  prisma: { taller: { findMany: mockFindMany, update: mockUpdate } },
+}))
+vi.mock('@/compartido/lib/log', () => ({ logActividad: vi.fn() }))
+vi.mock('@/compartido/lib/email', async (importActual) => {
+  const actual = await importActual<typeof import('@/compartido/lib/email')>()
+  return { ...actual, sendEmail: mockSendEmail }
+})
+
+import { GET } from '@/app/api/cron/gracia-cuit/route'
+
+const SECRET = 'test-cron-secret'
+const diasAtras = (n: number) => new Date(Date.now() - n * 86_400_000)
+
+function req(auth?: string): NextRequest {
+  return new NextRequest('http://localhost/api/cron/gracia-cuit', {
+    headers: auth ? { authorization: auth } : {},
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockSendEmail.mockResolvedValue({ exito: true })
+  mockUpdate.mockResolvedValue({})
+  process.env.CRON_SECRET = SECRET
+})
+
+describe('GET /api/cron/gracia-cuit — auth', () => {
+  it('401 sin header Authorization', async () => {
+    mockFindMany.mockResolvedValue([])
+    const res = await GET(req())
+    expect(res.status).toBe(401)
+    expect(mockFindMany).not.toHaveBeenCalled()
+  })
+
+  it('401 con secret incorrecto', async () => {
+    mockFindMany.mockResolvedValue([])
+    const res = await GET(req('Bearer otra-cosa'))
+    expect(res.status).toBe(401)
+  })
+
+  it('401 si CRON_SECRET no está configurado (no queda abierto)', async () => {
+    delete process.env.CRON_SECRET
+    mockFindMany.mockResolvedValue([])
+    const res = await GET(req('Bearer '))
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('GET /api/cron/gracia-cuit — acciones', () => {
+  const enGracia = (id: string, dias: number, extra: Record<string, unknown> = {}) => ({
+    id,
+    nombre: `Taller ${id}`,
+    verificadoAfip: false,
+    estadoCuenta: 'EN_GRACIA',
+    inicioGracia: diasAtras(dias),
+    recordatorioCuitEnviadoAt: null,
+    user: { email: `${id}@pdt.org.ar` },
+    ...extra,
+  })
+
+  it('día ~55 => manda recordatorio y sella recordatorioCuitEnviadoAt', async () => {
+    mockFindMany.mockResolvedValue([enGracia('t-remind', 55)])
+    const res = await GET(req(`Bearer ${SECRET}`))
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.recordatorios).toBe(1)
+    expect(body.inactivaciones).toBe(0)
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 't-remind' },
+        data: expect.objectContaining({ recordatorioCuitEnviadoAt: expect.any(Date) }),
+      }),
+    )
+    expect(mockSendEmail).toHaveBeenCalledTimes(1)
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 't-remind@pdt.org.ar' }),
+    )
+  })
+
+  it('día ~65 => inactiva (estadoCuenta INACTIVA + inactivadaAt) y manda email', async () => {
+    mockFindMany.mockResolvedValue([enGracia('t-off', 65)])
+    const res = await GET(req(`Bearer ${SECRET}`))
+    const body = await res.json()
+
+    expect(body.inactivaciones).toBe(1)
+    expect(body.recordatorios).toBe(0)
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 't-off' },
+        data: expect.objectContaining({ estadoCuenta: 'INACTIVA', inactivadaAt: expect.any(Date) }),
+      }),
+    )
+    expect(mockSendEmail).toHaveBeenCalledTimes(1)
+  })
+
+  it('día ~10 => no hace nada', async () => {
+    mockFindMany.mockResolvedValue([enGracia('t-joven', 10)])
+    const res = await GET(req(`Bearer ${SECRET}`))
+    const body = await res.json()
+
+    expect(body.recordatorios).toBe(0)
+    expect(body.inactivaciones).toBe(0)
+    expect(mockUpdate).not.toHaveBeenCalled()
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('recordatorio ya enviado => no re-envía (idempotencia)', async () => {
+    mockFindMany.mockResolvedValue([
+      enGracia('t-ya', 55, { recordatorioCuitEnviadoAt: diasAtras(5) }),
+    ])
+    const res = await GET(req(`Bearer ${SECRET}`))
+    const body = await res.json()
+
+    expect(body.recordatorios).toBe(0)
+    expect(mockSendEmail).not.toHaveBeenCalled()
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('batch mixto: cuenta cada acción por separado', async () => {
+    mockFindMany.mockResolvedValue([
+      enGracia('a', 55), // recordatorio
+      enGracia('b', 65), // inactivar
+      enGracia('c', 10), // nada
+      enGracia('d', 55, { recordatorioCuitEnviadoAt: diasAtras(3) }), // nada (ya avisado)
+    ])
+    const res = await GET(req(`Bearer ${SECRET}`))
+    const body = await res.json()
+
+    expect(body.evaluados).toBe(4)
+    expect(body.recordatorios).toBe(1)
+    expect(body.inactivaciones).toBe(1)
+    expect(mockSendEmail).toHaveBeenCalledTimes(2)
+  })
+
+  it('taller sin email => no rompe, lo cuenta en sinEmail', async () => {
+    mockFindMany.mockResolvedValue([enGracia('t-noemail', 65, { user: null })])
+    const res = await GET(req(`Bearer ${SECRET}`))
+    const body = await res.json()
+
+    expect(body.inactivaciones).toBe(1)
+    expect(body.sinEmail).toBe(1)
+    expect(mockSendEmail).not.toHaveBeenCalled()
+    // La inactivación igual se persiste aunque no haya a quién avisar.
+    expect(mockUpdate).toHaveBeenCalled()
+  })
+
+  it('idempotencia real: correr dos veces = mismo resultado (segunda corrida sin cambios)', async () => {
+    // 1ª corrida: sella el recordatorio.
+    mockFindMany.mockResolvedValueOnce([enGracia('t', 55)])
+    const r1 = await GET(req(`Bearer ${SECRET}`))
+    expect((await r1.json()).recordatorios).toBe(1)
+
+    vi.clearAllMocks()
+    mockUpdate.mockResolvedValue({})
+    mockSendEmail.mockResolvedValue({ exito: true })
+
+    // 2ª corrida: el taller ya tiene recordatorioCuitEnviadoAt => NADA.
+    mockFindMany.mockResolvedValueOnce([
+      enGracia('t', 55, { recordatorioCuitEnviadoAt: diasAtras(0) }),
+    ])
+    const r2 = await GET(req(`Bearer ${SECRET}`))
+    const body2 = await r2.json()
+    expect(body2.recordatorios).toBe(0)
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/gracia.test.ts
+++ b/src/__tests__/gracia.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest'
 import {
   clasificarGracia,
   estadoCuentaInicial,
+  datosReactivacion,
+  planificarAccionGracia,
   DIAS_GRACIA,
   DIAS_VENCE_PRONTO,
 } from '@/compartido/lib/gracia'
@@ -102,5 +104,68 @@ describe('estadoCuentaInicial (estado al alta)', () => {
     const r = clasificarGracia({ verificadoAfip: false, inicioGracia }, INICIO)
     expect(r.estado).toBe('EN_GRACIA')
     expect(r.diasRestantes).toBe(DIAS_GRACIA)
+  })
+})
+
+describe('datosReactivacion (verificar CUIT reactiva)', () => {
+  it('vuelve a ACTIVA y limpia todo el reloj de gracia', () => {
+    expect(datosReactivacion()).toEqual({
+      estadoCuenta: 'ACTIVA',
+      inicioGracia: null,
+      inactivadaAt: null,
+      recordatorioCuitEnviadoAt: null,
+    })
+  })
+})
+
+describe('planificarAccionGracia (decisión del cron, pura)', () => {
+  const enGracia = (extra: Partial<Parameters<typeof planificarAccionGracia>[0]> = {}) => ({
+    verificadoAfip: false,
+    estadoCuenta: 'EN_GRACIA' as const,
+    inicioGracia: INICIO,
+    recordatorioCuitEnviadoAt: null,
+    ...extra,
+  })
+
+  it('día 49 => NADA (aún no vence pronto)', () => {
+    expect(planificarAccionGracia(enGracia(), masDias(49))).toBe('NADA')
+  })
+
+  it('día 50 => RECORDATORIO (entra a la ventana)', () => {
+    expect(planificarAccionGracia(enGracia(), masDias(DIAS_VENCE_PRONTO))).toBe('RECORDATORIO')
+  })
+
+  it('día 55 => RECORDATORIO', () => {
+    expect(planificarAccionGracia(enGracia(), masDias(55))).toBe('RECORDATORIO')
+  })
+
+  it('día 50 con recordatorio YA enviado => NADA (idempotencia)', () => {
+    expect(
+      planificarAccionGracia(enGracia({ recordatorioCuitEnviadoAt: masDias(50) }), masDias(52)),
+    ).toBe('NADA')
+  })
+
+  it('día 60 => INACTIVAR', () => {
+    expect(planificarAccionGracia(enGracia(), masDias(DIAS_GRACIA))).toBe('INACTIVAR')
+  })
+
+  it('día 65 => INACTIVAR (aunque nunca se haya mandado el recordatorio: inactivar tiene prioridad)', () => {
+    expect(planificarAccionGracia(enGracia(), masDias(65))).toBe('INACTIVAR')
+  })
+
+  it('corrida perdida 48 -> 53: en el día 53 sigue mandando el RECORDATORIO', () => {
+    expect(planificarAccionGracia(enGracia(), masDias(53))).toBe('RECORDATORIO')
+  })
+
+  it('taller verificado => NADA aunque tenga reloj', () => {
+    expect(planificarAccionGracia(enGracia({ verificadoAfip: true }), masDias(65))).toBe('NADA')
+  })
+
+  it('taller ya INACTIVA (no EN_GRACIA) => NADA (no re-actúa, idempotencia)', () => {
+    expect(planificarAccionGracia(enGracia({ estadoCuenta: 'INACTIVA' }), masDias(65))).toBe('NADA')
+  })
+
+  it('taller ACTIVA => NADA', () => {
+    expect(planificarAccionGracia(enGracia({ estadoCuenta: 'ACTIVA' }), masDias(65))).toBe('NADA')
   })
 })

--- a/src/app/api/cron/gracia-cuit/route.ts
+++ b/src/app/api/cron/gracia-cuit/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/compartido/lib/prisma'
+import { logActividad } from '@/compartido/lib/log'
+import { planificarAccionGracia, clasificarGracia } from '@/compartido/lib/gracia'
+import {
+  sendEmail,
+  buildRecordatorioCuitEmail,
+  buildCuentaInactivaEmail,
+} from '@/compartido/lib/email'
+
+// Cron diario de la gracia de CUIT (Etapa 2.3-B1). Vercel lo invoca según
+// `vercel.json#crons` con `Authorization: Bearer ${CRON_SECRET}`.
+//
+// Qué hace cada corrida, sobre los talleres con estadoCuenta = EN_GRACIA:
+//   - RECORDATORIO (ventana [50,60), sin recordatorio previo): manda el email día ~50
+//     y sella `recordatorioCuitEnviadoAt` (idempotencia: no re-envía).
+//   - INACTIVAR (>=60 días): estadoCuenta=INACTIVA + inactivadaAt=NOW + email de inactivación.
+//     El filtro por EN_GRACIA hace la inactivación un no-op repetible (idempotencia).
+//
+// La DECISIÓN vive en `planificarAccionGracia` (pura, testeada con fechas fabricadas);
+// esta route solo EJECUTA. La ventana (no el día exacto) tolera corridas perdidas.
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+function autorizado(req: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET
+  // Sin secret configurado, rechazar (no dejar el endpoint abierto por omisión).
+  if (!secret) return false
+  return req.headers.get('authorization') === `Bearer ${secret}`
+}
+
+export async function GET(req: NextRequest) {
+  if (!autorizado(req)) {
+    return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+  }
+
+  const ahora = new Date()
+
+  const talleres = await prisma.taller.findMany({
+    where: { estadoCuenta: 'EN_GRACIA' },
+    select: {
+      id: true,
+      nombre: true,
+      verificadoAfip: true,
+      estadoCuenta: true,
+      inicioGracia: true,
+      recordatorioCuitEnviadoAt: true,
+      user: { select: { email: true } },
+    },
+  })
+
+  let recordatorios = 0
+  let inactivaciones = 0
+  let sinEmail = 0
+  let errores = 0
+
+  for (const taller of talleres) {
+    const accion = planificarAccionGracia(taller, ahora)
+    if (accion === 'NADA') continue
+
+    const email = taller.user?.email
+
+    // Aislar cada taller: si uno falla (DB/email), no aborta el resto del batch.
+    try {
+      if (accion === 'RECORDATORIO') {
+        const { diasRestantes } = clasificarGracia(taller, ahora)
+        // Sellar ANTES de mandar (idempotencia): si el email falla, no se reintenta en la
+        // próxima corrida — evita spam por reintentos. El copy es "estimulante", no crítico.
+        await prisma.taller.update({
+          where: { id: taller.id },
+          data: { recordatorioCuitEnviadoAt: ahora },
+        })
+        if (email) {
+          await sendEmail({
+            to: email,
+            ...buildRecordatorioCuitEmail({ nombreTaller: taller.nombre, diasRestantes }),
+          })
+        } else {
+          sinEmail++
+        }
+        recordatorios++
+      } else if (accion === 'INACTIVAR') {
+        await prisma.taller.update({
+          where: { id: taller.id },
+          data: { estadoCuenta: 'INACTIVA', inactivadaAt: ahora },
+        })
+        if (email) {
+          await sendEmail({
+            to: email,
+            ...buildCuentaInactivaEmail({ nombreTaller: taller.nombre }),
+          })
+        } else {
+          sinEmail++
+        }
+        inactivaciones++
+      }
+    } catch (err) {
+      errores++
+      console.error('[CRON gracia-cuit] error en taller', taller.id, err)
+    }
+  }
+
+  const resumen = {
+    ok: true,
+    evaluados: talleres.length,
+    recordatorios,
+    inactivaciones,
+    sinEmail,
+    errores,
+    at: ahora.toISOString(),
+  }
+
+  console.log('[CRON gracia-cuit]', JSON.stringify(resumen))
+  logActividad('CRON_GRACIA_CUIT', null, resumen)
+
+  return NextResponse.json(resumen)
+}

--- a/src/app/api/cron/gracia-lanzamiento/route.ts
+++ b/src/app/api/cron/gracia-lanzamiento/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/compartido/lib/prisma'
+import { logActividad } from '@/compartido/lib/log'
+import { sendEmail, buildLanzamientoGraciaEmail } from '@/compartido/lib/email'
+
+// Email de LANZAMIENTO de la gracia (Etapa 2.3-B1). NO es parte del cron: es un one-off
+// que Gerardo dispara UNA vez, manualmente, poco después de promover B0 a prod (cuando
+// el backfill ya arrancó el reloj de 60 días de los talleres existentes sin verificar).
+//
+// Avisa a los talleres EN_GRACIA "tenés 60 días desde hoy para verificar tu CUIT". NO
+// toca `inicioGracia` (el reloj ya lo arrancó el backfill de B0) — solo notifica.
+//
+// Protegido con el mismo `CRON_SECRET`. Requiere POST + `?confirmar=SI` para evitar un
+// disparo accidental (mandaría un email masivo). No es idempotente: dispararlo dos veces
+// manda dos emails. Por eso es manual y una sola vez — ver el runbook.
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+function autorizado(req: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET
+  if (!secret) return false
+  return req.headers.get('authorization') === `Bearer ${secret}`
+}
+
+export async function POST(req: NextRequest) {
+  if (!autorizado(req)) {
+    return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+  }
+
+  const confirmar = req.nextUrl.searchParams.get('confirmar')
+  if (confirmar !== 'SI') {
+    return NextResponse.json(
+      { error: 'Falta confirmación', hint: 'Agregá ?confirmar=SI para disparar el envío masivo (one-off).' },
+      { status: 400 },
+    )
+  }
+
+  const talleres = await prisma.taller.findMany({
+    where: { estadoCuenta: 'EN_GRACIA' },
+    select: { id: true, nombre: true, user: { select: { email: true } } },
+  })
+
+  let enviados = 0
+  let sinEmail = 0
+  let errores = 0
+
+  for (const taller of talleres) {
+    const email = taller.user?.email
+    if (!email) {
+      sinEmail++
+      continue
+    }
+    try {
+      await sendEmail({ to: email, ...buildLanzamientoGraciaEmail({ nombreTaller: taller.nombre }) })
+      enviados++
+    } catch (err) {
+      errores++
+      console.error('[CRON gracia-lanzamiento] error en taller', taller.id, err)
+    }
+  }
+
+  const resumen = {
+    ok: true,
+    destinatarios: talleres.length,
+    enviados,
+    sinEmail,
+    errores,
+    at: new Date().toISOString(),
+  }
+
+  console.log('[CRON gracia-lanzamiento]', JSON.stringify(resumen))
+  logActividad('CRON_GRACIA_LANZAMIENTO', null, resumen)
+
+  return NextResponse.json(resumen)
+}

--- a/src/compartido/lib/arca.ts
+++ b/src/compartido/lib/arca.ts
@@ -1,6 +1,7 @@
 import Afip from '@afipsdk/afip.js'
 import { prisma } from './prisma'
 import { logActividad } from './log'
+import { datosReactivacion } from './gracia'
 import type { TipoInscripcionAfip, EstadoCuit } from '@prisma/client'
 
 // ---------------------------------------------------------------------------
@@ -181,6 +182,11 @@ export async function sincronizarTaller(tallerId: string, force = false, userId?
       data: {
         verificadoAfip: true,
         verificadoAfipAt: new Date(),
+        // Reactivacion automatica (2.3-B1): si el taller estaba EN_GRACIA o INACTIVA,
+        // verificar el CUIT lo vuelve a ACTIVA y limpia el reloj (inicioGracia/inactivadaAt/
+        // recordatorioCuitEnviadoAt). Para un taller ya ACTIVA, escribir ACTIVA + nulls es
+        // idempotente (no cambia nada). Sin trámite extra: pasa por el flujo ARCA existente.
+        ...datosReactivacion(),
         tipoInscripcionAfip: resultado.datos.tipoInscripcion,
         categoriaMonotributo: resultado.datos.categoriaMonotributo ?? null,
         estadoCuitAfip: resultado.datos.estadoCuit,

--- a/src/compartido/lib/email.ts
+++ b/src/compartido/lib/email.ts
@@ -296,6 +296,72 @@ export function buildInvitacionRegistroEmail(data: {
   }
 }
 
+// ── Gracia de CUIT (Etapa 2.3-B1) ──────────────────────────────────────────
+// Copy alineado con el banner del dashboard (BannerGracia). La regla de comms del
+// piloto: si se menciona al equipo, se firma "Coordinación" (nunca "Estado").
+
+/** Recordatorio del día ~50: countdown estimulante, CTA a verificar el CUIT. */
+export function buildRecordatorioCuitEmail(data: {
+  nombreTaller: string
+  diasRestantes: number
+}): { subject: string; html: string } {
+  const dias = data.diasRestantes === 1 ? 'queda 1 día' : `quedan ${data.diasRestantes} días`
+  const formalizarUrl = `${appBaseUrl}/taller/formalizacion`
+  return {
+    subject: `Te ${dias} para verificar tu CUIT - PDT`,
+    html: emailWrapper(`
+      <h2 style="margin: 0 0 12px; color: #b45309;">Te ${dias} para verificar tu CUIT</h2>
+      <p>Hola <strong>${data.nombreTaller}</strong>, para aparecer en el directorio y cotizar pedidos necesitás verificar tu CUIT.</p>
+      <p style="background: #fffbeb; border-left: 4px solid #f59e0b; padding: 12px 16px; border-radius: 4px;">
+        Todavía estás a tiempo: te <strong>${dias}</strong> dentro del período de gracia. Verificarlo lleva unos minutos.
+      </p>
+      <p>Mientras tanto seguís teniendo acceso a la Academia y los Recursos. Una vez verificado tu CUIT vas a poder cotizar pedidos y aparecer en el directorio.</p>
+      ${btnPrimario(formalizarUrl, 'Verificar mi CUIT')}
+      <p style="color: #64748b; margin-top: 16px;">Cualquier duda, escribinos y te acompañamos.<br><strong>Equipo de Coordinación</strong> · Plataforma Digital Textil</p>
+    `),
+  }
+}
+
+/** Aviso al momento de inactivarse (día 60): la cuenta quedó inactiva, invita a reactivar. */
+export function buildCuentaInactivaEmail(data: {
+  nombreTaller: string
+}): { subject: string; html: string } {
+  const formalizarUrl = `${appBaseUrl}/taller/formalizacion`
+  return {
+    subject: 'Tu cuenta quedó inactiva - PDT',
+    html: emailWrapper(`
+      <h2 style="margin: 0 0 12px; color: #dc2626;">Tu cuenta quedó inactiva</h2>
+      <p>Hola <strong>${data.nombreTaller}</strong>, pasaron los 60 días del período de gracia y tu cuenta quedó <strong>inactiva</strong> porque tu CUIT todavía no está verificado.</p>
+      <p style="background: #fef2f2; border-left: 4px solid #dc2626; padding: 12px 16px; border-radius: 4px;">
+        <strong>Tus datos siguen acá.</strong> Verificá tu CUIT para reactivar tu cuenta al instante y volver a aparecer en el directorio — sin trámites ni cargar todo de nuevo.
+      </p>
+      <p>Mientras tanto seguís teniendo acceso a la Academia y los Recursos.</p>
+      ${btnPrimario(formalizarUrl, 'Verificar mi CUIT y reactivar')}
+      <p style="color: #64748b; margin-top: 16px;">Estamos para ayudarte a completar el paso.<br><strong>Equipo de Coordinación</strong> · Plataforma Digital Textil</p>
+    `),
+  }
+}
+
+/** Email de lanzamiento (one-off manual): arranca el reloj de 60 días para los existentes. */
+export function buildLanzamientoGraciaEmail(data: {
+  nombreTaller: string
+}): { subject: string; html: string } {
+  const formalizarUrl = `${appBaseUrl}/taller/formalizacion`
+  return {
+    subject: 'Verificá tu CUIT en los próximos 60 días - PDT',
+    html: emailWrapper(`
+      <h2 style="margin: 0 0 12px; color: #1e3a5f;">Verificá tu CUIT para seguir activo</h2>
+      <p>Hola <strong>${data.nombreTaller}</strong>, estamos poniendo en marcha la verificación de CUIT en la Plataforma Digital Textil.</p>
+      <p style="background: #f0f9ff; border-left: 4px solid #1e3a5f; padding: 12px 16px; border-radius: 4px;">
+        Tenés <strong>60 días desde hoy</strong> para verificar tu CUIT. Una vez verificado vas a aparecer en el directorio y vas a poder cotizar pedidos de marcas formales.
+      </p>
+      <p>Es un trámite de pocos minutos. Si no lo verificás dentro de los 60 días, tu cuenta pasa a inactiva — pero tus datos quedan guardados y podés reactivarla verificando el CUIT en cualquier momento.</p>
+      ${btnPrimario(formalizarUrl, 'Verificar mi CUIT')}
+      <p style="color: #64748b; margin-top: 16px;">Cualquier duda, escribinos y te acompañamos en el proceso.<br><strong>Equipo de Coordinación</strong> · Plataforma Digital Textil</p>
+    `),
+  }
+}
+
 export function buildPedidoDisponibleEmail(data: {
   nombreTaller: string
   nombreMarca: string

--- a/src/compartido/lib/gracia.ts
+++ b/src/compartido/lib/gracia.ts
@@ -81,3 +81,55 @@ export function estadoCuentaInicial(
     ? { estadoCuenta: 'ACTIVA', inicioGracia: null }
     : { estadoCuenta: 'EN_GRACIA', inicioGracia: ahora }
 }
+
+/**
+ * Campos a escribir cuando un taller EN_GRACIA o INACTIVA verifica su CUIT (B1):
+ * vuelve a ACTIVA y se limpia todo el reloj (inicioGracia, inactivadaAt y el marcador
+ * de idempotencia del recordatorio). PURA — la usa `sincronizarTaller` al setear
+ * `verificadoAfip: true`, asi la reactivacion es automatica y sin trámite extra.
+ */
+export function datosReactivacion(): {
+  estadoCuenta: 'ACTIVA'
+  inicioGracia: null
+  inactivadaAt: null
+  recordatorioCuitEnviadoAt: null
+} {
+  return {
+    estadoCuenta: 'ACTIVA',
+    inicioGracia: null,
+    inactivadaAt: null,
+    recordatorioCuitEnviadoAt: null,
+  }
+}
+
+/**
+ * Accion que el cron diario (B1) debe tomar sobre un taller EN_GRACIA a la fecha `ahora`.
+ * PURA — separa la DECISION (testeable con fechas fabricadas) de la EJECUCION (writes +
+ * emails en la route). El cron ya filtra por `estadoCuenta = EN_GRACIA`; esta funcion
+ * re-chequea de forma defensiva y clasifica:
+ *
+ *   - INACTIVAR    : el reloj llego a >=60 dias (clasificacion INACTIVA).
+ *   - RECORDATORIO : esta en la ventana [50, 60) y NO se envio el recordatorio todavia
+ *                    (idempotencia por `recordatorioCuitEnviadoAt`).
+ *   - NADA         : verificado, no EN_GRACIA, dia <50, o recordatorio ya enviado.
+ *
+ * La INACTIVACION tiene prioridad sobre el RECORDATORIO: si el cron se saltea corridas y
+ * el taller salta directo a >=60 sin haber recibido el recordatorio, se inactiva (y la
+ * route manda el email de inactivacion, no el de recordatorio).
+ */
+export type AccionGracia = 'NADA' | 'RECORDATORIO' | 'INACTIVAR'
+
+export function planificarAccionGracia(
+  taller: TallerGracia & {
+    estadoCuenta?: string | null
+    recordatorioCuitEnviadoAt?: Date | null
+  },
+  ahora: Date,
+): AccionGracia {
+  if (taller.verificadoAfip || taller.estadoCuenta !== 'EN_GRACIA') return 'NADA'
+
+  const { estado } = clasificarGracia(taller, ahora)
+  if (estado === 'INACTIVA') return 'INACTIVAR'
+  if (estado === 'VENCE_PRONTO' && !taller.recordatorioCuitEnviadoAt) return 'RECORDATORIO'
+  return 'NADA'
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,7 @@
 {
   "regions": ["gru1"],
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"gh-pages\" ]; then exit 0; fi; exit 1"
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"gh-pages\" ]; then exit 0; fi; exit 1",
+  "crons": [
+    { "path": "/api/cron/gracia-cuit", "schedule": "0 11 * * *" }
+  ]
 }


### PR DESCRIPTION
## Etapa 2.3-B1 — cron de gracia + emails + reactivación automática + email de lanzamiento

**Último PR de la Etapa 2.** Pone en movimiento el modelo de B0 (enum `EstadoCuenta`, `clasificarGracia` pura, banners). No mergear — QA de Sergio (demo del cron + INACTIVA).

### Qué construye

**1. Cron diario** `GET /api/cron/gracia-cuit` (nodejs, force-dynamic, `Authorization: Bearer ${CRON_SECRET}` → 401 sin secret). `vercel.json#crons`: `0 11 * * *` (08:00 ART). Cada corrida, sobre talleres `EN_GRACIA`:
- **Recordatorio** ventana [50,60) sin recordatorio previo → email + sella `recordatorioCuitEnviadoAt` (idempotente).
- **Inactivación** ≥60 días → `estadoCuenta=INACTIVA` + `inactivadaAt` + email (no-op repetible por el filtro `EN_GRACIA`).
- Decisión pura en `planificarAccionGracia` (testeada con fechas fabricadas); la route solo ejecuta. Ventana (no día exacto) → tolera corridas perdidas. Cada corrida loguea `{evaluados, recordatorios, inactivaciones, sinEmail, errores}`. Cada taller aislado en try/catch.

**2. Reactivación automática** — `sincronizarTaller` (arca.ts): al verificar CUIT → `ACTIVA` + reloj limpio (`datosReactivacion`). Cubre `/api/estado/arca/reverificar` + cualquier caller. Sin trámite extra.

**3. Emails** (Resend, firma "Coordinación"): `buildRecordatorioCuitEmail`, `buildCuentaInactivaEmail`, `buildLanzamientoGraciaEmail`. Copy alineado con el banner de B0.

**4. Email de lanzamiento** (one-off manual, NO cron): `POST /api/cron/gracia-lanzamiento?confirmar=SI` protegido con `CRON_SECRET`. Lo dispara Gerardo una vez al promover a prod. No idempotente por diseño (por eso manual + `?confirmar=SI`).

### Tests
- `gracia.test.ts` — `planificarAccionGracia` (día 49/50/55/60/65, recordatorio ya enviado, corrida perdida, no-EN_GRACIA, verificado) + `datosReactivacion`.
- `cron-gracia.test.ts` — route: 401 (sin/secret malo/sin CRON_SECRET) + recordatorio+sello + inactivación + batch mixto + sin email + **idempotencia doble-corrida**.
- `arca.test.ts` — `sincronizarTaller` reactiva (ACTIVA + reloj limpio).

### Pendiente para Gerardo
- **`CRON_SECRET`** — setear en Vercel (Production + Preview). Sin el secret el endpoint responde 401 (no queda abierto).

### Runbook
`.claude/specs/v4-etapa2-3b1-runbook.md` — setup CRON_SECRET, demo de INACTIVA para Sergio (reloj a 65 + cron manual), email de lanzamiento, a dónde van los emails en DEV/preview.

NO TOCADO: gates comerciales (verificados en B0), login (Academia/Recursos abiertos), `clasificarGracia` (el cron la usa, no la reimplementa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)