### PR TITLE
fix: circuito CUIT PR-3 — normalización de formato de CUIT

### DIFF
--- a/.claude/specs/RUNBOOK_PROMOCION_PROD.md
+++ b/.claude/specs/RUNBOOK_PROMOCION_PROD.md
@@ -276,3 +276,51 @@ Porque es un release de 105 commits, no un parche: el smoke cubre las features q
 - **Mergear #421** a develop (queda disponible el flag para el paso f).
 - Confirmar el **tier de Supabase** (decisión 2) — opcional, el `pg_dump` cubre.
 - Que Sergio confirme que correrá el **smoke ampliado** (§5), no solo el habitual.
+
+---
+
+## 7. ⏳ PRÓXIMO deploy — saneo one-time de CUITs (PR-3 circuito CUIT, 2026-07)
+
+> El seed guardó CUITs **con guiones** y el `@unique` de `cuit` compara strings exactos →
+> `"20-X..."` y `"20X..."` coexistirían como cuentas distintas del mismo CUIT. El código nuevo
+> (PR-3 `fix/cuit-normalizacion`) normaliza a dígitos en `consultarPadron` y en el registro,
+> pero las filas viejas de PROD quedan sucias hasta este saneo. **En DEV ya se corrió**
+> (2026-07-13: 5 talleres + 3 marcas normalizados, 0 colisiones). Correr en PROD **después**
+> de que el deploy aplique el código de PR-3.
+
+```sql
+-- 1) DIAGNÓSTICO (read-only): ¿cuántas filas sucias hay?
+SELECT id, cuit, "verificadoAfip", "estadoCuenta" FROM "talleres"
+WHERE cuit IS NOT NULL AND cuit !~ '^[0-9]{11}$';
+SELECT id, cuit FROM "marcas"
+WHERE cuit IS NOT NULL AND cuit !~ '^[0-9]{11}$';
+
+-- 2) COLISIONES (read-only): deben dar 0 filas las CUATRO antes de tocar nada.
+--    (a) la forma normalizada ya existe en otra fila limpia:
+SELECT t1.id, t1.cuit FROM "talleres" t1
+WHERE t1.cuit !~ '^[0-9]{11}$' AND EXISTS (
+  SELECT 1 FROM "talleres" t2 WHERE t2.id <> t1.id AND t2.cuit = regexp_replace(t1.cuit, '\D', '', 'g'));
+SELECT m1.id, m1.cuit FROM "marcas" m1
+WHERE m1.cuit !~ '^[0-9]{11}$' AND EXISTS (
+  SELECT 1 FROM "marcas" m2 WHERE m2.id <> m1.id AND m2.cuit = regexp_replace(m1.cuit, '\D', '', 'g'));
+--    (b) dos filas sucias que normalizan a lo mismo:
+SELECT regexp_replace(cuit,'\D','','g') AS norm, count(*) FROM "talleres"
+WHERE cuit !~ '^[0-9]{11}$' GROUP BY 1 HAVING count(*) > 1;
+SELECT regexp_replace(cuit,'\D','','g') AS norm, count(*) FROM "marcas"
+WHERE cuit !~ '^[0-9]{11}$' GROUP BY 1 HAVING count(*) > 1;
+
+-- 3) UPDATE (solo si 2 dio 0 filas en todas — si hay colisión, resolver a mano ANTES):
+UPDATE "talleres" SET cuit = regexp_replace(cuit,'\D','','g')
+WHERE cuit IS NOT NULL AND cuit !~ '^[0-9]{11}$';
+UPDATE "marcas" SET cuit = regexp_replace(cuit,'\D','','g')
+WHERE cuit IS NOT NULL AND cuit !~ '^[0-9]{11}$';
+
+-- 4) VERIFICACIÓN post-saneo: ambas deben dar 0.
+SELECT count(*) FROM "talleres" WHERE cuit IS NOT NULL AND cuit !~ '^[0-9]{11}$';
+SELECT count(*) FROM "marcas" WHERE cuit IS NOT NULL AND cuit !~ '^[0-9]{11}$';
+```
+
+⚠️ **Si corrés esto por script Node/Prisma** (no en el editor SQL de Supabase): escapar el
+patrón como `'\\D'` — en un template literal de JS, `\D` llega al SQL como `D` y el
+regexp_replace borra letras D en vez de no-dígitos (nos pasó en DEV; en el editor SQL va `\D`
+tal cual).

