### PR TITLE
fix: eliminar Recursos + ajustes copy (aprobación B1) + regresión onboarding

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,13 @@
 ## 2026-07-09
 
 ### Gerardo Breard
+- **16:55** `39f10e7` — fix: eliminar seccion Recursos + ajustes de copy (aprobacion B1) + regresion onboarding
+  - `src/app/(public)/recursos/page.tsx`
+  - `src/compartido/componentes/layout/footer.tsx`
+  - `src/compartido/lib/content/institutional.ts`
+  - `src/compartido/lib/email.ts`
+  - `src/compartido/lib/onboarding.ts`
+  - `src/taller/componentes/banner-gracia.tsx`
 - **19:37** `bacbf27` — docs(discovery): circuito CUIT + limbo verificacion ARCA (esperando decision Sergio)
   - `.claude/specs/v4-circuito-cuit-discovery.md`
 

--- a/src/app/(public)/recursos/page.tsx
+++ b/src/app/(public)/recursos/page.tsx
@@ -1,14 +1,19 @@
-import { EmptyState } from '@/compartido/componentes/ui/empty-state'
-import { Construction } from 'lucide-react'
+import { redirect } from 'next/navigation'
+import { auth } from '@/compartido/lib/auth'
 
-export default function RecursosPage() {
-  return (
-    <div className="max-w-7xl mx-auto px-4 py-16">
-      <EmptyState
-        icon={<Construction className="w-12 h-12 text-gray-400" />}
-        titulo="Recursos"
-        mensaje="Esta secci\u00f3n estar\u00e1 disponible pr\u00f3ximamente."
-      />
-    </div>
-  )
+// /recursos se descontinuó (decisión de Sergio al aprobar B1): era una página vacía
+// "Próximamente" que el banner del taller inactivo prometía — promesa incumplida. No se
+// elimina "a secas" para no romper links viejos ni menciones en emails ya enviados:
+// redirige a la sección de cursos.
+//
+// Redirect CONTEXTUAL: un taller logueado va a su Academia (/taller/aprender); cualquier
+// otro caso (incluido anónimo) a la Academia pública. Es TEMPORAL (no permanente) a
+// propósito: como el destino depende de la sesión, un 308 cacheado por el browser
+// mandaría siempre al mismo lugar y rompería el contexto (un anónimo cachearía
+// /academia-publica y no re-evaluaría al loguearse como taller).
+export const dynamic = 'force-dynamic'
+
+export default async function RecursosPage() {
+  const session = await auth()
+  redirect(session?.user?.role === 'TALLER' ? '/taller/aprender' : '/academia-publica')
 }

--- a/src/compartido/componentes/layout/footer.tsx
+++ b/src/compartido/componentes/layout/footer.tsx
@@ -46,13 +46,13 @@ export function Footer() {
             </ul>
           </div>
 
-          {/* Col 3 — Recursos */}
+          {/* Col 3 — Enlaces útiles */}
           <div>
             <h3 className="font-overpass font-bold text-white text-xs uppercase tracking-widest mb-3">
-              Recursos
+              Enlaces útiles
             </h3>
             <ul className="space-y-2">
-              {FOOTER_LINKS.recursos.map(link => (
+              {FOOTER_LINKS.enlacesUtiles.map(link => (
                 <li key={link.href}>
                   <Link href={link.href} className="text-sm hover:text-white transition-colors">
                     {link.label}

--- a/src/compartido/lib/content/institutional.ts
+++ b/src/compartido/lib/content/institutional.ts
@@ -12,7 +12,7 @@ export const FOOTER_LINKS = {
     { label: '\u00bfC\u00f3mo funciona?', href: '/#como-funciona' },
     { label: 'Impacto', href: '/#impacto' },
   ],
-  recursos: [
+  enlacesUtiles: [
     { label: 'Centro de ayuda', href: '/ayuda' },
     { label: 'Contacto', href: 'mailto:soporte@plataformatextil.ar' },
   ],

--- a/src/compartido/lib/email.ts
+++ b/src/compartido/lib/email.ts
@@ -315,7 +315,7 @@ export function buildRecordatorioCuitEmail(data: {
       <p style="background: #fffbeb; border-left: 4px solid #f59e0b; padding: 12px 16px; border-radius: 4px;">
         Todavía estás a tiempo: te <strong>${dias}</strong> dentro del período de gracia. Verificarlo lleva unos minutos.
       </p>
-      <p>Mientras tanto seguís teniendo acceso a la Academia y los Recursos. Una vez verificado tu CUIT vas a poder cotizar pedidos y aparecer en el directorio.</p>
+      <p>Mientras tanto seguís teniendo acceso a la Academia y a explorar la red de talleres. Una vez verificado tu CUIT vas a poder cotizar pedidos y aparecer en el directorio.</p>
       ${btnPrimario(formalizarUrl, 'Verificar mi CUIT')}
       <p style="color: #64748b; margin-top: 16px;">Cualquier duda, escribinos y te acompañamos.<br><strong>Equipo de Coordinación</strong> · Plataforma Digital Textil</p>
     `),
@@ -335,7 +335,7 @@ export function buildCuentaInactivaEmail(data: {
       <p style="background: #fef2f2; border-left: 4px solid #dc2626; padding: 12px 16px; border-radius: 4px;">
         <strong>Tus datos siguen acá.</strong> Verificá tu CUIT para reactivar tu cuenta al instante y volver a aparecer en el directorio — sin trámites ni cargar todo de nuevo.
       </p>
-      <p>Mientras tanto seguís teniendo acceso a la Academia y los Recursos.</p>
+      <p>Mientras tanto seguís teniendo acceso a la Academia y a explorar la red de talleres.</p>
       ${btnPrimario(formalizarUrl, 'Verificar mi CUIT y reactivar')}
       <p style="color: #64748b; margin-top: 16px;">Estamos para ayudarte a completar el paso.<br><strong>Equipo de Coordinación</strong> · Plataforma Digital Textil</p>
     `),

--- a/src/compartido/lib/onboarding.ts
+++ b/src/compartido/lib/onboarding.ts
@@ -94,8 +94,13 @@ export async function calcularPasosTaller(userId: string): Promise<PasoOnboardin
       href: '/taller/formalizacion',
     },
     {
+      // Reformulado (aprobación B1 de Sergio): "Recibir tu primera cotización aceptada"
+      // sonaba a marketplace/gamificación. Se acordó reformular en el QA de #439 (lista
+      // "PR aparte, no bloquean piloto"), pero nunca llegó a aplicarse — no fue rollback.
+      // La condición de completado sigue siendo la misma (tener una cotización aceptada =
+      // haberte conectado con una marca).
       id: 'cotizacion',
-      texto: 'Recibir tu primera cotizacion aceptada',
+      texto: 'Conectarte con tu primera marca',
       completado: (taller?.cotizaciones.length ?? 0) > 0,
       href: '/taller/pedidos/disponibles',
     },

--- a/src/taller/componentes/banner-gracia.tsx
+++ b/src/taller/componentes/banner-gracia.tsx
@@ -32,7 +32,7 @@ export function BannerGracia({
         </p>
         <p className="text-sm text-red-700">
           Verificá tu CUIT para reactivarla y aparecer en el directorio. Mientras tanto,
-          seguís teniendo acceso a la Academia y los Recursos.
+          seguís teniendo acceso a la Academia y a explorar la red de talleres.
         </p>
         <Link
           href="/taller/formalizacion"
@@ -53,7 +53,7 @@ export function BannerGracia({
       </p>
       <p className="text-sm text-amber-700">
         Una vez verificado tu CUIT vas a poder cotizar pedidos y aparecer en el directorio.
-        Mientras tanto, podés capacitarte en la Academia y usar los Recursos.
+        Mientras tanto, podés capacitarte en la Academia y explorar la red de talleres.
       </p>
       <Link
         href="/taller/formalizacion"


### PR DESCRIPTION
Cierra los ajustes que pidió Sergio al aprobar B1 + una regresión detectada. **No mergear hasta QA de Sergio** (copy/navegación visible).

## Los 5 puntos
1. **/recursos → redirect** (no se elimina a secas). Era una página vacía "Próximamente" que el banner del taller inactivo prometía. Redirect **contextual**: taller logueado → `/taller/aprender`, resto (anónimo incluido) → `/academia-publica`. Es **temporal (307)**, no permanente: el destino depende de la sesión y un 308 cacheado por rol rompería el contexto.
   - ⚠️ **Nota para Sergio:** no existe ninguna ruta `/cursos` en el proyecto (tu instrucción decía `/cursos`). La sección de cursos vive en `/academia-publica` (pública) y `/taller/aprender` (taller). Por eso aterriza ahí. Si querés oficializar el URL `/cursos`, es un PR trivial aparte.
   - ⚠️ `/academia-publica` hoy es **también** un placeholder "Próximamente"; pero el taller (audiencia del banner de gracia) cae en `/taller/aprender`, que es la Academia real.
2. **Nav del taller:** ya **no** había item "Recursos" (verificado en `TABS_BY_ROLE.TALLER` y `user-sidebar`). Nada que remover — punto ya satisfecho.
3. **Copy gracia/inactiva:** quitada la mención a "Recursos" del banner y de los 2 emails de B1 que la mencionaban (recordatorio + inactiva). Banner INACTIVA con el copy nuevo de Sergio. *(El 3er email de B1 —lanzamiento— no mencionaba Recursos.)*
4. **Footer:** columna "Recursos" → **"Enlaces útiles"** (Centro de ayuda + Contacto; no duplicaba "Plataforma", no se consolida).
5. **Regresión onboarding:** "Recibir tu primera cotización aceptada" → **"Conectarte con tu primera marca"**.

## Diagnóstico de la regresión (punto 5)
**Veredicto: nunca-aplicado, NO rollback.**
- Pickaxe `git log -S "Conectarte con tu primera marca" --all` → **vacío** (nunca se escribió en ninguna rama).
- El texto viejo aparece en **un solo commit** (`f59946b`, T-03, su introducción original); nunca se modificó después.
- `#439b` (`43738fc`) tocó `onboarding.ts` pero solo re-indentó una línea; no tocó el texto del paso.
- Coincide con la hipótesis del QA de #439: estaba en la lista "PR aparte, no bloquean piloto" y nunca tuvo su PR.

## Verificación
- Typecheck limpio (`tsc --noEmit`).
- **767/767** tests vitest (52 archivos).
- Banner INACTIVA verificado **en vivo** con `demo.gracia@pdt.org.ar` (INACTIVA, 68 días) a **320 y 375px**: copy nuevo, sin "Recursos", sin overflow.
- Redirect `/recursos` verificado en vivo: anónimo → `/academia-publica`, taller → `/taller/aprender`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)