### PR TITLE
feat: circuito CUIT Piezas A+B — corrección de CUIT + reverificación (PR-2)

### DIFF
--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,9 @@
 ## 2026-07-13
 
 ### Gerardo Breard
+- **16:11** `8f7bee8` — docs(spec): circuito CUIT — PR-1 (Pieza D) HECHO (02ed22d, #452)
+  - `.claude/specs/v4-circuito-cuit-implementacion.md`
+
 - **14:18** `f0d4a59` — chore: redeploy preview — tomar ARCA_PROVIDER=mock (demo Pieza D)
 
 

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,10 @@
 ## 2026-07-13
 
 ### Gerardo Breard
+- **23:55** `8d86a65` — fix: QA #453 — CUIT_CORREGIDO visible en Historial + renombrar botones ARCA
+  - `src/app/(estado)/estado/talleres/[id]/page.tsx`
+  - `src/app/(estado)/estado/talleres/[id]/reverificar-button.tsx`
+
 - **17:09** `14521a5` — feat: circuito CUIT Piezas A+B — corrección de CUIT + reverificación
   - `src/__tests__/corregir-cuit-helper.test.ts`
   - `src/__tests__/corregir-cuit-route.test.ts`

--- a/DAILY.md
+++ b/DAILY.md
@@ -3,6 +3,17 @@
 ## 2026-07-13
 
 ### Gerardo Breard
+- **17:09** `14521a5` — feat: circuito CUIT Piezas A+B — corrección de CUIT + reverificación
+  - `src/__tests__/corregir-cuit-helper.test.ts`
+  - `src/__tests__/corregir-cuit-route.test.ts`
+  - `src/app/(estado)/estado/talleres/[id]/corregir-cuit-coord.tsx`
+  - `src/app/(estado)/estado/talleres/[id]/page.tsx`
+  - `src/app/(taller)/taller/formalizacion/page.tsx`
+  - `src/app/api/arca/corregir-cuit/[id]/route.ts`
+  - `src/compartido/lib/arca.ts`
+  - `src/taller/componentes/banner-gracia.tsx`
+  - `src/taller/componentes/corregir-cuit-form.tsx`
+
 - **16:11** `8f7bee8` — docs(spec): circuito CUIT — PR-1 (Pieza D) HECHO (02ed22d, #452)
   - `.claude/specs/v4-circuito-cuit-implementacion.md`
 

--- a/src/__tests__/corregir-cuit-helper.test.ts
+++ b/src/__tests__/corregir-cuit-helper.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Unit del helper corregirYVerificarCuit (Piezas A+B del circuito CUIT V4). Corre ARCA en modo
+// MOCK (ARCA_PROVIDER=mock -> consultarPadron short-circuitea a mockConsulta, que valida cualquier
+// CUIT salvo 00000000000 -> INEXISTENTE y 11111111111 -> INACTIVO). Prisma y el log van mockeados.
+
+const { mockFindUnique, mockTransaction, mockTxFindFirst, mockTxUpdate, mockLog } = vi.hoisted(() => ({
+  mockFindUnique: vi.fn(),
+  mockTransaction: vi.fn(),
+  mockTxFindFirst: vi.fn(),
+  mockTxUpdate: vi.fn(),
+  mockLog: vi.fn(),
+}))
+
+vi.mock('@/compartido/lib/prisma', () => ({
+  prisma: {
+    taller: { findUnique: mockFindUnique },
+    $transaction: mockTransaction,
+  },
+}))
+vi.mock('@/compartido/lib/log', () => ({ logActividad: mockLog }))
+
+import { corregirYVerificarCuit } from '@/compartido/lib/arca'
+
+const OK_CUIT = '20111111112'   // no-reservado -> mock valida
+const BAD_CUIT = '11111111111'  // reservado -> mock CUIT_INACTIVO
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  process.env.ARCA_PROVIDER = 'mock'
+  mockTxFindFirst.mockResolvedValue(null) // sin colisión por defecto
+  mockTxUpdate.mockResolvedValue({})
+  // $transaction ejecuta el callback con un tx que expone taller.findFirst/update.
+  mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+    fn({ taller: { findFirst: mockTxFindFirst, update: mockTxUpdate } }),
+  )
+})
+
+describe('corregirYVerificarCuit', () => {
+  it('corrige-y-valida: persiste cuit nuevo + verificadoAfip + reactivación (ACTIVA)', async () => {
+    mockFindUnique.mockResolvedValue({ id: 't1', cuit: '20000000001', verificadoAfip: false })
+
+    const r = await corregirYVerificarCuit('t1', OK_CUIT, 'user-taller')
+
+    expect(r.exitosa).toBe(true)
+    expect(mockTxUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 't1' },
+        data: expect.objectContaining({
+          cuit: OK_CUIT,
+          verificadoAfip: true,
+          estadoCuenta: 'ACTIVA',
+          inicioGracia: null,
+          inactivadaAt: null,
+          recordatorioCuitEnviadoAt: null,
+        }),
+      }),
+    )
+  })
+
+  it('audita CUIT_CORREGIDO con actor, cuit anterior y nuevo', async () => {
+    mockFindUnique.mockResolvedValue({ id: 't1', cuit: '20000000001', verificadoAfip: false })
+
+    await corregirYVerificarCuit('t1', OK_CUIT, 'user-estado')
+
+    expect(mockLog).toHaveBeenCalledWith('CUIT_CORREGIDO', 'user-estado', {
+      tallerId: 't1',
+      cuitAnterior: '20000000001',
+      cuitNuevo: OK_CUIT,
+      exitosa: true,
+    })
+  })
+
+  it('gating: taller ya verificado -> YA_VERIFICADO, sin llamar a ARCA ni persistir', async () => {
+    mockFindUnique.mockResolvedValue({ id: 't1', cuit: '20000000001', verificadoAfip: true })
+
+    const r = await corregirYVerificarCuit('t1', OK_CUIT, 'user-taller')
+
+    expect(r.exitosa).toBe(false)
+    expect(r.error).toBe('YA_VERIFICADO')
+    expect(mockTransaction).not.toHaveBeenCalled()
+    expect(mockLog).not.toHaveBeenCalled()
+  })
+
+  it('colisión @unique (findFirst encuentra otro taller) -> CUIT_EN_USO, no persiste ni audita', async () => {
+    mockFindUnique.mockResolvedValue({ id: 't1', cuit: '20000000001', verificadoAfip: false })
+    mockTxFindFirst.mockResolvedValue({ id: 'otro-taller' })
+
+    const r = await corregirYVerificarCuit('t1', OK_CUIT, 'user-taller')
+
+    expect(r.exitosa).toBe(false)
+    expect(r.error).toBe('CUIT_EN_USO')
+    expect(mockTxUpdate).not.toHaveBeenCalled()
+    expect(mockLog).not.toHaveBeenCalled()
+  })
+
+  it('colisión por constraint (update tira P2002) -> CUIT_EN_USO', async () => {
+    mockFindUnique.mockResolvedValue({ id: 't1', cuit: '20000000001', verificadoAfip: false })
+    mockTxUpdate.mockRejectedValue(Object.assign(new Error('unique'), { code: 'P2002' }))
+
+    const r = await corregirYVerificarCuit('t1', OK_CUIT, 'user-taller')
+
+    expect(r.error).toBe('CUIT_EN_USO')
+    expect(mockLog).not.toHaveBeenCalled()
+  })
+
+  it('reintento sin cambiar el número (mismo cuit, ARCA ahora valida) reactiva', async () => {
+    mockFindUnique.mockResolvedValue({ id: 't1', cuit: OK_CUIT, verificadoAfip: false })
+
+    const r = await corregirYVerificarCuit('t1', OK_CUIT, 'user-taller')
+
+    expect(r.exitosa).toBe(true)
+    expect(mockTxUpdate).toHaveBeenCalled()
+    expect(mockLog).toHaveBeenCalledWith('CUIT_CORREGIDO', 'user-taller',
+      expect.objectContaining({ cuitAnterior: OK_CUIT, cuitNuevo: OK_CUIT }))
+  })
+
+  it('ARCA rechaza el CUIT (reservado inactivo) -> no persiste, devuelve el código de ARCA', async () => {
+    mockFindUnique.mockResolvedValue({ id: 't1', cuit: '20000000001', verificadoAfip: false })
+
+    const r = await corregirYVerificarCuit('t1', BAD_CUIT, 'user-taller')
+
+    expect(r.exitosa).toBe(false)
+    expect(r.error).toBe('CUIT_INACTIVO')
+    expect(mockTransaction).not.toHaveBeenCalled()
+    expect(mockLog).not.toHaveBeenCalled()
+  })
+
+  it('taller inexistente -> TALLER_NO_ENCONTRADO', async () => {
+    mockFindUnique.mockResolvedValue(null)
+
+    const r = await corregirYVerificarCuit('nope', OK_CUIT, 'user-taller')
+
+    expect(r.error).toBe('TALLER_NO_ENCONTRADO')
+  })
+})