--- a/.claude/specs/RUNBOOK_PROMOCION_PROD.md
+++ b/.claude/specs/RUNBOOK_PROMOCION_PROD.md
@@ -288,14 +288,20 @@ Porque es un release de 105 commits, no un parche: el smoke cubre las features q
 > (2026-07-13: 5 talleres + 3 marcas normalizados, 0 colisiones). Correr en PROD **después**
 > de que el deploy aplique el código de PR-3.
 
+> **Cubre TRES tablas:** `talleres`, `marcas` y `users` (`users.cuit` es el "CUIT centralizado"
+> de U-02/D2, también `@unique`; en DEV está sin poblar — 0 de 16 — pero en PROD puede tener
+> datos del backfill multi-rol, por eso va defensivo).
+
 ```sql
 -- 1) DIAGNÓSTICO (read-only): ¿cuántas filas sucias hay?
 SELECT id, cuit, "verificadoAfip", "estadoCuenta" FROM "talleres"
 WHERE cuit IS NOT NULL AND cuit !~ '^[0-9]{11}$';
 SELECT id, cuit FROM "marcas"
 WHERE cuit IS NOT NULL AND cuit !~ '^[0-9]{11}$';
+SELECT id, email, cuit FROM "users"
+WHERE cuit IS NOT NULL AND cuit !~ '^[0-9]{11}$';
 
--- 2) COLISIONES (read-only): deben dar 0 filas las CUATRO antes de tocar nada.
+-- 2) COLISIONES (read-only): deben dar 0 filas las SEIS antes de tocar nada.
 --    (a) la forma normalizada ya existe en otra fila limpia:
 SELECT t1.id, t1.cuit FROM "talleres" t1
 WHERE t1.cuit !~ '^[0-9]{11}$' AND EXISTS (
@@ -303,10 +309,15 @@ WHERE t1.cuit !~ '^[0-9]{11}$' AND EXISTS (
 SELECT m1.id, m1.cuit FROM "marcas" m1
 WHERE m1.cuit !~ '^[0-9]{11}$' AND EXISTS (
   SELECT 1 FROM "marcas" m2 WHERE m2.id <> m1.id AND m2.cuit = regexp_replace(m1.cuit, '\D', '', 'g'));
+SELECT u1.id, u1.cuit FROM "users" u1
+WHERE u1.cuit !~ '^[0-9]{11}$' AND EXISTS (
+  SELECT 1 FROM "users" u2 WHERE u2.id <> u1.id AND u2.cuit = regexp_replace(u1.cuit, '\D', '', 'g'));
 --    (b) dos filas sucias que normalizan a lo mismo:
 SELECT regexp_replace(cuit,'\D','','g') AS norm, count(*) FROM "talleres"
 WHERE cuit !~ '^[0-9]{11}$' GROUP BY 1 HAVING count(*) > 1;
 SELECT regexp_replace(cuit,'\D','','g') AS norm, count(*) FROM "marcas"
+WHERE cuit !~ '^[0-9]{11}$' GROUP BY 1 HAVING count(*) > 1;
+SELECT regexp_replace(cuit,'\D','','g') AS norm, count(*) FROM "users"
 WHERE cuit !~ '^[0-9]{11}$' GROUP BY 1 HAVING count(*) > 1;
 
 -- 3) UPDATE (solo si 2 dio 0 filas en todas — si hay colisión, resolver a mano ANTES):
@@ -314,10 +325,13 @@ UPDATE "talleres" SET cuit = regexp_replace(cuit,'\D','','g')
 WHERE cuit IS NOT NULL AND cuit !~ '^[0-9]{11}$';
 UPDATE "marcas" SET cuit = regexp_replace(cuit,'\D','','g')
 WHERE cuit IS NOT NULL AND cuit !~ '^[0-9]{11}$';
+UPDATE "users" SET cuit = regexp_replace(cuit,'\D','','g')
+WHERE cuit IS NOT NULL AND cuit !~ '^[0-9]{11}$';
 
--- 4) VERIFICACIÓN post-saneo: ambas deben dar 0.
+-- 4) VERIFICACIÓN post-saneo: las tres deben dar 0.
 SELECT count(*) FROM "talleres" WHERE cuit IS NOT NULL AND cuit !~ '^[0-9]{11}$';
 SELECT count(*) FROM "marcas" WHERE cuit IS NOT NULL AND cuit !~ '^[0-9]{11}$';
+SELECT count(*) FROM "users" WHERE cuit IS NOT NULL AND cuit !~ '^[0-9]{11}$';
 ```
 
 ⚠️ **Si corrés esto por script Node/Prisma** (no en el editor SQL de Supabase): escapar el

