### PR TITLE
feat: circuito CUIT Pieza D — reintento ARCA en el cron de gracia (PR-1)

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -1,5 +1,12 @@
 # Daily Log
 
+## 2026-07-13
+
+### Gerardo Breard
+- **14:18** `f0d4a59` — chore: redeploy preview — tomar ARCA_PROVIDER=mock (demo Pieza D)
+
+
+
 ## 2026-07-11
 
 ### Gerardo Breard

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,10 @@
 ## 2026-07-11
 
 ### Gerardo Breard
+- **18:16** `db3686b` — feat: circuito CUIT Pieza D — reintento ARCA en el cron de gracia
+  - `src/__tests__/cron-gracia.test.ts`
+  - `src/app/api/cron/gracia-cuit/route.ts`
+
 - **17:45** `844cddc` — docs(spec): circuito CUIT — spec de implementación A+D+B (DECIDIDO)
   - `.claude/specs/v4-circuito-cuit-implementacion.md`
 

--- a/src/__tests__/cron-gracia.test.ts
+++ b/src/__tests__/cron-gracia.test.ts
@@ -5,16 +5,18 @@ import { NextRequest } from 'next/server'
 // e idempotencia. La DECISIÓN pura (planificarAccionGracia) se testea en gracia.test.ts;
 // acá se verifica que la ROUTE ejecuta los writes + emails correctos.
 