--- a/src/__tests__/corregir-cuit-route.test.ts
+++ b/src/__tests__/corregir-cuit-route.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// Endpoint POST /api/arca/corregir-cuit/[id]: auth DUAL (dueño o ESTADO/ADMIN), validación de
+// CUIT y mapeo de los códigos del helper a HTTP status. El helper corregirYVerificarCuit va
+// mockeado (su lógica se testea en corregir-cuit-helper.test.ts).
+
+const { mockAuth, mockFindUnique, mockCYV } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockFindUnique: vi.fn(),
+  mockCYV: vi.fn(),
+}))
+
+vi.mock('@/compartido/lib/auth', () => ({ auth: mockAuth }))
+vi.mock('@/compartido/lib/prisma', () => ({
+  prisma: { taller: { findUnique: mockFindUnique } },
+}))
+vi.mock('@/compartido/lib/arca', () => ({
+  corregirYVerificarCuit: mockCYV,
+  mensajeErrorArca: (c: string) => `msg:${c}`,
+}))
+
+import { POST } from '@/app/api/arca/corregir-cuit/[id]/route'
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) })
+function req(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/arca/corregir-cuit/t1', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFindUnique.mockResolvedValue({ userId: 'owner-1' })
+  mockCYV.mockResolvedValue({ exitosa: true, duracionMs: 10 })
+})
+
+describe('POST /api/arca/corregir-cuit/[id] — auth dual', () => {
+  it('401 sin sesión', async () => {
+    mockAuth.mockResolvedValue(null)
+    const res = await POST(req({ cuit: '20111111112' }), ctx('t1'))
+    expect(res.status).toBe(401)
+    expect(mockCYV).not.toHaveBeenCalled()
+  })
+
+  it('404 si el taller no existe', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u1', activeMode: 'TALLER' } })
+    mockFindUnique.mockResolvedValue(null)
+    const res = await POST(req({ cuit: '20111111112' }), ctx('t1'))
+    expect(res.status).toBe(404)
+  })
+
+  it('403 si no es dueño ni ESTADO/ADMIN', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'ajeno', activeMode: 'TALLER' } })
+    mockFindUnique.mockResolvedValue({ userId: 'owner-1' })
+    const res = await POST(req({ cuit: '20111111112' }), ctx('t1'))
+    expect(res.status).toBe(403)
+    expect(mockCYV).not.toHaveBeenCalled()
+  })
+
+  it('dueño del taller -> autorizado, 200 exitosa', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'owner-1', activeMode: 'TALLER' } })
+    const res = await POST(req({ cuit: '20-11111111-2' }), ctx('t1'))
+    const data = await res.json()
+    expect(res.status).toBe(200)
+    expect(data.exitosa).toBe(true)
+    // El cuit llega normalizado (sin guiones) al helper.
+    expect(mockCYV).toHaveBeenCalledWith('t1', '20111111112', 'owner-1')
+  })
+
+  it('ESTADO sobre taller ajeno -> autorizado (override de COORD)', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'coord-1', activeMode: 'ESTADO' } })
+    mockFindUnique.mockResolvedValue({ userId: 'owner-1' })
+    const res = await POST(req({ cuit: '20111111112' }), ctx('t1'))
+    expect(res.status).toBe(200)
+    expect(mockCYV).toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/arca/corregir-cuit/[id] — validación y mapeo de códigos', () => {
+  beforeEach(() => {
+    mockAuth.mockResolvedValue({ user: { id: 'owner-1', activeMode: 'TALLER' } })
+  })
+
+  it('400 si el CUIT no tiene 11 dígitos', async () => {
+    const res = await POST(req({ cuit: '123' }), ctx('t1'))
+    expect(res.status).toBe(400)
+    expect(mockCYV).not.toHaveBeenCalled()
+  })
+
+  it('409 YA_VERIFICADO (gating)', async () => {
+    mockCYV.mockResolvedValue({ exitosa: false, error: 'YA_VERIFICADO', duracionMs: 0 })
+    const res = await POST(req({ cuit: '20111111112' }), ctx('t1'))
+    const data = await res.json()
+    expect(res.status).toBe(409)
+    expect(data.codigo).toBe('YA_VERIFICADO')
+  })
+
+  it('409 CUIT_EN_USO (colisión) sin filtrar datos del otro taller', async () => {
+    mockCYV.mockResolvedValue({ exitosa: false, error: 'CUIT_EN_USO', duracionMs: 0 })
+    const res = await POST(req({ cuit: '20111111112' }), ctx('t1'))
+    const data = await res.json()
+    expect(res.status).toBe(409)
+    expect(data.codigo).toBe('CUIT_EN_USO')
+    expect(data.mensaje).not.toMatch(/owner|taller-|id/i)
+  })
+
+  it('200 exitosa:false con mensaje ARCA cuando el CUIT no valida', async () => {
+    mockCYV.mockResolvedValue({ exitosa: false, error: 'CUIT_INEXISTENTE', duracionMs: 30 })
+    const res = await POST(req({ cuit: '20111111112' }), ctx('t1'))
+    const data = await res.json()
+    expect(res.status).toBe(200)
+    expect(data.exitosa).toBe(false)
+    expect(data.mensaje).toBe('msg:CUIT_INEXISTENTE')
+  })
+})