--- a/src/__tests__/arca.test.ts
+++ b/src/__tests__/arca.test.ts
@@ -133,14 +133,15 @@ describe('consultarPadron', () => {
     expect(resultado.error).toBe('AFIPSDK_ERROR')
   })
 
-  it('registra consulta en ConsultaArca para cada llamada', async () => {
+  it('registra consulta en ConsultaArca para cada llamada (cuit NORMALIZADO en el log)', async () => {
     mockGetTaxpayerDetails.mockResolvedValue(fixtureActivo)
     await consultarPadron('20-30123456-7', 'taller-123')
 
     expect(mockCreate).toHaveBeenCalledWith({
       data: expect.objectContaining({
         tallerId: 'taller-123',
-        cuit: '20-30123456-7',
+        // Se registra la forma normalizada (solo dígitos), no el string crudo.
+        cuit: '20301234567',
         endpoint: 'padron-a13',
         exitosa: true,
       }),
@@ -156,6 +157,37 @@ describe('consultarPadron', () => {
         tallerId: null,
       }),
     })
+  })
+
+  // ─── Normalización de formato (PR-3 circuito CUIT) ─────────────────────────
+
+  it('normaliza espacios y guiones antes de consultar (el SDK recibe el numero entero)', async () => {
+    mockGetTaxpayerDetails.mockResolvedValue(fixtureActivo)
+    const resultado = await consultarPadron('20 30123456 7')
+
+    // Antes: parseInt truncaba en el primer espacio y consultaba el CUIT "20".
+    expect(mockGetTaxpayerDetails).toHaveBeenCalledWith(20301234567)
+    expect(resultado.exitosa).toBe(true)
+  })
+
+  it('CUIT que no queda en 11 digitos -> CUIT_INEXISTENTE explicito, sin llamar al SDK', async () => {
+    const resultado = await consultarPadron('123-45')
+
+    expect(resultado.exitosa).toBe(false)
+    expect(resultado.error).toBe('CUIT_INEXISTENTE')
+    expect(mockGetTaxpayerDetails).not.toHaveBeenCalled()
+    // La consulta fallida igual queda registrada (observabilidad).
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({ cuit: '12345', exitosa: false, error: 'CUIT_INEXISTENTE' }),
+    })
+  })
+
+  it('el guard corta tambien en modo mock (consistencia mock/real)', async () => {
+    process.env.ARCA_PROVIDER = 'mock'
+    const resultado = await consultarPadron('20-123')
+
+    expect(resultado.exitosa).toBe(false)
+    expect(resultado.error).toBe('CUIT_INEXISTENTE')
   })
 })
 