-const { mockFindMany, mockUpdate, mockSendEmail } = vi.hoisted(() => ({
+const { mockFindMany, mockUpdate, mockSendEmail, mockSincronizarTaller } = vi.hoisted(() => ({
   mockFindMany: vi.fn(),
   mockUpdate: vi.fn(),
   mockSendEmail: vi.fn().mockResolvedValue({ exito: true }),
+  mockSincronizarTaller: vi.fn(),
 }))
 
 vi.mock('@/compartido/lib/prisma', () => ({
   prisma: { taller: { findMany: mockFindMany, update: mockUpdate } },
 }))
 vi.mock('@/compartido/lib/log', () => ({ logActividad: vi.fn() }))
+vi.mock('@/compartido/lib/arca', () => ({ sincronizarTaller: mockSincronizarTaller }))
 vi.mock('@/compartido/lib/email', async (importActual) => {
   const actual = await importActual<typeof import('@/compartido/lib/email')>()
   return { ...actual, sendEmail: mockSendEmail }
@@ -24,6 +26,21 @@ import { GET } from '@/app/api/cron/gracia-cuit/route'
 
 const SECRET = 'test-cron-secret'
 const diasAtras = (n: number) => new Date(Date.now() - n * 86_400_000)
+
+// Helper compartido: un taller EN_GRACIA realista (con CUIT => elegible para el reintento
+// de Pieza D). Por defecto el reintento ARCA falla (mock en beforeEach) => cae al flujo
+// normal de recordatorio/inactivación, así los tests de acciones siguen valiendo.
+const enGracia = (id: string, dias: number, extra: Record<string, unknown> = {}) => ({
+  id,
+  nombre: `Taller ${id}`,
+  cuit: '20111111112',
+  verificadoAfip: false,
+  estadoCuenta: 'EN_GRACIA',
+  inicioGracia: diasAtras(dias),
+  recordatorioCuitEnviadoAt: null,
+  user: { email: `${id}@pdt.org.ar` },
+  ...extra,
+})
 
 function req(auth?: string): NextRequest {
   return new NextRequest('http://localhost/api/cron/gracia-cuit', {
@@ -35,6 +52,8 @@ beforeEach(() => {
   vi.clearAllMocks()
   mockSendEmail.mockResolvedValue({ exito: true })
   mockUpdate.mockResolvedValue({})
+  // Default: ARCA no valida en el reintento (no responde) => el taller sigue su curso normal.
+  mockSincronizarTaller.mockResolvedValue({ exitosa: false, error: 'ARCA_NO_RESPONDE', duracionMs: 0 })
   process.env.CRON_SECRET = SECRET
 })
 
@@ -61,17 +80,6 @@ describe('GET /api/cron/gracia-cuit — auth', () => {
 })
 
 describe('GET /api/cron/gracia-cuit — acciones', () => {
-  const enGracia = (id: string, dias: number, extra: Record<string, unknown> = {}) => ({
-    id,
-    nombre: `Taller ${id}`,
-    verificadoAfip: false,
-    estadoCuenta: 'EN_GRACIA',
-    inicioGracia: diasAtras(dias),
-    recordatorioCuitEnviadoAt: null,
-    user: { email: `${id}@pdt.org.ar` },
-    ...extra,
-  })
-
   it('día ~55 => manda recordatorio y sella recordatorioCuitEnviadoAt', async () => {
     mockFindMany.mockResolvedValue([enGracia('t-remind', 55)])
     const res = await GET(req(`Bearer ${SECRET}`))
@@ -177,5 +185,90 @@ describe('GET /api/cron/gracia-cuit — acciones', () => {
     const body2 = await r2.json()
     expect(body2.recordatorios).toBe(0)
     expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /api/cron/gracia-cuit — Pieza D (reintento ARCA)', () => {
+  it('reintento exitoso => reactiva y NO manda email ni sella/inactiva esa corrida', async () => {
+    // Día 55: sin el reintento recibiría el recordatorio. Pero ARCA valida => se reactiva y sale.
+    mockSincronizarTaller.mockResolvedValueOnce({ exitosa: true, duracionMs: 40 })
+    mockFindMany.mockResolvedValue([enGracia('t-cura', 55)])
+
+    const res = await GET(req(`Bearer ${SECRET}`))
+    const body = await res.json()
+
+    expect(mockSincronizarTaller).toHaveBeenCalledWith('t-cura', true)
+    expect(body.reintentosArca).toBe(1)
+    expect(body.reactivacionesAuto).toBe(1)
+    expect(body.recordatorios).toBe(0)
+    expect(body.inactivaciones).toBe(0)
+    // El cron NO hace su propio update (la reactivación la hizo sincronizarTaller) ni manda email.
+    expect(mockUpdate).not.toHaveBeenCalled()
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('reintento fallido (ARCA caído) => cae al flujo normal y NO cuenta como error', async () => {
+    // Default mock: exitosa:false / ARCA_NO_RESPONDE. Día 55 => recordatorio normal.
+    mockFindMany.mockResolvedValue([enGracia('t-caido', 55)])
+
+    const res = await GET(req(`Bearer ${SECRET}`))
+    const body = await res.json()
+
+    expect(body.reintentosArca).toBe(1)
+    expect(body.reactivacionesAuto).toBe(0)
+    expect(body.recordatorios).toBe(1)
+    expect(body.errores).toBe(0) // un fallo de ARCA NO es error del cron
+    expect(mockSendEmail).toHaveBeenCalledTimes(1)
+  })
+
+  it('reintento exitoso día ~61 => evita la inactivación', async () => {
+    mockSincronizarTaller.mockResolvedValueOnce({ exitosa: true, duracionMs: 30 })
+    mockFindMany.mockResolvedValue([enGracia('t-borde', 61)])
+
+    const res = await GET(req(`Bearer ${SECRET}`))
+    const body = await res.json()
+
+    expect(body.reactivacionesAuto).toBe(1)
+    expect(body.inactivaciones).toBe(0)
+    expect(mockUpdate).not.toHaveBeenCalled()
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('taller sin CUIT => no se reintenta, cae al flujo normal', async () => {
+    mockFindMany.mockResolvedValue([enGracia('t-sincuit', 55, { cuit: null })])
+
+    const res = await GET(req(`Bearer ${SECRET}`))
+    const body = await res.json()
+
+    expect(mockSincronizarTaller).not.toHaveBeenCalled()
+    expect(body.reintentosArca).toBe(0)
+    expect(body.recordatorios).toBe(1) // sigue su curso: recibe el recordatorio del día 55
+  })
+
+  it('reintento diario: se llama a ARCA en cada taller elegible (sin backoff)', async () => {
+    mockFindMany.mockResolvedValue([
+      enGracia('a', 10), // joven, igual se reintenta
+      enGracia('b', 55),
+      enGracia('c', 30),
+    ])
+
+    const res = await GET(req(`Bearer ${SECRET}`))
+    const body = await res.json()
+
+    expect(mockSincronizarTaller).toHaveBeenCalledTimes(3)
+    expect(body.reintentosArca).toBe(3)
+  })
+
+  it('error REAL de sincronizarTaller (DB) sí cuenta como error y no aborta el batch', async () => {
+    mockSincronizarTaller
+      .mockRejectedValueOnce(new Error('DB caída'))          // taller a: throw
+      .mockResolvedValueOnce({ exitosa: true, duracionMs: 20 }) // taller b: valida
+    mockFindMany.mockResolvedValue([enGracia('a', 55), enGracia('b', 55)])
+
+    const res = await GET(req(`Bearer ${SECRET}`))
+    const body = await res.json()
+
+    expect(body.errores).toBe(1)
+    expect(body.reactivacionesAuto).toBe(1) // el segundo taller no fue afectado por el fallo del primero
   })
 })

--- a/src/app/api/cron/gracia-cuit/route.ts
+++ b/src/app/api/cron/gracia-cuit/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/compartido/lib/prisma'
 import { logActividad } from '@/compartido/lib/log'
 import { planificarAccionGracia, clasificarGracia } from '@/compartido/lib/gracia'
+import { sincronizarTaller } from '@/compartido/lib/arca'
 import {
   sendEmail,
   buildRecordatorioCuitEmail,
@@ -12,6 +13,12 @@ import {
 // `vercel.json#crons` con `Authorization: Bearer ${CRON_SECRET}`.
 //
 // Qué hace cada corrida, sobre los talleres con estadoCuenta = EN_GRACIA:
+//   - REINTENTO ARCA (Pieza D del circuito CUIT V4): ANTES de clasificar, para cada taller
+//     sin verificar con CUIT, reintenta `sincronizarTaller(force=true)`. Si ARCA valida, el
+//     taller se reactiva solo (datosReactivacion) y sale de la gracia SIN recibir el email
+//     ni inactivarse esa corrida. Autocura el caso "CUIT correcto que falló por ARCA caído
+//     al registrarse". Reintento DIARIO sin backoff (población de piloto chica); un fallo de
+//     ARCA (no responde / CUIT malo) NO es error del cron: cae al flujo normal de abajo.
 //   - RECORDATORIO (ventana [50,60), sin recordatorio previo): manda el email día ~50
 //     y sella `recordatorioCuitEnviadoAt` (idempotencia: no re-envía).
 //   - INACTIVAR (>=60 días): estadoCuenta=INACTIVA + inactivadaAt=NOW + email de inactivación.
@@ -42,6 +49,7 @@ export async function GET(req: NextRequest) {
     select: {
       id: true,
       nombre: true,
+      cuit: true,
       verificadoAfip: true,
       estadoCuenta: true,
       inicioGracia: true,
@@ -54,15 +62,30 @@ export async function GET(req: NextRequest) {
   let inactivaciones = 0
   let sinEmail = 0
   let errores = 0
+  let reintentosArca = 0      // Pieza D: cuántos talleres se reintentaron contra ARCA
+  let reactivacionesAuto = 0  // Pieza D: cuántos validaron en el reintento y se reactivaron
 
   for (const taller of talleres) {
-    const accion = planificarAccionGracia(taller, ahora)
-    if (accion === 'NADA') continue
-
     const email = taller.user?.email
 
-    // Aislar cada taller: si uno falla (DB/email), no aborta el resto del batch.
+    // Aislar cada taller: si uno falla (DB/email/ARCA), no aborta el resto del batch.
     try {
+      // Pieza D — reintento ARCA antes de clasificar. Un fallo de ARCA (no responde o CUIT
+      // malo) devuelve { exitosa:false } SIN lanzar => no cuenta como error del cron; solo un
+      // error real (DB) cae al catch. Si valida, `sincronizarTaller` ya dejó el taller ACTIVA
+      // (datosReactivacion) => `continue` sin recordatorio ni inactivación esta corrida.
+      if (!taller.verificadoAfip && taller.cuit) {
+        reintentosArca++
+        const rescate = await sincronizarTaller(taller.id, true)
+        if (rescate.exitosa) {
+          reactivacionesAuto++
+          continue
+        }
+      }
+
+      const accion = planificarAccionGracia(taller, ahora)
+      if (accion === 'NADA') continue
+
       if (accion === 'RECORDATORIO') {
         const { diasRestantes } = clasificarGracia(taller, ahora)
         // Sellar ANTES de mandar (idempotencia): si el email falla, no se reintenta en la
@@ -104,6 +127,8 @@ export async function GET(req: NextRequest) {
   const resumen = {
     ok: true,
     evaluados: talleres.length,
+    reintentosArca,
+    reactivacionesAuto,
     recordatorios,
     inactivaciones,
     sinEmail,


### PR DESCRIPTION
## Qué

**Pieza D** del circuito CUIT V4 (prioridad 1 de Sergio: *"el caso invisible que nadie atiende"*). Antes de clasificar recordatorio/inactivación, el cron de gracia **reintenta la verificación ARCA** de cada taller `EN_GRACIA` sin verificar con CUIT. Si ARCA valida, el taller se **reactiva solo** (`datosReactivacion`) y sale de la gracia **sin recibir el email ni inactivarse esa corrida**.

Autocura el escenario del "limbo": un **CUIT correcto que falló por ARCA caído al registrarse** hoy se inactiva a los 60 días aunque el número sea válido. Con D, cada corrida diaria lo reintenta y lo sana en cuanto ARCA vuelve.

## Cómo (spec §2)

- **Reintento DIARIO sin backoff** — población de piloto chica, simplicidad primero (decisión de Gerardo, §8.1 del spec). Si crece post-piloto, se agrega backoff entonces.
- **Orden dentro del `for`:** reintento ARCA → si valida, `continue` (no recordatorio, no inactivación) → si no, sigue el flujo normal intacto.
- **Un fallo de ARCA NO es error del cron:** `sincronizarTaller` devuelve `{exitosa:false}` sin lanzar → cae al flujo normal. Solo un error real (DB) va al `catch` y suma `errores`.
- **Reintento dentro del `try` de aislamiento por taller:** un fallo no aborta el batch.
- **Resumen extendido:** `reintentosArca` + `reactivacionesAuto` para la bitácora/observabilidad.

## Alcance

- **Solo Pieza D.** A (self-service del taller) y B (override de COORD) van en PR-2 (comparten backend). Ver spec §6.
- **No toca** el flujo documental, `verificadoAfip` como fuente de verdad (lo sigue escribiendo solo `sincronizarTaller`), ni el gate comercial. Invariantes del spec §1 respetados.

## Tests (6 nuevos, suite 773/773 verde)

- reintento exitoso → reactiva, no manda email ni sella/inactiva esa corrida
- reintento fallido (ARCA caído) → cae al flujo normal, `errores=0`
- reintento exitoso día ~61 → evita la inactivación
- taller sin CUIT → no se reintenta
- reintento diario → se llama a ARCA en cada taller elegible (sin backoff)
- error real de DB en `sincronizarTaller` → cuenta como error y no aborta el batch

## Archivos

- `src/app/api/cron/gracia-cuit/route.ts` — reintento + contadores
- `src/__tests__/cron-gracia.test.ts` — mock de `sincronizarTaller` + bloque Pieza D

Spec: `.claude/specs/v4-circuito-cuit-implementacion.md` §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCZF8j8BDAWTfqdsTMrUsT