--- a/src/app/(estado)/estado/talleres/[id]/corregir-cuit-coord.tsx
+++ b/src/app/(estado)/estado/talleres/[id]/corregir-cuit-coord.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { ShieldCheck, Loader2 } from 'lucide-react'
+
+// Pieza B del circuito CUIT V4 — override de COORD. Extiende el panel ARCA de ESTADO con la
+// comparación LADO A LADO que pidió Sergio: el CUIT declarado (el que falla) frente a un campo
+// para el CUIT corregido que COORD copia del PDF de la constancia que tiene a la vista. Usa el
+// MISMO endpoint que el self-service del taller (auth dual): POST /api/arca/corregir-cuit/[id].
+export function CorregirCuitCoord({ tallerId, cuitDeclarado }: { tallerId: string; cuitDeclarado: string }) {
+  const router = useRouter()
+  const [cuit, setCuit] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState<{ ok: boolean; texto: string } | null>(null)
+
+  async function handleVerificar() {
+    setLoading(true)
+    setMsg(null)
+    try {
+      const res = await fetch(`/api/arca/corregir-cuit/${tallerId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cuit }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (res.ok && data.exitosa) {
+        setMsg({ ok: true, texto: 'CUIT corregido y verificado. El taller quedó reactivado.' })
+        setTimeout(() => router.refresh(), 1200)
+        return
+      }
+      setMsg({ ok: false, texto: data.mensaje || 'No se pudo verificar el CUIT.' })
+    } catch {
+      setMsg({ ok: false, texto: 'Error de conexión.' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const cuitValido = /^\d{11}$/.test(cuit.replace(/-/g, ''))
+
+  return (
+    <div className="mt-3 rounded-lg border border-gray-200 bg-gray-50 p-4">
+      <p className="text-sm font-semibold text-gray-700 mb-3">Corregir CUIT contra la constancia</p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-xs font-semibold text-gray-500 mb-1">CUIT declarado (falla en ARCA)</label>
+          <input
+            type="text"
+            value={cuitDeclarado || '—'}
+            readOnly
+            className="w-full border border-gray-200 bg-gray-100 rounded-lg px-3 py-2 text-sm text-gray-500"
+          />
+        </div>
+        <div>
+          <label htmlFor="cuit-coord" className="block text-xs font-semibold text-gray-500 mb-1">CUIT corregido (del PDF)</label>
+          <input
+            id="cuit-coord"
+            type="text"
+            inputMode="numeric"
+            value={cuit}
+            onChange={(e) => setCuit(e.target.value)}
+            disabled={loading}
+            placeholder="11 dígitos, sin guiones"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue/40 disabled:opacity-50"
+          />
+        </div>
+      </div>
+      <div className="flex items-center gap-3 mt-3">
+        <button
+          onClick={handleVerificar}
+          disabled={loading || !cuitValido}
+          className="flex items-center gap-2 px-3 py-1.5 bg-brand-blue text-white rounded-lg text-xs font-semibold hover:bg-brand-blue/90 disabled:opacity-50"
+        >
+          {loading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <ShieldCheck className="w-3.5 h-3.5" />}
+          {loading ? 'Verificando...' : 'Verificar CUIT corregido contra ARCA'}
+        </button>
+        {msg && (
+          <span className={`text-xs ${msg.ok ? 'text-green-600' : 'text-amber-600'}`}>{msg.texto}</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(estado)/estado/talleres/[id]/page.tsx
+++ b/src/app/(estado)/estado/talleres/[id]/page.tsx
@@ -264,7 +264,12 @@ export default async function EstadoDetalleTallerPage({ params, searchParams }: 
                   title={labelPorNombre[v.tipo] ?? v.tipo}
                   status={estadoToStatus[v.estado] || 'optional'}
                   description={
-                    v.estado === 'COMPLETADO' ? 'Verificado'
+                    // QA #453 p3 (opción a): CUIT verificado por ARCA pero paso documental sin
+                    // aprobar — recordarle a COORD que la aprobación es independiente y suya.
+                    // Solo PENDIENTE/NO_INICIADO (un rechazo/vencido conserva su motivo).
+                    taller.verificadoAfip && v.tipo === 'CUIT/Monotributo' && (v.estado === 'PENDIENTE' || v.estado === 'NO_INICIADO')
+                      ? 'El CUIT ya esta verificado por ARCA — la aprobacion documental de este paso es independiente y la decide la Coordinacion.'
+                    : v.estado === 'COMPLETADO' ? 'Verificado'
                     : v.estado === 'PENDIENTE' && !v.documentoUrl && enlacePorNombre[v.tipo]
                       ? 'Tramite externo — verificar en ARCA/SIPA'
                     : v.estado === 'PENDIENTE' ? 'Pendiente de revision'

--- a/src/app/(estado)/estado/talleres/[id]/page.tsx
+++ b/src/app/(estado)/estado/talleres/[id]/page.tsx
@@ -65,13 +65,16 @@ export default async function EstadoDetalleTallerPage({ params, searchParams }: 
             'ESTADO_VALIDACION_APROBADA', 'ESTADO_VALIDACION_RECHAZADA', 'ESTADO_VALIDACION_REVOCADA',
             'ADMIN_VALIDACION_COMPLETADO', 'ADMIN_VALIDACION_RECHAZADO',
             'NIVEL_SUBIDO', 'NIVEL_BAJADO',
+            // Correcciones de CUIT (Piezas A/B): el evento sensible debe ser visible acá,
+            // venga del taller (self-service) o de COORD (override).
+            'CUIT_CORREGIDO',
           ],
         },
         detalles: { path: ['tallerId'], equals: id },
       },
       orderBy: { timestamp: 'desc' },
       take: 30,
-      include: { user: { select: { name: true } } },
+      include: { user: { select: { name: true, email: true } } },
     }),
   ])
 
@@ -287,7 +290,9 @@ export default async function EstadoDetalleTallerPage({ params, searchParams }: 
                       rel="noopener noreferrer"
                       className="text-brand-blue underline text-xs"
                     >
-                      Verificar en ARCA
+                      {/* Antes "Verificar en ARCA" — confundia con el boton de re-consulta del
+                          padrón en la pestaña Datos. Esto solo ABRE el sitio externo. QA #453 p2. */}
+                      Abrir el trámite en ARCA (sitio externo)
                     </a>
                   </div>
                 )}
@@ -356,11 +361,17 @@ export default async function EstadoDetalleTallerPage({ params, searchParams }: 
                   nivelNuevo?: string
                   motivo?: string
                   tipoDocumento?: string
+                  cuitAnterior?: string
+                  cuitNuevo?: string
                 }
                 const esEstado = log.accion.startsWith('ESTADO_')
                 const actor = log.user?.name ?? (esEstado ? 'Estado' : 'Admin (pre-V3)')
                 const descripcion =
-                  log.accion.includes('APROBADA') || log.accion.includes('COMPLETADO')
+                  // CUIT_CORREGIDO va PRIMERO: los matchers por substring de abajo son laxos
+                  // y un futuro rename podria pisarlo. El actor distingue taller vs COORD.
+                  log.accion === 'CUIT_CORREGIDO'
+                    ? `${log.user?.name || log.user?.email || 'Alguien'} corrigio el CUIT: ${detalles.cuitAnterior} → ${detalles.cuitNuevo} (verificado por ARCA)`
+                  : log.accion.includes('APROBADA') || log.accion.includes('COMPLETADO')
                     ? `${actor} aprobo ${detalles.tipoDocumento || 'una validacion'}`
                   : log.accion.includes('RECHAZADA') || log.accion.includes('RECHAZADO')
                     ? `${actor} rechazo ${detalles.tipoDocumento || 'una validacion'}${detalles.motivo ? ` — ${detalles.motivo}` : ''}`

--- a/src/app/(estado)/estado/talleres/[id]/page.tsx
+++ b/src/app/(estado)/estado/talleres/[id]/page.tsx
@@ -17,6 +17,7 @@ import { nivelAEtapa } from '@/compartido/lib/formalizacion'
 import { Breadcrumbs } from '@/compartido/componentes/ui/breadcrumbs'
 import { BadgeArca } from '@/compartido/componentes/badge-arca'
 import { ReverificarButton } from './reverificar-button'
+import { CorregirCuitCoord } from './corregir-cuit-coord'
 import { VerDocumentoButton } from '@/taller/componentes/ver-documento-button'
 
 const estadoToStatus: Record<string, 'completed' | 'pending' | 'warning' | 'optional'> = {
@@ -469,7 +470,14 @@ export default async function EstadoDetalleTallerPage({ params, searchParams }: 
                 )}
               </div>
             ) : (
-              <p className="text-sm text-amber-600">Este taller no tiene verificacion de ARCA. Usa el boton para re-verificar.</p>
+              <>
+                <p className="text-sm text-amber-600">Este taller no tiene verificacion de ARCA. Usa el boton para re-verificar el CUIT almacenado, o corregilo abajo si la constancia muestra otro numero.</p>
+                {/* Pieza B — corregir el CUIT (comparacion lado a lado). Solo ESTADO (no ADMIN, que es
+                    solo lectura); un taller verificado no llega aca (esta rama es !verificadoAfip). */}
+                {!soloLectura && (
+                  <CorregirCuitCoord tallerId={taller.id} cuitDeclarado={taller.cuit ?? ''} />
+                )}
+              </>
             )}
           </div>
 

--- a/src/app/(estado)/estado/talleres/[id]/reverificar-button.tsx
+++ b/src/app/(estado)/estado/talleres/[id]/reverificar-button.tsx
@@ -32,7 +32,10 @@ export function ReverificarButton({ tallerId }: { tallerId: string }) {
         className="flex items-center gap-2 px-3 py-1.5 bg-brand-blue text-white rounded-lg text-xs font-semibold hover:bg-brand-blue/90 disabled:opacity-50"
       >
         <RefreshCw className={`w-3.5 h-3.5 ${verificando ? 'animate-spin' : ''}`} />
-        {verificando ? 'Verificando...' : 'Re-verificar contra ARCA'}
+        {/* "Re-consultar (CUIT actual)" y no "Re-verificar": deja claro que consulta el
+            padrón con el CUIT ALMACENADO (vs. "Corregir CUIT" abajo, y vs. el link externo
+            al trámite en la pestaña Formalización). QA #453 punto 2. */}
+        {verificando ? 'Consultando...' : 'Re-consultar ARCA (CUIT actual)'}
       </button>
       {resultado && (
         <span className={`text-xs ${resultado.exitosa ? 'text-green-600' : 'text-amber-600'}`}>

--- a/src/app/(taller)/taller/formalizacion/page.tsx
+++ b/src/app/(taller)/taller/formalizacion/page.tsx
@@ -127,7 +127,13 @@ export default async function TallerFormalizacionPage() {
                       title={td.label}
                       status={status}
                       description={
-                        estado === 'COMPLETADO'   ? `Verificado por ${validacion?.usuarioAprobador?.role === 'ESTADO' ? 'la Coordinación' : 'el equipo de PDT'}`
+                        // QA #453 p3 (opción a, Sergio): CUIT ya verificado por ARCA pero el paso
+                        // documental sigue sin aprobar — aclarar la independencia para no confundir.
+                        // NO cambia comportamiento: el paso lo sigue aprobando la Coordinación.
+                        // Solo PENDIENTE/NO_INICIADO: un RECHAZADO/VENCIDO debe seguir mostrando su motivo.
+                        taller.verificadoAfip && td.nombre === 'CUIT/Monotributo' && (estado === 'PENDIENTE' || estado === 'NO_INICIADO')
+                                                  ? 'Tu CUIT ya está verificado por ARCA — este paso documental lo revisa la Coordinación por separado.'
+                      : estado === 'COMPLETADO'   ? `Verificado por ${validacion?.usuarioAprobador?.role === 'ESTADO' ? 'la Coordinación' : 'el equipo de PDT'}`
                       : estado === 'PENDIENTE'    ? 'En revisión por el equipo de PDT'
                       : estado === 'VENCIDO'      ? 'Documento vencido — requiere actualización'
                       : estado === 'RECHAZADO'    ? `Rechazado: ${validacion?.detalle || 'Revisá la documentación'}`

--- a/src/app/(taller)/taller/formalizacion/page.tsx
+++ b/src/app/(taller)/taller/formalizacion/page.tsx
@@ -12,6 +12,7 @@ import { ExternalLink } from 'lucide-react'
 import { UploadButton } from '@/taller/componentes/upload-button'
 import { VerDocumentoButton } from '@/taller/componentes/ver-documento-button'
 import { MarcarRealizadoButton } from '@/taller/componentes/marcar-realizado-button'
+import { CorregirCuitForm } from '@/taller/componentes/corregir-cuit-form'
 import { nivelAEtapa } from '@/compartido/lib/formalizacion'
 
 const estadoToStatus: Record<string, 'completed' | 'pending' | 'warning' | 'optional'> = {
@@ -27,7 +28,7 @@ export default async function TallerFormalizacionPage() {
 
   const taller = await prisma.taller.findFirst({
     where: { userId: session.user.id },
-    select: { id: true, nivel: true, puntaje: true },
+    select: { id: true, nivel: true, puntaje: true, cuit: true, verificadoAfip: true, estadoCuenta: true },
   })
 
   if (!taller) {
@@ -61,6 +62,17 @@ export default async function TallerFormalizacionPage() {
   return (
     <div className="space-y-6">
       <h1 className="font-serif font-bold text-3xl text-ink-primary">Mi recorrido</h1>
+
+      {/* Pieza A del circuito CUIT V4 — corregir/reverificar CUIT (self-service). Solo para
+          talleres SIN verificar (gracia o inactiva); un taller verificado no ve la acción.
+          Anclada en #verificar-cuit para el CTA de los banners de gracia/inactiva. */}
+      {!taller.verificadoAfip && (
+        <CorregirCuitForm
+          tallerId={taller.id}
+          cuitActual={taller.cuit ?? ''}
+          inactiva={taller.estadoCuenta === 'INACTIVA'}
+        />
+      )}
 
       {/* Resumen. La V4 descartó el porcentaje/ring de avance como gamificación:
           el recorrido se comunica por requisito (badges COMPLETADO/PENDIENTE más abajo),

--- a/src/app/api/arca/corregir-cuit/[id]/route.ts
+++ b/src/app/api/arca/corregir-cuit/[id]/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/compartido/lib/auth'
+import { prisma } from '@/compartido/lib/prisma'
+import { modoActivo } from '@/compartido/lib/roles'
+import { corregirYVerificarCuit, mensajeErrorArca } from '@/compartido/lib/arca'
+import { apiHandler } from '@/compartido/lib/api-errors'
+
+// POST /api/arca/corregir-cuit/[id] — Piezas A y B del circuito CUIT V4.
+// Corrige el CUIT de un taller y lo verifica contra ARCA; solo persiste si valida.
+//
+// Auth DUAL (una sola implementación): lo puede usar el DUEÑO del taller (self-service, Pieza A)
+// o un usuario ESTADO/ADMIN (override de COORD, Pieza B). El gating "solo si verificadoAfip=false"
+// vive en el helper `corregirYVerificarCuit` (rechaza con YA_VERIFICADO antes de llamar a ARCA).
+//
+// Contrato de respuesta (el cliente lee `exitosa` y `mensaje`):
+//   200 { exitosa:true }                              -> validó, persistió, reactivó
+//   200 { exitosa:false, mensaje, codigo }            -> ARCA rechazó (inexistente/inactivo/...)
+//   400 { exitosa:false, mensaje }                    -> CUIT mal formado
+//   401/403/404 { exitosa:false, mensaje }            -> auth / ownership / taller inexistente
+//   409 { exitosa:false, mensaje, codigo }            -> YA_VERIFICADO | CUIT_EN_USO
+export const POST = apiHandler(async (req: NextRequest, { params }) => {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ exitosa: false, mensaje: 'Necesitás iniciar sesión.' }, { status: 401 })
+  }
+
+  const { id } = (await params!) as { id: string }
+
+  const taller = await prisma.taller.findUnique({
+    where: { id },
+    select: { userId: true },
+  })
+  if (!taller) {
+    return NextResponse.json({ exitosa: false, mensaje: 'Taller no encontrado.' }, { status: 404 })
+  }
+
+  const esDueno = taller.userId === session.user.id
+  const rol = modoActivo(session.user)
+  const esEstadoAdmin = rol === 'ESTADO' || rol === 'ADMIN'
+  if (!esDueno && !esEstadoAdmin) {
+    return NextResponse.json({ exitosa: false, mensaje: 'No tenés permiso sobre este taller.' }, { status: 403 })
+  }
+
+  const body = (await req.json().catch(() => ({}))) as { cuit?: unknown }
+  const cuitRaw = typeof body.cuit === 'string' ? body.cuit.trim() : ''
+  const cuit = cuitRaw.replace(/-/g, '')
+  if (!/^\d{11}$/.test(cuit)) {
+    return NextResponse.json(
+      { exitosa: false, mensaje: 'El CUIT debe tener 11 dígitos (sin guiones).' },
+      { status: 400 },
+    )
+  }
+
+  const resultado = await corregirYVerificarCuit(id, cuit, session.user.id)
+
+  if (resultado.exitosa) {
+    return NextResponse.json({ exitosa: true })
+  }
+
+  // Códigos de dominio propios -> 409 con mensaje a medida (sin filtrar datos de otro taller).
+  if (resultado.error === 'YA_VERIFICADO') {
+    return NextResponse.json(
+      { exitosa: false, mensaje: 'Tu CUIT ya está verificado.', codigo: 'YA_VERIFICADO' },
+      { status: 409 },
+    )
+  }
+  if (resultado.error === 'CUIT_EN_USO') {
+    return NextResponse.json(
+      { exitosa: false, mensaje: 'Este CUIT ya está registrado en otra cuenta.', codigo: 'CUIT_EN_USO' },
+      { status: 409 },
+    )
+  }
+  if (resultado.error === 'TALLER_NO_ENCONTRADO') {
+    return NextResponse.json({ exitosa: false, mensaje: 'Taller no encontrado.' }, { status: 404 })
+  }
+
+  // Verdicto de ARCA (CUIT_INEXISTENTE / CUIT_INACTIVO / CUIT_SIN_ACTIVIDAD / ARCA_NO_RESPONDE):
+  // no es un error del sistema, es el resultado a mostrarle al usuario. 200 con el mensaje ARCA.
+  return NextResponse.json({
+    exitosa: false,
+    mensaje: resultado.error ? mensajeErrorArca(resultado.error) : 'No se pudo verificar el CUIT.',
+    codigo: resultado.error,
+  })
+})

--- a/src/compartido/lib/arca.ts
+++ b/src/compartido/lib/arca.ts
@@ -179,21 +179,7 @@ export async function sincronizarTaller(tallerId: string, force = false, userId?
   if (resultado.exitosa && resultado.datos) {
     await prisma.taller.update({
       where: { id: tallerId },
-      data: {
-        verificadoAfip: true,
-        verificadoAfipAt: new Date(),
-        // Reactivacion automatica (2.3-B1): si el taller estaba EN_GRACIA o INACTIVA,
-        // verificar el CUIT lo vuelve a ACTIVA y limpia el reloj (inicioGracia/inactivadaAt/
-        // recordatorioCuitEnviadoAt). Para un taller ya ACTIVA, escribir ACTIVA + nulls es
-        // idempotente (no cambia nada). Sin trámite extra: pasa por el flujo ARCA existente.
-        ...datosReactivacion(),
-        tipoInscripcionAfip: resultado.datos.tipoInscripcion,
-        categoriaMonotributo: resultado.datos.categoriaMonotributo ?? null,
-        estadoCuitAfip: resultado.datos.estadoCuit,
-        fechaInscripcionAfip: resultado.datos.fechaInscripcion ?? null,
-        actividadesAfip: resultado.datos.actividades,
-        domicilioFiscalAfip: resultado.datos.domicilioFiscal ?? undefined,
-      },
+      data: aplicarDatosArca(resultado.datos),
     })
   } else if (resultado.error === 'CUIT_INACTIVO' || resultado.error === 'CUIT_INEXISTENTE') {
     // Marcar como no verificado si ARCA dice explicitamente que no es valido
@@ -207,6 +193,100 @@ export async function sincronizarTaller(tallerId: string, force = false, userId?
     })
   }
   // Si es ARCA_NO_RESPONDE o AFIPSDK_ERROR, no tocamos el estado actual
+
+  return resultado
+}
+
+// ---------------------------------------------------------------------------
+// Datos a escribir en el taller cuando una verificación ARCA es EXITOSA
+// ---------------------------------------------------------------------------
+
+// Único lugar que setea `verificadoAfip: true` (invariante del circuito CUIT V4: el flag
+// solo lo escribe una verificación ARCA exitosa, nunca un click humano). Reactiva el taller
+// (datosReactivacion: ACTIVA + reloj limpio) y vuelca los datos de ARCA. Compartido por
+// `sincronizarTaller` (CUIT almacenado) y `corregirYVerificarCuit` (CUIT corregido).
+function aplicarDatosArca(datos: DatosArca) {
+  return {
+    verificadoAfip: true,
+    verificadoAfipAt: new Date(),
+    // Reactivacion automatica: si el taller estaba EN_GRACIA o INACTIVA, verificar el CUIT lo
+    // vuelve a ACTIVA y limpia el reloj (inicioGracia/inactivadaAt/recordatorioCuitEnviadoAt).
+    // Para un taller ya ACTIVA es idempotente.
+    ...datosReactivacion(),
+    tipoInscripcionAfip: datos.tipoInscripcion,
+    categoriaMonotributo: datos.categoriaMonotributo ?? null,
+    estadoCuitAfip: datos.estadoCuit,
+    fechaInscripcionAfip: datos.fechaInscripcion ?? null,
+    actividadesAfip: datos.actividades,
+    domicilioFiscalAfip: datos.domicilioFiscal ?? undefined,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Corrección de CUIT + verificación (Piezas A y B del circuito CUIT V4)
+// ---------------------------------------------------------------------------
+
+// Backend compartido por el self-service del taller (A) y el override de COORD (B). Valida un
+// CUIT CANDIDATO contra ARCA y, SOLO si valida, lo persiste + verifica + reactiva. Es el único
+// write nuevo de `verificadoAfip: true` (via aplicarDatosArca). Devuelve un ResultadoConsulta;
+// `error` lleva los códigos de dominio propios (YA_VERIFICADO / CUIT_EN_USO / TALLER_NO_ENCONTRADO)
+// o el código de ARCA (CUIT_INEXISTENTE, etc.) cuando la verificación no valida.
+export async function corregirYVerificarCuit(
+  tallerId: string,
+  cuitCandidato: string,
+  actorUserId: string,
+): Promise<ResultadoConsulta> {
+  const cuit = cuitCandidato.replace(/-/g, '')
+
+  const taller = await prisma.taller.findUnique({
+    where: { id: tallerId },
+    select: { id: true, cuit: true, verificadoAfip: true },
+  })
+  if (!taller) return { exitosa: false, error: 'TALLER_NO_ENCONTRADO', duracionMs: 0 }
+  // Gating (invariante): un taller ya verificado NO puede tocar su CUIT (evita swap de identidad
+  // sobre una cuenta validada). Se rechaza ANTES de gastar una llamada a ARCA.
+  if (taller.verificadoAfip) return { exitosa: false, error: 'YA_VERIFICADO', duracionMs: 0 }
+
+  const resultado = await consultarPadron(cuit, taller.id, actorUserId)
+  // ARCA no validó (inexistente / inactivo / sin actividad / no responde) -> NO se persiste nada.
+  if (!(resultado.exitosa && resultado.datos)) return resultado
+
+  const cuitAnterior = taller.cuit
+  try {
+    // Transacción: chequear colisión @unique y persistir juntos (evita TOCTOU).
+    await prisma.$transaction(async (tx) => {
+      const colision = await tx.taller.findFirst({
+        where: { cuit, id: { not: taller.id } },
+        select: { id: true },
+      })
+      if (colision) {
+        const e = new Error('CUIT_EN_USO') as Error & { code?: string }
+        e.code = 'CUIT_EN_USO'
+        throw e
+      }
+      await tx.taller.update({
+        where: { id: taller.id },
+        data: { cuit, ...aplicarDatosArca(resultado.datos!) },
+      })
+    })
+  } catch (e) {
+    // Colisión detectada (o carrera que igual pega el @unique): mensaje neutro, sin filtrar
+    // datos del otro taller. No se persistió el cambio.
+    const code = (e as { code?: string })?.code
+    if (code === 'CUIT_EN_USO' || code === 'P2002') {
+      return { exitosa: false, error: 'CUIT_EN_USO', duracionMs: resultado.duracionMs }
+    }
+    throw e
+  }
+
+  // Auditoría: el cambio de CUIT es un evento sensible. Queda quién (actor + implícito rol por
+  // el userId), cuándo (timestamp del log) y el CUIT anterior/nuevo.
+  logActividad('CUIT_CORREGIDO', actorUserId, {
+    tallerId: taller.id,
+    cuitAnterior,
+    cuitNuevo: cuit,
+    exitosa: true,
+  })
 
   return resultado
 }

--- a/src/taller/componentes/banner-gracia.tsx
+++ b/src/taller/componentes/banner-gracia.tsx
@@ -35,7 +35,7 @@ export function BannerGracia({
           seguís teniendo acceso a la Academia y a explorar la red de talleres.
         </p>
         <Link
-          href="/taller/formalizacion"
+          href="/taller/formalizacion#verificar-cuit"
           className="inline-flex items-center gap-1 mt-2 text-sm font-semibold text-red-800 hover:underline"
         >
           Verificar mi CUIT →
@@ -56,10 +56,10 @@ export function BannerGracia({
         Mientras tanto, podés capacitarte en la Academia y explorar la red de talleres.
       </p>
       <Link
-        href="/taller/formalizacion"
+        href="/taller/formalizacion#verificar-cuit"
         className="inline-flex items-center gap-1 mt-2 text-sm font-semibold text-amber-800 hover:underline"
       >
-        Ir a Formalización →
+        Verificar mi CUIT →
       </Link>
     </div>
   )

--- a/src/taller/componentes/corregir-cuit-form.tsx
+++ b/src/taller/componentes/corregir-cuit-form.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { ShieldCheck, Loader2 } from 'lucide-react'
+import { Button } from '@/compartido/componentes/ui/button'
+import { useToast } from '@/compartido/componentes/ui/toast'
+
+interface Props {
+  tallerId: string
+  cuitActual: string
+  // Estado de gracia para adaptar el copy (banner de INACTIVA vs EN_GRACIA).
+  inactiva: boolean
+}
+
+// Pieza A del circuito CUIT V4 — self-service del taller. Vive en /taller/formalizacion, anclado
+// desde el CTA "Verificar mi CUIT" de los banners de gracia/inactiva. Doble uso en la misma UI:
+// corregir el número mal cargado O reintentar el mismo (el caso "mi CUIT está bien, ARCA estaba
+// caído al registrarme"). Solo se renderiza si el taller NO está verificado (gating server-side
+// en la página + en el endpoint).
+export function CorregirCuitForm({ tallerId, cuitActual, inactiva }: Props) {
+  const router = useRouter()
+  const { toast } = useToast()
+  const [cuit, setCuit] = useState(cuitActual ?? '')
+  const [loading, setLoading] = useState(false)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  async function handleVerificar() {
+    setLoading(true)
+    setErrorMsg(null)
+    try {
+      const res = await fetch(`/api/arca/corregir-cuit/${tallerId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cuit }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (res.ok && data.exitosa) {
+        toast('¡CUIT verificado! Tu cuenta se reactivó y ya aparecés en el directorio.')
+        setTimeout(() => router.refresh(), 1200)
+        return
+      }
+      const mensaje = data.mensaje || 'No se pudo verificar el CUIT. Intentá de nuevo.'
+      setErrorMsg(mensaje)
+      toast(mensaje, 'error')
+    } catch {
+      const mensaje = 'Error de conexión. Intentá de nuevo en un momento.'
+      setErrorMsg(mensaje)
+      toast(mensaje, 'error')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const cuitNorm = cuit.replace(/-/g, '')
+  const cuitValido = /^\d{11}$/.test(cuitNorm)
+
+  return (
+    <div
+      id="verificar-cuit"
+      className="border-l-4 border-l-brand-blue bg-pastel-blue/40 rounded-card p-4 scroll-mt-24"
+    >
+      <p className="flex items-center gap-1.5 font-overpass font-bold text-brand-blue mb-1">
+        <ShieldCheck className="w-4 h-4 shrink-0" />
+        {inactiva
+          ? 'Verificá tu CUIT para reactivar tu cuenta'
+          : 'Verificá tu CUIT para aparecer en el directorio'}
+      </p>
+      <p className="text-sm text-gray-600 mb-3">
+        El CUIT que tenés cargado todavía no pudo verificarse contra ARCA. Corregilo si está mal, o
+        volvé a intentar si es correcto (a veces ARCA no responde en el momento del registro). En
+        cuanto se verifique, tu cuenta {inactiva ? 'se reactiva' : 'aparece en el directorio'} y vas
+        a poder cotizar pedidos.
+      </p>
+
+      <label htmlFor="cuit-input" className="block text-xs font-semibold text-gray-500 mb-1">
+        CUIT (11 dígitos, sin guiones)
+      </label>
+      <div className="flex flex-col sm:flex-row gap-2">
+        <input
+          id="cuit-input"
+          type="text"
+          inputMode="numeric"
+          value={cuit}
+          onChange={(e) => setCuit(e.target.value)}
+          disabled={loading}
+          placeholder="20123456789"
+          className="w-full sm:flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue/40 disabled:opacity-50"
+        />
+        <Button
+          onClick={handleVerificar}
+          disabled={loading || !cuitValido}
+          icon={loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <ShieldCheck className="w-4 h-4" />}
+          className="w-full sm:w-auto"
+        >
+          {loading ? 'Verificando...' : 'Verificar contra ARCA'}
+        </Button>
+      </div>
+
+      {errorMsg && <p className="text-sm text-red-600 mt-2">{errorMsg}</p>}
+    </div>
+  )
+}


### PR DESCRIPTION
## Qué

**Piezas A + B** del circuito CUIT V4 (spec `v4-circuito-cuit-implementacion.md` §A/§B/§5). Cierra el "limbo": ahora hay un camino en producto para que un CUIT mal cargado (o correcto pero no verificado por ARCA caído) se corrija y verifique.

Comparten **un solo backend** (helper + endpoint con auth dual), como decidió Gerardo.

## Backend compartido (§5)

- **`arca.ts` → `corregirYVerificarCuit(tallerId, cuit, actor)`**: valida un CUIT candidato contra ARCA y **solo si valida** lo persiste + verifica + reactiva. **Único write nuevo de `verificadoAfip=true`** (vía `aplicarDatosArca`, extraído de `sincronizarTaller` — un solo lugar setea el flag, respetando el invariante). Gating `verificadoAfip=false`, colisión `@unique` chequeada en transacción (mensaje neutro, sin filtrar datos del otro taller), auditoría `logActividad('CUIT_CORREGIDO', …)` con actor + CUIT anterior/nuevo.
- **`POST /api/arca/corregir-cuit/[id]`** con **auth dual** (dueño del taller **o** ESTADO/ADMIN). Mapea códigos → HTTP: 409 `YA_VERIFICADO`/`CUIT_EN_USO`, 200 con mensaje ARCA cuando no valida, 400 CUIT mal formado.

## Pieza A — self-service del taller

- `corregir-cuit-form.tsx` en `/taller/formalizacion`, **gated server-side** (solo si `verificadoAfip=false`; un taller verificado no ve ni puede usar la acción). **Doble uso**: corregir el número o reintentar el mismo (caso "mi CUIT está bien, ARCA estaba caído"). Copy conectado al lenguaje de los banners. **Mobile-first**.
- Banners de gracia/inactiva: el CTA **"Verificar mi CUIT →"** ahora ancla a `/taller/formalizacion#verificar-cuit` — **arregla el CTA muerto** que antes no verificaba nada.

## Pieza B — override de COORD

- `corregir-cuit-coord.tsx` en el panel ARCA de ESTADO: **CUIT declarado | CUIT corregido (del PDF) lado a lado** (la comparación explícita que pidió Sergio). Mismo endpoint. Solo ESTADO (no ADMIN, que es lectura).

## Invariantes (ratificados)

`verificadoAfip=true` solo lo escribe una verificación ARCA exitosa · aprobación documental ↔ ARCA siguen desacopladas (no se toca) · gate comercial intacto · sin rate-limit en el piloto (post-piloto).

## Tests (17 nuevos, suite 790/790)

Helper: corrige-y-valida reactiva · auditoría escrita · gating verificado → YA_VERIFICADO · colisión `@unique` (findFirst + P2002) → CUIT_EN_USO · reintento mismo número · ARCA rechaza · taller inexistente.
Endpoint: auth dual (dueño ✓ / ESTADO ajeno ✓ / otro → 403) · 401 sin sesión · 404 · validación cuit → 400 · mapeo 409/200.

## Alcance

- **No mergear** — QA de Sergio. Verificación en vivo con demo.gracia (mobile 320/375) en el hilo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCZF8j8BDAWTfqdsTMrUsT