--- a/src/__tests__/registro-cuit-normalizacion.test.ts
+++ b/src/__tests__/registro-cuit-normalizacion.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// PR-3 circuito CUIT — normalización de formato al GUARDAR. El zod del registro transforma el
+// cuit a solo-dígitos antes de persistir: "20-30123456-7" queda "20301234567" en la DB, así el
+// @unique de cuit significa unicidad real (dos formas del mismo CUIT no coexisten). ARCA corre
+// en modo mock (valida cualquier CUIT de 11 dígitos), Prisma/bcrypt/email mockeados.
+
+const { mockUserFindUnique, mockUserCreate, mockTallerFindUnique, mockHash } = vi.hoisted(() => ({
+  mockUserFindUnique: vi.fn(),
+  mockUserCreate: vi.fn(),
+  mockTallerFindUnique: vi.fn(),
+  mockHash: vi.fn().mockResolvedValue('hashed'),
+}))
+
+vi.mock('@/compartido/lib/prisma', () => ({
+  prisma: {
+    user: { findUnique: mockUserFindUnique, create: mockUserCreate },
+    taller: { findUnique: mockTallerFindUnique },
+    // El guard de consultarPadron registra la consulta fallida (observabilidad).
+    consultaArca: { create: vi.fn().mockResolvedValue({}) },
+  },
+}))
+vi.mock('@/compartido/lib/log', () => ({ logActividad: vi.fn() }))
+vi.mock('@/compartido/lib/ratelimit', () => ({
+  rateLimit: vi.fn().mockResolvedValue(null),
+  getClientIp: vi.fn().mockReturnValue('1.2.3.4'),
+}))
+vi.mock('@/compartido/lib/email', () => ({
+  sendEmail: vi.fn().mockResolvedValue({ exito: true }),
+  buildBienvenidaEmail: vi.fn().mockReturnValue({ subject: 's', html: 'h' }),
+}))
+vi.mock('bcryptjs', () => ({ default: { hash: mockHash } }))
+
+import { POST } from '@/app/api/auth/registro/route'
+
+function req(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/auth/registro', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  process.env.ARCA_PROVIDER = 'mock' // mock valida cualquier CUIT de 11 dígitos
+  mockUserFindUnique.mockResolvedValue(null)
+  mockUserCreate.mockResolvedValue({ id: 'u1', email: 'x@x.com', name: null, role: 'TALLER' })
+  mockTallerFindUnique.mockResolvedValue(null) // salta el createMany de validaciones
+  mockHash.mockResolvedValue('hashed')
+})
+
+describe('POST /api/auth/registro — normalización de CUIT', () => {
+  it('taller: cuit con guiones se guarda normalizado (solo dígitos)', async () => {
+    const res = await POST(req({
+      email: 'nuevo@test.com', password: 'password123', role: 'TALLER',
+      tallerData: { nombre: 'Taller X', cuit: '20-30123456-7' },
+    }), {})
+
+    expect(res.status).toBe(201)
+    expect(mockUserCreate).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        taller: { create: expect.objectContaining({ cuit: '20301234567' }) },
+      }),
+    }))
+  })
+
+  it('marca: cuit con guiones se guarda normalizado', async () => {
+    mockUserCreate.mockResolvedValue({ id: 'u2', email: 'm@x.com', name: null, role: 'MARCA' })
+    const res = await POST(req({
+      email: 'marca@test.com', password: 'password123', role: 'MARCA',
+      marcaData: { nombre: 'Marca X', cuit: '27-32456789-1' },
+    }), {})
+
+    expect(res.status).toBe(201)
+    expect(mockUserCreate).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        marca: { create: expect.objectContaining({ cuit: '27324567891' }) },
+      }),
+    }))
+  })
+
+  it('cuit con espacios que no queda en 11 dígitos -> 400 (guard de consultarPadron bloquea)', async () => {
+    const res = await POST(req({
+      email: 'corto@test.com', password: 'password123', role: 'TALLER',
+      tallerData: { nombre: 'Taller Y', cuit: '20 4' },
+    }), {})
+
+    // consultarPadron normaliza a "204" (3 dígitos) -> CUIT_INEXISTENTE -> errorBloqueaRegistro.
+    expect(res.status).toBe(400)
+    expect(mockUserCreate).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/u-09-agregar-rol.test.ts
+++ b/src/__tests__/u-09-agregar-rol.test.ts
@@ -116,7 +116,7 @@ describe('POST /api/usuarios/me/roles', () => {
     const res = await post({ rol: 'TALLER', nombre: 'Mi Taller', cuit: '30-71890234-5' })
     expect(res.status).toBe(200)
     expect(mockPadron).toHaveBeenCalledTimes(1)
-    expect(mockPadron).toHaveBeenCalledWith('30-71890234-5')
+    expect(mockPadron).toHaveBeenCalledWith('30718902345') // normalizado por el zod (PR-3)
   })
 
   it('B-02: CUIT verificado en User (sin entidad) → 200 SIN llamar a ARCA', async () => {
@@ -148,7 +148,7 @@ describe('POST /api/usuarios/me/roles', () => {
     const res = await post({ rol: 'MARCA', nombre: 'Mi Marca', cuit: '20-12345678-9' })
     expect(res.status).toBe(200)
     expect(mockPadron).toHaveBeenCalledTimes(1)
-    expect(mockPadron).toHaveBeenCalledWith('20-12345678-9')
+    expect(mockPadron).toHaveBeenCalledWith('20123456789') // normalizado por el zod (PR-3)
   })
 
   it('D: CUIT difiere del verificado → 200 LLAMANDO a ARCA como antes', async () => {
@@ -161,7 +161,7 @@ describe('POST /api/usuarios/me/roles', () => {
     const res = await post({ rol: 'MARCA', nombre: 'Mi Marca', cuit: '27-99999999-3' })
     expect(res.status).toBe(200)
     expect(mockPadron).toHaveBeenCalledTimes(1)
-    expect(mockPadron).toHaveBeenCalledWith('27-99999999-3')
+    expect(mockPadron).toHaveBeenCalledWith('27999999993') // normalizado por el zod (PR-3)
   })
 
   it('rol ya poseído → 409, sin crear entidad', async () => {
@@ -184,6 +184,17 @@ describe('POST /api/usuarios/me/roles', () => {
     const res = await post({ rol: 'MARCA', nombre: 'Mi Marca', cuit: '99-99999999-9' })
     expect(res.status).toBe(400)
     expect(mockCrear).not.toHaveBeenCalled()
+  })
+
+  it('normaliza el cuit a dígitos antes de verificar y persistir (PR-3 circuito CUIT)', async () => {
+    mockUserFind.mockResolvedValue({ id: 'u1', roles: [], role: 'TALLER', taller: { id: 't1' }, marca: null })
+    mockCrear.mockResolvedValue({ id: 'marca-1' })
+
+    const res = await post({ rol: 'MARCA', nombre: 'Mi Marca', cuit: '20-12345678-9' })
+    expect(res.status).toBe(200)
+    // consultarPadron y crearEntidadParaRol reciben el cuit SIN guiones (el zod lo transforma).
+    expect(mockPadron).toHaveBeenCalledWith('20123456789')
+    expect(mockCrear).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ cuit: '20123456789' }))
   })
 
   it('sin sesión → 401', async () => {

--- a/src/app/api/auth/registro/route.ts
+++ b/src/app/api/auth/registro/route.ts
@@ -19,13 +19,17 @@ const registerSchema = z.object({
   phone: z.string().trim().optional(),
   tallerData: z.object({
     nombre: z.string().trim().min(1, 'Nombre de taller requerido'),
-    cuit: z.string().trim().min(1, 'CUIT requerido'),
+    // Normalizar a dígitos al GUARDAR (guiones/espacios fuera): el @unique de cuit compara
+    // strings exactos — "20-X..." y "20X..." coexistirían como cuentas distintas del mismo
+    // CUIT. Un valor que no queda en 11 dígitos lo corta ARCA (consultarPadron -> CUIT_INEXISTENTE
+    // -> errorBloqueaRegistro), asi que no hace falta refine acá.
+    cuit: z.string().trim().min(1, 'CUIT requerido').transform(c => c.replace(/\D/g, '')),
     ubicacion: z.string().trim().min(1, 'Ubicacion requerida').optional().nullable(),
     capacidadMensual: z.number().int().min(0).optional(),
   }).optional(),
   marcaData: z.object({
     nombre: z.string().trim().min(1, 'Nombre de marca requerido'),
-    cuit: z.string().trim().min(1, 'CUIT requerido'),
+    cuit: z.string().trim().min(1, 'CUIT requerido').transform(c => c.replace(/\D/g, '')),
     ubicacion: z.string().trim().min(1, 'Ubicacion requerida').optional().nullable(),
     tipo: z.string().trim().min(1, 'Tipo requerido').optional().nullable(),
   }).optional(),

--- a/src/app/api/usuarios/me/roles/route.ts
+++ b/src/app/api/usuarios/me/roles/route.ts
@@ -32,7 +32,11 @@ import { logActividad } from '@/compartido/lib/log'
 const bodySchema = z.object({
   rol: z.enum(['TALLER', 'MARCA']),
   nombre: z.string().trim().min(1, 'Nombre requerido'),
-  cuit: z.string().trim().min(1, 'CUIT requerido'),
+  // Normalizar a dígitos al entrar (PR-3 circuito CUIT): crearEntidadParaRol persiste este
+  // valor tal cual en taller/marca — sin transform, el 2º rol era un borde de escritura de
+  // formato sucio que el registro ya no permite. Un valor que no queda en 11 dígitos lo
+  // corta consultarPadron (guard -> CUIT_INEXISTENTE -> errorBloqueaRegistro).
+  cuit: z.string().trim().min(1, 'CUIT requerido').transform(c => c.replace(/\D/g, '')),
 })
 
 export const POST = apiHandler(async (req: NextRequest) => {

--- a/src/compartido/lib/arca.ts
+++ b/src/compartido/lib/arca.ts
@@ -89,9 +89,21 @@ export type CodigoErrorArca =
 // Función principal: consultarPadron
 // ---------------------------------------------------------------------------
 
-export async function consultarPadron(cuit: string, tallerId?: string, userId?: string | null): Promise<ResultadoConsulta> {
+export async function consultarPadron(cuitRaw: string, tallerId?: string, userId?: string | null): Promise<ResultadoConsulta> {
   const inicio = Date.now()
   const config = getConfig()
+
+  // Normalizar a dígitos ANTES de todo (guiones, espacios, puntos — lo que sea). Si no quedan
+  // 11 dígitos, el CUIT jamás existirá en ARCA: CUIT_INEXISTENTE explícito sin gastar la
+  // llamada. Antes solo se limpiaban guiones y parseInt truncaba en el primer no-dígito
+  // ("20 4..." consultaba el CUIT "20" en silencio). Cubre a TODOS los callers, incluidos
+  // el cron de gracia (Pieza D) y el mock (que así queda consistente con el path real).
+  const cuit = cuitRaw.replace(/\D/g, '')
+  if (cuit.length !== 11) {
+    await registrarConsulta(tallerId, cuit, 'padron-a13', false, null, 'CUIT_INEXISTENTE', inicio)
+    logAfipVerificacion(tallerId, cuit, false, 'CUIT_INEXISTENTE', userId)
+    return { exitosa: false, error: 'CUIT_INEXISTENTE', duracionMs: Date.now() - inicio }
+  }
 
   if (!config.enabled || config.provider === 'mock') {
     return mockConsulta(cuit)
@@ -99,7 +111,7 @@ export async function consultarPadron(cuit: string, tallerId?: string, userId?: 
 
   try {
     const sdk = getCliente()
-    const cuitNumero = parseInt(cuit.replace(/-/g, ''), 10)
+    const cuitNumero = parseInt(cuit, 10)
 
     // Timeout de 10 segundos para no bloquear registro si ARCA tarda
     const respuesta = await Promise.race([


### PR DESCRIPTION
## Qué

**PR-3 del circuito CUIT** (seguimiento aprobado por Gerardo tras la mini-verificación de formato post-D). Cierra los dos huecos reales detectados: el `parseInt` truncador ante caracteres no-guion, y el `@unique` de `cuit` agujereado por formato sucio. El escenario temido original ("D no cura CUITs con guiones") resultó **falso** — los guiones ya se limpiaban; esto endurece lo que faltaba.

## Las 3 piezas

**1. `consultarPadron` (arca.ts):** normaliza a **dígitos** (`\D`, no solo guiones) en la entrada + **guard de 11 dígitos** → `CUIT_INEXISTENTE` explícito sin gastar la llamada al SDK. Antes, `parseInt` truncaba en el primer no-dígito y consultaba un número basura en silencio (`"20 4..."` → consultaba el CUIT "20"). Cubre a **todos** los callers (cron D, corrección A/B, registro, reverificación) y al mock (consistente con el path real). `ConsultaArca` ahora loguea la forma normalizada. Bonus: un CUIT malformado bloquea el registro incluso con ARCA caído (el guard corre antes de la red).

**2. Registro (zod):** `.transform` a solo-dígitos en `tallerData.cuit` y `marcaData.cuit` → no entran más filas sucias; el `@unique` vuelve a significar unicidad real (`"20-X"` y `"20X"` ya no coexisten como cuentas distintas).

**3. Saneo one-time:**
- **DEV: ejecutado** (2026-07-13): 5 talleres + 3 marcas normalizados, 4 queries de colisión en 0, post-saneo 0 sucios.
- **PROD: documentado** en `RUNBOOK_PROMOCION_PROD.md` **§7** para el próximo deploy: diagnóstico → colisiones (gate) → UPDATE → verificación. Incluye la advertencia del escaping (`\\D` en scripts Node vs `\D` en el editor SQL — la primera corrida en DEV falló silenciosamente por esto).

## Tests (6 nuevos, suite 796/796)

- normaliza espacios/guiones → el SDK recibe el número entero
- guard corta sin llamar al SDK + registra la consulta (observabilidad)
- guard consistente en modo mock
- registro taller y marca guardan el cuit normalizado
- cuit corto → 400 (bloquea registro)

## Alcance

No toca el flujo de corrección A/B (#453) ni el cron D (#452) — solo los hace más robustos vía `consultarPadron`. Invariantes intactos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCZF8j8BDAWTfqdsTMrUsT